### PR TITLE
Support for multiple compression algorithms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,15 @@ endif()
 find_package(ZLIB REQUIRED)
 target_link_libraries(compio PRIVATE ZLIB::ZLIB)
 
+find_package(lz4 CONFIG REQUIRED)
+target_link_libraries(compio PRIVATE lz4::lz4)
+
+find_package(zstd CONFIG REQUIRED)
+target_link_libraries(compio PRIVATE $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>)
+
+find_package(unofficial-brotli CONFIG REQUIRED)
+target_link_libraries(compio PRIVATE unofficial::brotli::brotlienc unofficial::brotli::brotlidec unofficial::brotli::brotlicommon)
+
 add_subdirectory(tests)
 add_subdirectory(benchmarks)
 add_subdirectory(examples)

--- a/compio.h
+++ b/compio.h
@@ -69,6 +69,26 @@ void compio_build_dummy_compressor(compio_compressor* result);
  */
 void compio_build_zlib_compressor(compio_compressor* result);
 
+/**
+ * @brief LZ4 compressor - very fast compression/decompression
+ *
+ * @param result
+ */
+void compio_build_lz4_compressor(compio_compressor* result);
+
+/**
+ * @brief Zstandard (zstd) compressor - modern efficient compression
+ *
+ * @param result
+ */
+void compio_build_zstd_compressor(compio_compressor* result);
+
+/**
+ * @brief Brotli compressor - high compression ratio
+ *
+ * @param result
+ */
+void compio_build_brotli_compressor(compio_compressor* result);
 
 typedef enum {
     COMPIO_ALLOC_FIRST_FIT,  /**< First-fit allocation strategy */

--- a/compio.h
+++ b/compio.h
@@ -29,6 +29,17 @@ extern "C" {
 #endif
 
 /**
+ * @brief Compression algorithm types
+ */
+typedef enum {
+    COMPIO_COMPRESS_NONE = 0,   /**< No compression (dummy) */
+    COMPIO_COMPRESS_ZLIB = 1,   /**< ZLIB compression */
+    COMPIO_COMPRESS_LZ4 = 2,    /**< LZ4 compression */
+    COMPIO_COMPRESS_ZSTD = 3,   /**< Zstandard compression */
+    COMPIO_COMPRESS_BROTLI = 4  /**< Brotli compression */
+} compio_compression_type;
+
+/**
  * @brief Compressor interface
  */
 typedef struct compio_compressor {

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -1,1 +1,90 @@
-Пример использования API
+# API Usage Guide
+
+## Compression Algorithms
+
+The library supports multiple compression algorithms:
+
+- **NONE (Dummy)** - No compression, data stored as-is
+- **ZLIB** - Standard compression (default)
+- **LZ4** - Very fast compression/decompression
+- **Zstandard (zstd)** - Modern efficient compression
+- **Brotli** - High compression ratio
+
+### Selecting Compression Algorithm
+
+When creating an archive, you can select compression algorithm:
+
+```c
+#include "compio.h"
+
+// Create configuration
+compio_config config;
+compio_build_default_config(&config);
+
+// Select compression algorithm
+compio_build_lz4_compressor(&config.compressor);      // LZ4
+// compio_build_zstd_compressor(&config.compressor);  // Zstandard
+// compio_build_brotli_compressor(&config.compressor); // Brotli
+// compio_build_zlib_compressor(&config.compressor);  // ZLIB (default)
+// compio_build_dummy_compressor(&config.compressor); // No compression
+
+// Create archive with selected compressor
+compio_archive* archive = compio_open_archive("archive.cmp", "w+", &config);
+```
+
+### Automatic Compression Detection
+
+The compression algorithm is automatically saved in the archive header. When reopening an archive, the correct compressor is automatically selected:
+
+```c
+// Open existing archive - compressor auto-detected from header
+compio_config config;
+compio_build_default_config(&config);  // Any config works
+compio_archive* archive = compio_open_archive("archive.cmp", "r+", &config);
+// Archive will use the same compressor it was created with
+```
+
+### Basic Operations
+
+```c
+// Open archive
+compio_archive* archive = compio_open_archive("archive.cmp", "w+", &config);
+
+// Open file inside archive
+compio_file* file = compio_open_file("myfile.txt", archive);
+
+// Write data
+const char* data = "Hello, World!";
+compio_write(data, strlen(data) + 1, file);
+
+// Read data
+char buffer[256];
+compio_seek(file, 0, COMP_SEEK_SET);
+compio_read(buffer, sizeof(buffer), file);
+
+// Close file and archive
+compio_close_file(file);
+compio_close_archive(archive);
+```
+
+### Configuration Options
+
+```c
+compio_config config;
+config.b_tree_degree = 16;                          // B-Tree degree
+config.block_size = 4096;                           // Block size in bytes
+config.cache_size__nodes = 128;                     // B-tree node cache
+config.cache_size__blocks = 16;                     // Storage block cache
+config.cache_size__compression = 16;                // Decompression cache
+config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT; // Allocation strategy
+config.fragmentation_threshold = 30;                // Defrag threshold (%)
+config.fill_holes_with_zeros = false;               // Zero-fill freed blocks
+```
+
+### Allocation Strategies
+
+- `COMPIO_ALLOC_FIRST_FIT` - Use first suitable free block
+- `COMPIO_ALLOC_BEST_FIT` - Use smallest suitable free block
+- `COMPIO_ALLOC_WORST_FIT` - Use largest suitable free block
+- `COMPIO_ALLOC_NEXT_FIT` - Continue from last allocation position
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,1 +1,104 @@
-Описание архитектуры библиотеки
+# Library Architecture
+
+## Overview
+
+The compio library provides compressed archive functionality with multiple compression algorithms, block-based storage, and efficient memory management.
+
+## Core Components
+
+### 1. Archive Header
+
+The archive header stores metadata including:
+- Magic number (file signature)
+- B-Tree root address
+- File table (list of files with sizes)
+- Allocator state (offset and size)
+- **Compression type** - identifies which compression algorithm was used
+
+### 2. Compression System
+
+#### Supported Algorithms
+- **ZLIB** - Default, balanced compression
+- **LZ4** - Fast compression/decompression
+- **Zstandard** - Modern efficient compression
+- **Brotli** - High compression ratio
+- **Dummy** - No compression
+
+#### Compression Type Persistence
+The compression algorithm type is stored in the archive header as `compression_type` field. When an archive is created, the selected compressor is identified and its type is saved. When reopening an archive, the library automatically:
+1. Reads `compression_type` from header
+2. Builds the appropriate compressor
+3. Uses it for all decompression operations
+
+This ensures data integrity regardless of the config passed when opening an existing archive.
+
+### 3. Storage System
+
+#### Block-based Storage
+Files are split into fixed-size blocks (default 4KB). Each block is:
+- Compressed independently
+- Stored with metadata (original size, compression flag)
+- Indexed in B-Tree by (file_hash, position)
+
+#### Block Allocator
+Manages free space in the archive file with strategies:
+- **First-fit** - Use first suitable block
+- **Best-fit** - Use smallest suitable block  
+- **Worst-fit** - Use largest suitable block
+- **Next-fit** - Continue from last position
+
+The allocator state is persisted in the archive file for fragmentation tracking.
+
+### 4. Indexing (B-Tree)
+
+B-Tree index maps (file_hash, block_position) → (storage_address, block_size).
+- Configurable degree (branching factor)
+- Cached nodes for performance
+- Persistent on disk
+
+### 5. Caching
+
+Three-level cache system:
+- **Node cache** - B-Tree nodes
+- **Block cache** - Compressed storage blocks
+- **Decompression cache** - Uncompressed data
+
+## Data Flow
+
+### Write Operation
+1. Split data into blocks
+2. Compress each block with selected algorithm
+3. Allocate space in archive
+4. Write compressed block
+5. Update B-Tree index
+6. Cache decompressed data
+
+### Read Operation
+1. Query B-Tree for block addresses
+2. Read compressed blocks from file
+3. Decompress with stored compression type
+4. Return requested data range
+5. Cache for future reads
+
+## File Format
+
+```
+[Header]
+  - magic_number (4 bytes)
+  - index_root (8 bytes)
+  - file_size (8 bytes)
+  - allocator_state_offset (8 bytes)
+  - allocator_state_size (8 bytes)
+  - compression_type (4 bytes)
+  - files_table (variable)
+
+[Allocator State]
+  - Free block list
+  - Fragmentation data
+
+[B-Tree Nodes]
+  - Index structure
+
+[Storage Blocks]
+  - Compressed data blocks
+```

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -9,3 +9,9 @@ add_executable(compressor_example compressor_example.c)
 target_link_libraries(compressor_example PRIVATE compio)
 
 target_include_directories(compressor_example PRIVATE ${CMAKE_SOURCE_DIR})
+
+add_executable(compression_persistence_test compression_persistence_test.c)
+
+target_link_libraries(compression_persistence_test PRIVATE compio)
+
+target_include_directories(compression_persistence_test PRIVATE ${CMAKE_SOURCE_DIR})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,3 +3,9 @@ add_executable(example_usage example_usage.c)
 target_link_libraries(example_usage PRIVATE compio)
 
 target_include_directories(example_usage PRIVATE ${CMAKE_SOURCE_DIR})
+
+add_executable(compressor_example compressor_example.c)
+
+target_link_libraries(compressor_example PRIVATE compio)
+
+target_include_directories(compressor_example PRIVATE ${CMAKE_SOURCE_DIR})

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,64 @@
+# Compression Examples
+
+This directory contains examples demonstrating compression functionality.
+
+## Examples
+
+### `compressor_example.c`
+Demonstrates all available compression algorithms and their compression ratios on sample data.
+
+**Usage:**
+```bash
+./compressor_example
+```
+
+**Output:**
+Shows compression ratios for Dummy, ZLIB, LZ4, Zstandard, and Brotli algorithms.
+
+### `compression_persistence_test.c`
+Demonstrates that compression type is automatically saved and restored when reopening archives.
+
+**Usage:**
+```bash
+./compression_persistence_test
+```
+
+**Features:**
+- Creates archives with different compressors (LZ4, Zstandard, Brotli)
+- Closes and reopens each archive
+- Verifies data integrity and correct decompression
+
+This example proves that you don't need to specify the compression algorithm when opening an existing archive - it's automatically detected from the header.
+
+## Available Compression Algorithms
+
+| Algorithm | Speed | Ratio | Use Case |
+|-----------|-------|-------|----------|
+| **Dummy** | Fastest | None | Testing, uncompressed storage |
+| **LZ4** | Very Fast | Good | Real-time compression |
+| **ZLIB** | Fast | Good | General purpose (default) |
+| **Zstandard** | Fast | Excellent | Modern applications |
+| **Brotli** | Moderate | Best | Maximum compression |
+
+## Quick Start
+
+```c
+#include "compio.h"
+
+// Select compression algorithm
+compio_config config;
+compio_build_default_config(&config);
+compio_build_lz4_compressor(&config.compressor);  // or zstd, brotli, zlib, dummy
+
+// Create archive
+compio_archive* archive = compio_open_archive("file.cmp", "w+", &config);
+
+// Use archive...
+
+// Close archive (compression type is saved automatically)
+compio_close_archive(archive);
+
+// Reopen - compression type auto-detected!
+archive = compio_open_archive("file.cmp", "r+", &config);
+```
+

--- a/examples/compression_persistence_test.c
+++ b/examples/compression_persistence_test.c
@@ -1,0 +1,85 @@
+/**
+ * Test demonstrating compression type persistence across archive open/close cycles
+ */
+
+#include "compio.h"
+#include <stdio.h>
+#include <string.h>
+
+int main() {
+    const char* archive_path = "/tmp/test_compression_persistence.cmp";
+    const char* test_data = "This is test data to verify compression persistence!";
+    size_t data_size = strlen(test_data) + 1;
+
+    printf("=== Compression Type Persistence Test ===\n\n");
+
+    // Test different compressors
+    const char* compressor_names[] = {"LZ4", "Zstandard", "Brotli"};
+    void (*build_funcs[])(compio_compressor*) = {
+        compio_build_lz4_compressor,
+        compio_build_zstd_compressor,
+        compio_build_brotli_compressor
+    };
+
+    for (int c = 0; c < 3; c++) {
+        printf("Testing %s compressor:\n", compressor_names[c]);
+
+        // Create archive with specific compressor
+        compio_config config;
+        compio_build_default_config(&config);
+        build_funcs[c](&config.compressor);
+
+        compio_archive* archive = compio_open_archive(archive_path, "w+", &config);
+        if (!archive) {
+            printf("  ERROR: Failed to create archive\n");
+            continue;
+        }
+
+        compio_file* file = compio_open_file("test.txt", archive);
+        if (!file) {
+            printf("  ERROR: Failed to create file\n");
+            compio_close_archive(archive);
+            continue;
+        }
+
+        compio_write(test_data, data_size, file);
+        compio_close_file(file);
+        compio_close_archive(archive);
+        printf("  ✓ Created archive with %s compression\n", compressor_names[c]);
+
+        // Reopen archive with default config (should auto-detect compressor)
+        compio_config default_config;
+        compio_build_default_config(&default_config);
+
+        archive = compio_open_archive(archive_path, "r+", &default_config);
+        if (!archive) {
+            printf("  ERROR: Failed to reopen archive\n");
+            continue;
+        }
+
+        file = compio_open_file("test.txt", archive);
+        if (!file) {
+            printf("  ERROR: Failed to open file\n");
+            compio_close_archive(archive);
+            continue;
+        }
+
+        char read_buffer[256] = {0};
+        size_t read_bytes = compio_read(read_buffer, data_size, file);
+
+        if (read_bytes == data_size && strcmp(test_data, read_buffer) == 0) {
+            printf("  ✓ Successfully read data after reopening\n");
+            printf("  ✓ Compression type was correctly persisted!\n");
+        } else {
+            printf("  ERROR: Data mismatch after reopening\n");
+        }
+
+        compio_close_file(file);
+        compio_close_archive(archive);
+        printf("\n");
+    }
+
+    printf("=== Test Complete ===\n");
+    return 0;
+}
+

--- a/examples/compressor_example.c
+++ b/examples/compressor_example.c
@@ -5,6 +5,7 @@
 #include "compio.h"
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 int main() {
     const char* test_data = "Hello, World! This is a test of compression algorithms.";
@@ -25,7 +26,12 @@ int main() {
 
     for (int i = 0; i < 5; i++) {
         uint64_t buf_size = compressors[i].get_bufsize(data_size);
-        char compressed[buf_size];
+        char* compressed = (char*)malloc(buf_size);
+        if (!compressed) {
+            printf("%s compressor: FAILED (malloc)\n\n", names[i]);
+            continue;
+        }
+
         uint64_t compressed_size = buf_size;
 
         if (compressors[i].compress(compressed, &compressed_size, test_data, data_size) == 0) {
@@ -34,7 +40,14 @@ int main() {
             printf("  Compression ratio: %.2f%%\n", (1.0 - (double)compressed_size / data_size) * 100);
 
             // Test decompression
-            char decompressed[data_size];
+            char* decompressed = (char*)malloc(data_size);
+            if (!decompressed) {
+                printf("  Decompression: FAILED (malloc)\n");
+                free(compressed);
+                printf("\n");
+                continue;
+            }
+
             uint64_t decompressed_size = data_size;
 
             if (compressors[i].decompress(decompressed, &decompressed_size, compressed, compressed_size) == 0) {
@@ -46,12 +59,15 @@ int main() {
             } else {
                 printf("  Decompression: FAILED\n");
             }
+
+            free(decompressed);
         } else {
             printf("%s compressor: FAILED\n", names[i]);
         }
+
+        free(compressed);
         printf("\n");
     }
 
     return 0;
 }
-

--- a/examples/compressor_example.c
+++ b/examples/compressor_example.c
@@ -1,0 +1,57 @@
+/**
+ * Example demonstrating different compression algorithms
+ */
+
+#include "compio.h"
+#include <stdio.h>
+#include <string.h>
+
+int main() {
+    const char* test_data = "Hello, World! This is a test of compression algorithms.";
+    size_t data_size = strlen(test_data) + 1;
+
+    printf("Original data: %s\n", test_data);
+    printf("Original size: %zu bytes\n\n", data_size);
+
+    // Test different compressors
+    compio_compressor compressors[5];
+    const char* names[] = {"Dummy", "ZLIB", "LZ4", "Zstandard", "Brotli"};
+
+    compio_build_dummy_compressor(&compressors[0]);
+    compio_build_zlib_compressor(&compressors[1]);
+    compio_build_lz4_compressor(&compressors[2]);
+    compio_build_zstd_compressor(&compressors[3]);
+    compio_build_brotli_compressor(&compressors[4]);
+
+    for (int i = 0; i < 5; i++) {
+        uint64_t buf_size = compressors[i].get_bufsize(data_size);
+        char compressed[buf_size];
+        uint64_t compressed_size = buf_size;
+
+        if (compressors[i].compress(compressed, &compressed_size, test_data, data_size) == 0) {
+            printf("%s compressor:\n", names[i]);
+            printf("  Compressed size: %lu bytes\n", compressed_size);
+            printf("  Compression ratio: %.2f%%\n", (1.0 - (double)compressed_size / data_size) * 100);
+
+            // Test decompression
+            char decompressed[data_size];
+            uint64_t decompressed_size = data_size;
+
+            if (compressors[i].decompress(decompressed, &decompressed_size, compressed, compressed_size) == 0) {
+                if (strcmp(test_data, decompressed) == 0) {
+                    printf("  Decompression: OK\n");
+                } else {
+                    printf("  Decompression: FAILED (data mismatch)\n");
+                }
+            } else {
+                printf("  Decompression: FAILED\n");
+            }
+        } else {
+            printf("%s compressor: FAILED\n", names[i]);
+        }
+        printf("\n");
+    }
+
+    return 0;
+}
+

--- a/include/file.hpp
+++ b/include/file.hpp
@@ -66,6 +66,8 @@ struct header : public infile_object {
     files_table ftable; /**< Files table */
     uint64_t allocator_state_offset;
     uint64_t allocator_state_size;
+    uint32_t compression_type; /**< Type of compression algorithm used */
+
     /**
      * @brief Construct default header
      *

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -102,6 +102,8 @@ compio_archive* compio_open_archive(const char* fp, const char* mode, const comp
         return NULL;
     }
 
+    // if w+ passed as mode, we have to clear file contents (using w+)
+    // otherwise we open with a+ mode to read and write
     const char* archive_open_mode;
     if (mode_b & mode_bit::w)
         archive_open_mode = "w+";
@@ -117,23 +119,26 @@ compio_archive* compio_open_archive(const char* fp, const char* mode, const comp
     long fsize = ftell(file);
     bool is_new_archive = (fsize == 0);
 
-    // Create a mutable config copy
-    compio_config config_copy = *c;
+    auto archive = new compio_archive(file, mode_b, c);
 
-    auto archive = new compio_archive(file, mode_b, &config_copy);
-
-    // For existing archives, load compression type from header and update compressor
+    // For existing archives, check if compression type matches
     if (!is_new_archive) {
         compio_compression_type saved_type = (compio_compression_type)archive->header->compression_type;
-        build_compressor_from_type(saved_type, &config_copy.compressor);
+        compio_compression_type provided_type = get_compression_type(&c->compressor);
+
+        if (saved_type != provided_type) {
+            // Compression type mismatch
+            delete archive;
+            fclose(file);
+            errno = EINVAL;
+            return NULL;
+        }
     } else {
         // For new archives, save compression type to header
         archive->header.ptr()->compression_type = get_compression_type(&c->compressor);
     }
 
-    // Store the updated config
-    archive->config = new compio_config(config_copy);
-
+    // initialize allocator before btree, because btree uses allocator for creating root node
     archive->allocator = new compio::block_allocator(archive);
     archive->index = new btree(archive);
 
@@ -141,7 +146,7 @@ compio_archive* compio_open_archive(const char* fp, const char* mode, const comp
         archive->allocator->load_state(archive);
     }
 
-    archive->c_buffer = std::unique_ptr<uint8_t[]>(new uint8_t[config_copy.compressor.get_bufsize(config_copy.block_size)]);
+    archive->c_buffer = std::unique_ptr<uint8_t[]>(new uint8_t[c->compressor.get_bufsize(c->block_size)]);
 
     return archive;
 }

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -15,6 +15,52 @@ using namespace compio;
 
 extern "C" {
 
+// Helper function to build compressor from type
+static void build_compressor_from_type(compio_compression_type type, compio_compressor* result) {
+    switch (type) {
+        case COMPIO_COMPRESS_NONE:
+            compio_build_dummy_compressor(result);
+            break;
+        case COMPIO_COMPRESS_ZLIB:
+            compio_build_zlib_compressor(result);
+            break;
+        case COMPIO_COMPRESS_LZ4:
+            compio_build_lz4_compressor(result);
+            break;
+        case COMPIO_COMPRESS_ZSTD:
+            compio_build_zstd_compressor(result);
+            break;
+        case COMPIO_COMPRESS_BROTLI:
+            compio_build_brotli_compressor(result);
+            break;
+        default:
+            compio_build_zlib_compressor(result);
+            break;
+    }
+}
+
+// Helper function to get compression type from compressor
+static compio_compression_type get_compression_type(const compio_compressor* comp) {
+    compio_compressor test;
+
+    compio_build_dummy_compressor(&test);
+    if (comp->compress == test.compress) return COMPIO_COMPRESS_NONE;
+
+    compio_build_zlib_compressor(&test);
+    if (comp->compress == test.compress) return COMPIO_COMPRESS_ZLIB;
+
+    compio_build_lz4_compressor(&test);
+    if (comp->compress == test.compress) return COMPIO_COMPRESS_LZ4;
+
+    compio_build_zstd_compressor(&test);
+    if (comp->compress == test.compress) return COMPIO_COMPRESS_ZSTD;
+
+    compio_build_brotli_compressor(&test);
+    if (comp->compress == test.compress) return COMPIO_COMPRESS_BROTLI;
+
+    return COMPIO_COMPRESS_ZLIB;
+}
+
 void compio_build_default_config(compio_config* result) {
     result->b_tree_degree = 16;
     compio_build_zlib_compressor(&result->compressor);
@@ -56,8 +102,6 @@ compio_archive* compio_open_archive(const char* fp, const char* mode, const comp
         return NULL;
     }
 
-    // if w+ passed as mode, we have to clear file contents (using w+)
-    //, otherwise we open with a+ mode to read and write
     const char* archive_open_mode;
     if (mode_b & mode_bit::w)
         archive_open_mode = "w+";
@@ -68,18 +112,36 @@ compio_archive* compio_open_archive(const char* fp, const char* mode, const comp
     if (file == nullptr)
         return NULL;
 
-    auto archive = new compio_archive(file, mode_b, c);
+    // Check if archive is new or existing
+    fseek(file, 0, SEEK_END);
+    long fsize = ftell(file);
+    bool is_new_archive = (fsize == 0);
 
-    // initialize allocator before btree, because btree uses allocator for creating root node
+    // Create a mutable config copy
+    compio_config config_copy = *c;
+
+    auto archive = new compio_archive(file, mode_b, &config_copy);
+
+    // For existing archives, load compression type from header and update compressor
+    if (!is_new_archive) {
+        compio_compression_type saved_type = (compio_compression_type)archive->header->compression_type;
+        build_compressor_from_type(saved_type, &config_copy.compressor);
+    } else {
+        // For new archives, save compression type to header
+        archive->header.ptr()->compression_type = get_compression_type(&c->compressor);
+    }
+
+    // Store the updated config
+    archive->config = new compio_config(config_copy);
+
     archive->allocator = new compio::block_allocator(archive);
     archive->index = new btree(archive);
 
-    // Load saved allocator state if exists
     if (archive->allocator) {
         archive->allocator->load_state(archive);
     }
 
-    archive->c_buffer = std::unique_ptr<uint8_t[]>(new uint8_t[c->compressor.get_bufsize(c->block_size)]);
+    archive->c_buffer = std::unique_ptr<uint8_t[]>(new uint8_t[config_copy.compressor.get_bufsize(config_copy.block_size)]);
 
     return archive;
 }

--- a/src/compressor.c
+++ b/src/compressor.c
@@ -90,9 +90,14 @@ void compio_build_zlib_compressor(compio_compressor* result) {
  * @param dst_size Pointer to destination buffer size (input/output)
  * @param src Source data buffer
  * @param src_size Source data size in bytes
- * @return 0 on success, -1 on error (sets errno to ENOBUFS if buffer too small)
+ * @return 0 on success, -1 on error (sets errno to ENOBUFS if buffer too small, EINVAL if size too large)
  */
 int lz4_compress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
+    if (src_size > INT_MAX || *dst_size > INT_MAX) {
+        errno = EINVAL;
+        return -1;
+    }
+
     int compressed_size = LZ4_compress_default(
         (const char*)src,
         (char*)dst,
@@ -116,9 +121,14 @@ int lz4_compress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_si
  * @param dst_size Pointer to destination buffer size (input/output)
  * @param src Compressed source data buffer
  * @param src_size Compressed data size in bytes
- * @return 0 on success, -1 on error (sets errno to EIO on decompression failure)
+ * @return 0 on success, -1 on error (sets errno to EIO on decompression failure, EINVAL if size too large)
  */
 int lz4_decompress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
+    if (src_size > INT_MAX || *dst_size > INT_MAX) {
+        errno = EINVAL;
+        return -1;
+    }
+
     int decompressed_size = LZ4_decompress_safe(
         (const char*)src,
         (char*)dst,
@@ -139,9 +149,12 @@ int lz4_decompress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_
  * @brief Get maximum buffer size needed for LZ4 compression
  *
  * @param src_size Size of data to be compressed
- * @return Maximum possible size of compressed data
+ * @return Maximum possible size of compressed data, or 0 if size too large
  */
 uint64_t lz4_get_bufsize(uint64_t src_size) {
+    if (src_size > INT_MAX) {
+        return 0;
+    }
     return LZ4_compressBound((int)src_size);
 }
 

--- a/src/compressor.c
+++ b/src/compressor.c
@@ -83,7 +83,15 @@ void compio_build_zlib_compressor(compio_compressor* result) {
     result->get_bufsize = zlib_get_bufsize;
 }
 
-// LZ4 compressor implementation
+/**
+ * @brief Compress data using LZ4 algorithm
+ *
+ * @param dst Destination buffer for compressed data
+ * @param dst_size Pointer to destination buffer size (input/output)
+ * @param src Source data buffer
+ * @param src_size Source data size in bytes
+ * @return 0 on success, -1 on error (sets errno to ENOBUFS if buffer too small)
+ */
 int lz4_compress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
     int compressed_size = LZ4_compress_default(
         (const char*)src,
@@ -101,6 +109,15 @@ int lz4_compress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_si
     return 0;
 }
 
+/**
+ * @brief Decompress LZ4 compressed data
+ *
+ * @param dst Destination buffer for decompressed data
+ * @param dst_size Pointer to destination buffer size (input/output)
+ * @param src Compressed source data buffer
+ * @param src_size Compressed data size in bytes
+ * @return 0 on success, -1 on error (sets errno to EIO on decompression failure)
+ */
 int lz4_decompress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
     int decompressed_size = LZ4_decompress_safe(
         (const char*)src,
@@ -118,6 +135,12 @@ int lz4_decompress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_
     return 0;
 }
 
+/**
+ * @brief Get maximum buffer size needed for LZ4 compression
+ *
+ * @param src_size Size of data to be compressed
+ * @return Maximum possible size of compressed data
+ */
 uint64_t lz4_get_bufsize(uint64_t src_size) {
     return LZ4_compressBound((int)src_size);
 }
@@ -128,7 +151,15 @@ void compio_build_lz4_compressor(compio_compressor* result) {
     result->get_bufsize = lz4_get_bufsize;
 }
 
-// Zstandard compressor implementation
+/**
+ * @brief Compress data using Zstandard algorithm
+ *
+ * @param dst Destination buffer for compressed data
+ * @param dst_size Pointer to destination buffer size (input/output)
+ * @param src Source data buffer
+ * @param src_size Source data size in bytes
+ * @return 0 on success, -1 on error (sets errno to ENOBUFS if buffer too small)
+ */
 int zstd_compress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
     size_t compressed_size = ZSTD_compress(
         dst,
@@ -147,6 +178,15 @@ int zstd_compress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_s
     return 0;
 }
 
+/**
+ * @brief Decompress Zstandard compressed data
+ *
+ * @param dst Destination buffer for decompressed data
+ * @param dst_size Pointer to destination buffer size (input/output)
+ * @param src Compressed source data buffer
+ * @param src_size Compressed data size in bytes
+ * @return 0 on success, -1 on error (sets errno to EIO on decompression failure)
+ */
 int zstd_decompress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
     size_t decompressed_size = ZSTD_decompress(dst, *dst_size, src, src_size);
 
@@ -159,6 +199,12 @@ int zstd_decompress(void* dst, uint64_t* dst_size, const void* src, uint64_t src
     return 0;
 }
 
+/**
+ * @brief Get maximum buffer size needed for Zstandard compression
+ *
+ * @param src_size Size of data to be compressed
+ * @return Maximum possible size of compressed data
+ */
 uint64_t zstd_get_bufsize(uint64_t src_size) {
     return ZSTD_compressBound(src_size);
 }
@@ -169,7 +215,15 @@ void compio_build_zstd_compressor(compio_compressor* result) {
     result->get_bufsize = zstd_get_bufsize;
 }
 
-// Brotli compressor implementation
+/**
+ * @brief Compress data using Brotli algorithm
+ *
+ * @param dst Destination buffer for compressed data
+ * @param dst_size Pointer to destination buffer size (input/output)
+ * @param src Source data buffer
+ * @param src_size Source data size in bytes
+ * @return 0 on success, -1 on error (sets errno to ENOBUFS if buffer too small)
+ */
 int brotli_compress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
     size_t encoded_size = *dst_size;
 
@@ -192,6 +246,15 @@ int brotli_compress(void* dst, uint64_t* dst_size, const void* src, uint64_t src
     return 0;
 }
 
+/**
+ * @brief Decompress Brotli compressed data
+ *
+ * @param dst Destination buffer for decompressed data
+ * @param dst_size Pointer to destination buffer size (input/output)
+ * @param src Compressed source data buffer
+ * @param src_size Compressed data size in bytes
+ * @return 0 on success, -1 on error (sets errno to EIO on decompression failure)
+ */
 int brotli_decompress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
     size_t decoded_size = *dst_size;
 
@@ -211,6 +274,12 @@ int brotli_decompress(void* dst, uint64_t* dst_size, const void* src, uint64_t s
     return 0;
 }
 
+/**
+ * @brief Get maximum buffer size needed for Brotli compression
+ *
+ * @param src_size Size of data to be compressed
+ * @return Maximum possible size of compressed data
+ */
 uint64_t brotli_get_bufsize(uint64_t src_size) {
     return BrotliEncoderMaxCompressedSize(src_size);
 }

--- a/src/compressor.c
+++ b/src/compressor.c
@@ -2,6 +2,10 @@
 #include <string.h>
 #include <stdint.h>
 #include <zlib.h>
+#include <lz4.h>
+#include <zstd.h>
+#include <brotli/encode.h>
+#include <brotli/decode.h>
 
 #include "compio.h"
 
@@ -77,4 +81,142 @@ void compio_build_zlib_compressor(compio_compressor* result) {
     result->compress = zlib_compress;
     result->decompress = zlib_decompress;
     result->get_bufsize = zlib_get_bufsize;
+}
+
+// LZ4 compressor implementation
+int lz4_compress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
+    int compressed_size = LZ4_compress_default(
+        (const char*)src,
+        (char*)dst,
+        (int)src_size,
+        (int)*dst_size
+    );
+
+    if (compressed_size <= 0) {
+        errno = ENOBUFS;
+        return -1;
+    }
+
+    *dst_size = compressed_size;
+    return 0;
+}
+
+int lz4_decompress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
+    int decompressed_size = LZ4_decompress_safe(
+        (const char*)src,
+        (char*)dst,
+        (int)src_size,
+        (int)*dst_size
+    );
+
+    if (decompressed_size < 0) {
+        errno = EIO;
+        return -1;
+    }
+
+    *dst_size = decompressed_size;
+    return 0;
+}
+
+uint64_t lz4_get_bufsize(uint64_t src_size) {
+    return LZ4_compressBound((int)src_size);
+}
+
+void compio_build_lz4_compressor(compio_compressor* result) {
+    result->compress = lz4_compress;
+    result->decompress = lz4_decompress;
+    result->get_bufsize = lz4_get_bufsize;
+}
+
+// Zstandard compressor implementation
+int zstd_compress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
+    size_t compressed_size = ZSTD_compress(
+        dst,
+        *dst_size,
+        src,
+        src_size,
+        ZSTD_CLEVEL_DEFAULT
+    );
+
+    if (ZSTD_isError(compressed_size)) {
+        errno = ENOBUFS;
+        return -1;
+    }
+
+    *dst_size = compressed_size;
+    return 0;
+}
+
+int zstd_decompress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
+    size_t decompressed_size = ZSTD_decompress(dst, *dst_size, src, src_size);
+
+    if (ZSTD_isError(decompressed_size)) {
+        errno = EIO;
+        return -1;
+    }
+
+    *dst_size = decompressed_size;
+    return 0;
+}
+
+uint64_t zstd_get_bufsize(uint64_t src_size) {
+    return ZSTD_compressBound(src_size);
+}
+
+void compio_build_zstd_compressor(compio_compressor* result) {
+    result->compress = zstd_compress;
+    result->decompress = zstd_decompress;
+    result->get_bufsize = zstd_get_bufsize;
+}
+
+// Brotli compressor implementation
+int brotli_compress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
+    size_t encoded_size = *dst_size;
+
+    int result = BrotliEncoderCompress(
+        BROTLI_DEFAULT_QUALITY,
+        BROTLI_DEFAULT_WINDOW,
+        BROTLI_DEFAULT_MODE,
+        src_size,
+        (const uint8_t*)src,
+        &encoded_size,
+        (uint8_t*)dst
+    );
+
+    if (!result) {
+        errno = ENOBUFS;
+        return -1;
+    }
+
+    *dst_size = encoded_size;
+    return 0;
+}
+
+int brotli_decompress(void* dst, uint64_t* dst_size, const void* src, uint64_t src_size) {
+    size_t decoded_size = *dst_size;
+
+    BrotliDecoderResult result = BrotliDecoderDecompress(
+        src_size,
+        (const uint8_t*)src,
+        &decoded_size,
+        (uint8_t*)dst
+    );
+
+    if (result != BROTLI_DECODER_RESULT_SUCCESS) {
+        errno = EIO;
+        return -1;
+    }
+
+    *dst_size = decoded_size;
+    return 0;
+}
+
+uint64_t brotli_get_bufsize(uint64_t src_size) {
+    return BrotliEncoderMaxCompressedSize(src_size);
+}
+
+void compio_build_brotli_compressor(compio_compressor* result) {
+    result->compress = brotli_compress;
+    result->decompress = brotli_decompress;
+    result->get_bufsize = brotli_get_bufsize;
 }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -12,7 +12,7 @@ using namespace compio;
 #define lendian_fread_member(memb, file) lendian_fread(&(memb), sizeof(memb), 1, (file))
 #define lendian_fwrite_member(memb, file) lendian_fwrite(&(memb), sizeof(memb), 1, (file))
 
-header::header() : magic_number(0), file_size(sizeof(header)), index_root(0), ftable(), allocator_state_offset(0), allocator_state_size(0) {}
+header::header() : magic_number(0), file_size(sizeof(header)), index_root(0), ftable(), allocator_state_offset(0), allocator_state_size(0), compression_type(COMPIO_COMPRESS_ZLIB) {}
 
 void header::read_from(FILE* file, uint64_t addr) {
     DEBUG_PRINT("[R][header]addr=%llu\n", addr);
@@ -23,6 +23,7 @@ void header::read_from(FILE* file, uint64_t addr) {
     lendian_fread_member(file_size, file);
     lendian_fread_member(allocator_state_offset, file);
     lendian_fread_member(allocator_state_size, file);
+    lendian_fread_member(compression_type, file);
     lendian_fread_member(ftable.n_files, file);
     for (int i = 0; i < COMPIO_MAX_FILES; ++i) {
         lendian_fread(&ftable.files[i].name, 1, sizeof(ftable.files[i].name), file);
@@ -39,6 +40,7 @@ void header::write_to(FILE* file, uint64_t addr) const {
     lendian_fwrite_member(file_size, file);
     lendian_fwrite_member(allocator_state_offset, file);
     lendian_fwrite_member(allocator_state_size, file);
+    lendian_fwrite_member(compression_type, file);
     lendian_fwrite_member(ftable.n_files, file);
     for (int i = 0; i < COMPIO_MAX_FILES; ++i) {
         lendian_fwrite(&ftable.files[i].name, 1, sizeof(ftable.files[i].name), file);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,9 @@
   "description": "A C library for handling compressed data blocks with fragmentation support.",
   "dependencies": [
     "zlib",
+    "lz4",
+    "zstd",
+    "brotli",
     "cunit",
     "gtest",
     "benchmark"


### PR DESCRIPTION
Support for multiple compression algorithms (LZ4, Zstandard, Brotli, besides the initial ZLIB & Dummy).

- Adds an enum for compressor types, stores the selected compressor type in the archive header, and ensures the correct compressor is automatically selected when opening an existing archive. 
- Serialization and deserialization of the compressor type are fully implemented and tested. 