### PR TITLE
feat+fix(test): store compression_type in compressor, check for failure while loading allocator state in tests 

### DIFF
--- a/benchmarks/src/allocator_strategies_benchmark.cpp
+++ b/benchmarks/src/allocator_strategies_benchmark.cpp
@@ -212,6 +212,10 @@ static void BM_AllocationFragmentationResistance(benchmark::State &state) {
         config.allocation_strategy = static_cast<compio_allocation_strategy>(strategy);
 
         compio_archive *archive = compio_open_archive(filename.c_str(), "w+", &config);
+        if (!archive) {
+            state.SkipWithError("Failed to create archive");
+            continue;
+        }
 
         // Create a pattern of mixed allocations and deallocations
         for (size_t cycle = 0; cycle < cycle_count; cycle++) {

--- a/compio.h
+++ b/compio.h
@@ -152,6 +152,15 @@ typedef struct {
 void compio_build_default_config(compio_config *result);
 
 /**
+ * @brief Get compression type from header of existing archive
+ * 
+ * @param fp path to archive file
+ * @param t pointer t compression_type object
+ * @return int
+ */
+int get_compression_type(const char *fp, compression_type* t);
+
+/**
  * @brief Opened archive
  */
 typedef struct compio_archive compio_archive;

--- a/compio.h
+++ b/compio.h
@@ -158,7 +158,7 @@ void compio_build_default_config(compio_config *result);
  * @param t pointer t compression_type object
  * @return int
  */
-int get_compression_type(const char *fp, compression_type* t);
+int get_compression_type(const char *fp, compio_compression_type* t);
 
 /**
  * @brief Opened archive

--- a/compio.h
+++ b/compio.h
@@ -32,11 +32,18 @@ extern "C" {
  * @brief Compression algorithm types
  */
 typedef enum {
-    COMPIO_COMPRESS_NONE = 0,  /**< No compression (dummy) */
-    COMPIO_COMPRESS_ZLIB = 1,  /**< ZLIB compression */
-    COMPIO_COMPRESS_LZ4 = 2,   /**< LZ4 compression */
-    COMPIO_COMPRESS_ZSTD = 3,  /**< Zstandard compression */
-    COMPIO_COMPRESS_BROTLI = 4 /**< Brotli compression */
+    /**
+     * @brief Custom compression (use it, when you're using your custom compress/decompress algorithm;
+     * note, that if you want to use archive, created with custom compression, in different program,
+     * you'll need to provide the exact same compressor, and set compression_type to custom)
+     *
+     */
+    COMPIO_COMPRESS_CUSTOM = 0,
+    COMPIO_COMPRESS_DUMMY = 1,  /**< No compression (dummy) */
+    COMPIO_COMPRESS_ZLIB = 2,  /**< ZLIB compression */
+    COMPIO_COMPRESS_LZ4 = 3,   /**< LZ4 compression */
+    COMPIO_COMPRESS_ZSTD = 4,  /**< Zstandard compression */
+    COMPIO_COMPRESS_BROTLI = 5 /**< Brotli compression */
 } compio_compression_type;
 
 /**
@@ -64,6 +71,13 @@ typedef struct compio_compressor {
      *
      */
     uint64_t (*get_bufsize)(uint64_t src_size);
+
+    /**
+     * @brief Compression type, that will be saved in archive header (see compio_compression_type
+     * for possible values)
+     *
+     */
+    compio_compression_type compression_type;
 } compio_compressor;
 
 /**

--- a/compio.h
+++ b/compio.h
@@ -158,7 +158,7 @@ void compio_build_default_config(compio_config *result);
  * @param t pointer t compression_type object
  * @return int
  */
-int get_compression_type(const char *fp, compio_compression_type* t);
+int compio_get_compression_type(const char *fp, compio_compression_type* t);
 
 /**
  * @brief Opened archive

--- a/include/compio/utils.hpp
+++ b/include/compio/utils.hpp
@@ -116,6 +116,8 @@ template <> constexpr tree_key _max<tree_key>() { return {(uint64_t)-1, (uint64_
 
 uint64_t get_hash_tail(const char *fname);
 
+bool is_file_empty(FILE *file);
+
 } // namespace compio
 
 #endif // UTILS_HEADER_

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -78,12 +78,14 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
     else
         archive_open_mode = "a+";
 
-    auto file = fopen(fp, archive_open_mode);
+    FILE *file;
+    file = fopen(fp, archive_open_mode);
     if (file == nullptr) {
         goto end;
     }
 
-    auto archive = new compio_archive(file, mode_b, c);
+    compio_archive* archive;
+    archive = new compio_archive(file, mode_b, c);
     if (!archive) {
         goto end1;
     }

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -79,6 +79,20 @@ void compio_build_default_config(compio_config *result) {
     result->fragmentation_threshold = 30;
 }
 
+int get_compression_type(const char *fp, enum compression_type* t) {
+    FILE *file = fopen(fp, "r");
+    if (file == nullptr) {
+        return -1; 
+    }
+
+    header h;
+    h.read_from(file, 0);
+    *t = (enum compression_type)h.compression_type;
+
+    fclose(file);
+    return 0;
+}
+
 compio_archive::compio_archive(FILE *file, uint8_t mode_b, const compio_config *config)
     : file(file),
       config(config),

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -206,7 +206,10 @@ int compio_close_archive(compio_archive *archive) {
     
     // Save allocator state before closing
     if (archive->allocator) {
-        archive->allocator->save_state(archive);
+        if (!archive->allocator->save_state(archive)) {
+            WARNING_PRINT("warning: failed to save allocator state\n");
+            return -3;
+        }
     }
 
     // 1) flush cached data to file

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -28,7 +28,7 @@ void compio_build_default_config(compio_config *result) {
     result->fragmentation_threshold = 30;
 }
 
-int get_compression_type(const char *fp, enum compression_type* t) {
+int get_compression_type(const char *fp, compio_compression_type* t) {
     FILE *file = fopen(fp, "r");
     if (file == nullptr) {
         return -1; 
@@ -36,7 +36,7 @@ int get_compression_type(const char *fp, enum compression_type* t) {
 
     header h;
     h.read_from(file, 0);
-    *t = (enum compression_type)h.compression_type;
+    *t = (compio_compression_type)h.compression_type;
 
     fclose(file);
     return 0;

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -90,7 +90,9 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
         goto end1;
     }
 
-    if (is_file_empty(file)) {
+    bool is_new_file;
+    is_new_file = is_file_empty(file);
+    if (is_new_file) {
         archive->header->compression_type = c->compressor.compression_type;
     } else if (archive->header->compression_type != c->compressor.compression_type) {
         // compression type mismatch
@@ -109,7 +111,7 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
         goto end3;
     }
 
-    if (!archive->allocator->load_state(archive)) {
+    if (!is_new_file && !archive->allocator->load_state(archive)) {
         goto end4;
     }
 

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -28,10 +28,15 @@ void compio_build_default_config(compio_config *result) {
     result->fragmentation_threshold = 30;
 }
 
-int get_compression_type(const char *fp, compio_compression_type* t) {
+int compio_get_compression_type(const char *fp, compio_compression_type* t) {
     FILE *file = fopen(fp, "r");
     if (file == nullptr) {
         return -1; 
+    }
+
+    if (is_file_empty(file)) {
+        fclose(file);
+        return -2;
     }
 
     header h;

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -87,6 +87,7 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
     compio_archive* archive;
     archive = new compio_archive(file, mode_b, c);
     if (!archive) {
+        WARNING_PRINT("warning: failed to allocate memory for compio_archive\n");
         goto end1;
     }
 
@@ -97,21 +98,25 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
     } else if (archive->header->compression_type != c->compressor.compression_type) {
         // compression type mismatch
         errno = EINVAL;
+        WARNING_PRINT("warning: compression type mismatch while opening archive\n");
         goto end2;
     }
 
     // initialize allocator before btree, because btree uses allocator for creating root node
     archive->allocator = new compio::block_allocator(archive);
     if (!archive->allocator) {
+        WARNING_PRINT("warning: failed to allocate memory for allocator\n");
         goto end2;
     }
 
     archive->index = new btree(archive);
     if (!archive->index) {
+        WARNING_PRINT("warning: failed to allocate memory for btree\n");
         goto end3;
     }
 
     if (!is_new_file && !archive->allocator->load_state(archive)) {
+        WARNING_PRINT("warning: failed to load allocator state from archive\n");
         goto end4;
     }
 

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -16,57 +16,6 @@ using namespace compio;
 
 extern "C" {
 
-// Helper function to build compressor from type
-static void build_compressor_from_type(compio_compression_type type, compio_compressor *result) {
-    switch (type) {
-    case COMPIO_COMPRESS_NONE:
-        compio_build_dummy_compressor(result);
-        break;
-    case COMPIO_COMPRESS_ZLIB:
-        compio_build_zlib_compressor(result);
-        break;
-    case COMPIO_COMPRESS_LZ4:
-        compio_build_lz4_compressor(result);
-        break;
-    case COMPIO_COMPRESS_ZSTD:
-        compio_build_zstd_compressor(result);
-        break;
-    case COMPIO_COMPRESS_BROTLI:
-        compio_build_brotli_compressor(result);
-        break;
-    default:
-        compio_build_zlib_compressor(result);
-        break;
-    }
-}
-
-// Helper function to get compression type from compressor
-static compio_compression_type get_compression_type(const compio_compressor *comp) {
-    compio_compressor test;
-
-    compio_build_dummy_compressor(&test);
-    if (comp->compress == test.compress)
-        return COMPIO_COMPRESS_NONE;
-
-    compio_build_zlib_compressor(&test);
-    if (comp->compress == test.compress)
-        return COMPIO_COMPRESS_ZLIB;
-
-    compio_build_lz4_compressor(&test);
-    if (comp->compress == test.compress)
-        return COMPIO_COMPRESS_LZ4;
-
-    compio_build_zstd_compressor(&test);
-    if (comp->compress == test.compress)
-        return COMPIO_COMPRESS_ZSTD;
-
-    compio_build_brotli_compressor(&test);
-    if (comp->compress == test.compress)
-        return COMPIO_COMPRESS_BROTLI;
-
-    return COMPIO_COMPRESS_ZLIB;
-}
-
 void compio_build_default_config(compio_config *result) {
     result->b_tree_degree = 16;
     compio_build_zlib_compressor(&result->compressor);
@@ -98,10 +47,9 @@ compio_archive::compio_archive(FILE *file, uint8_t mode_b, const compio_config *
       config(config),
       mode_b(mode_b),
       dec_cache(config->cache_size__compression),
+      c_buffer(new uint8_t[config->compressor.get_bufsize(config->block_size)]),
       block_reader(file, config->cache_size__blocks) {
-    fseek(file, 0, SEEK_END);
-    long fsize = ftell(file);
-    if (fsize == 0)
+    if (is_file_empty(file))
         header = smart_infile_object<compio::header>(file, 0, new compio::header());
     else
         header = smart_infile_object<compio::header>(file, 0);
@@ -119,7 +67,7 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
     uint8_t mode_b = parse_mode(mode);
     if (!mode_b) {
         errno = EINVAL;
-        return NULL;
+        goto end;
     }
 
     // if w+ passed as mode, we have to clear file contents (using w+)
@@ -131,46 +79,50 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
         archive_open_mode = "a+";
 
     auto file = fopen(fp, archive_open_mode);
-    if (file == nullptr)
-        return NULL;
-
-    // Check if archive is new or existing
-    fseek(file, 0, SEEK_END);
-    long fsize = ftell(file);
-    bool is_new_archive = (fsize == 0);
+    if (file == nullptr) {
+        goto end;
+    }
 
     auto archive = new compio_archive(file, mode_b, c);
+    if (!archive) {
+        goto end1;
+    }
 
-    // For existing archives, check if compression type matches
-    if (!is_new_archive) {
-        compio_compression_type saved_type =
-            (compio_compression_type)archive->header->compression_type;
-        compio_compression_type provided_type = get_compression_type(&c->compressor);
-
-        if (saved_type != provided_type) {
-            // Compression type mismatch
-            delete archive;
-            fclose(file);
-            errno = EINVAL;
-            return NULL;
-        }
-    } else {
-        // For new archives, save compression type to header
-        archive->header.ptr()->compression_type = get_compression_type(&c->compressor);
+    if (is_file_empty(file)) {
+        archive->header->compression_type = c->compressor.compression_type;
+    } else if (archive->header->compression_type != c->compressor.compression_type) {
+        // compression type mismatch
+        errno = EINVAL;
+        goto end2;
     }
 
     // initialize allocator before btree, because btree uses allocator for creating root node
     archive->allocator = new compio::block_allocator(archive);
-    archive->index = new btree(archive);
-
-    if (archive->allocator) {
-        archive->allocator->load_state(archive);
+    if (!archive->allocator) {
+        goto end2;
     }
 
-    archive->c_buffer =
-        std::unique_ptr<uint8_t[]>(new uint8_t[c->compressor.get_bufsize(c->block_size)]);
+    archive->index = new btree(archive);
+    if (!archive->index) {
+        goto end3;
+    }
+
+    if (!archive->allocator->load_state(archive)) {
+        goto end4;
+    }
 
     return archive;
+
+end4:
+    delete archive->index;
+end3:
+    delete archive->allocator;
+end2:
+    delete archive;
+end1:
+    fclose(file);
+end:
+    return NULL;
 }
 
 compio_file *compio_open_file(const char *name, compio_archive *archive) {

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -189,14 +189,21 @@ int compio_remove_file(compio_archive *archive, const char *name) {
 }
 
 int compio_close_file(compio_file *file) {
+    if (!file) {
+        WARNING_PRINT("warning: passed nullptr into compio_close_file\n");
+        return -1;
+    }
+
     delete file;
     return 0;
 }
 
 int compio_close_archive(compio_archive *archive) {
-    if (!archive)
-        return COMPIO_ERROR;
-
+    if (!archive) {
+        WARNING_PRINT("warning: passed nullptr into compio_close_archive\n");
+        return -1;
+    }
+    
     // Save allocator state before closing
     if (archive->allocator) {
         archive->allocator->save_state(archive);
@@ -212,10 +219,12 @@ int compio_close_archive(compio_archive *archive) {
     // not calling `delete header`, because it's not a pointer created with new,
     // but a smart_infile_object, which will destroy and flush it's internal pointer
     archive->header = {};
-
+    
     // 4) and finally we close the file
-    if (fclose(archive->file))
-        return COMPIO_ERROR;
+    if (fclose(archive->file)) {
+        WARNING_PRINT("warning: failed to close file in compio_close_archive\n");
+        return -2;
+    }
 
     delete archive->index;
     delete archive;

--- a/src/compressor.c
+++ b/src/compressor.c
@@ -29,6 +29,7 @@ void compio_build_dummy_compressor(compio_compressor *result) {
     result->compress = dummy_compress;
     result->decompress = dummy_decompress;
     result->get_bufsize = dummy_get_bufsize;
+    result->compression_type = COMPIO_COMPRESS_DUMMY;
 }
 
 int zlib_compress(void *dst, uint64_t *dst_size, const void *src, uint64_t src_size) {
@@ -78,6 +79,7 @@ void compio_build_zlib_compressor(compio_compressor *result) {
     result->compress = zlib_compress;
     result->decompress = zlib_decompress;
     result->get_bufsize = zlib_get_bufsize;
+    result->compression_type = COMPIO_COMPRESS_ZLIB;
 }
 
 /**
@@ -153,6 +155,7 @@ void compio_build_lz4_compressor(compio_compressor *result) {
     result->compress = lz4_compress;
     result->decompress = lz4_decompress;
     result->get_bufsize = lz4_get_bufsize;
+    result->compression_type = COMPIO_COMPRESS_LZ4;
 }
 
 /**
@@ -209,6 +212,7 @@ void compio_build_zstd_compressor(compio_compressor *result) {
     result->compress = zstd_compress;
     result->decompress = zstd_decompress;
     result->get_bufsize = zstd_get_bufsize;
+    result->compression_type = COMPIO_COMPRESS_ZSTD;
 }
 
 /**
@@ -272,4 +276,5 @@ void compio_build_brotli_compressor(compio_compressor *result) {
     result->compress = brotli_compress;
     result->decompress = brotli_decompress;
     result->get_bufsize = brotli_get_bufsize;
+    result->compression_type = COMPIO_COMPRESS_BROTLI;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -51,4 +51,10 @@ uint64_t get_hash_tail(const char *fname) {
     return hash_tail;
 }
 
+bool is_file_empty(FILE *file) {
+    fseek(file, 0, SEEK_END);
+    long fsize = ftell(file);
+    return fsize == 0;
+}
+
 } // namespace compio

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(compio_gtest
     src/test_allocator_advanced.cpp
     src/test_allocator_edge_cases.cpp
     src/test_allocator_serialization.cpp
+    src/test_compression_type.cpp
     src/test_library.cpp
 )
 

--- a/tests/src/test_allocator_advanced.cpp
+++ b/tests/src/test_allocator_advanced.cpp
@@ -123,6 +123,7 @@ protected:
         ASSERT_TRUE(file != nullptr);
 
         auto *config = new compio_config();
+        compio_build_default_config(config);
         config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
         config->fragmentation_threshold = 30;
         config->fill_holes_with_zeros = false;
@@ -216,6 +217,7 @@ protected:
         ASSERT_TRUE(file != nullptr);
 
         auto *config = new compio_config();
+        compio_build_default_config(config);
         config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
         config->fragmentation_threshold = 30;
         config->fill_holes_with_zeros = false;
@@ -298,6 +300,7 @@ protected:
         ASSERT_TRUE(file != nullptr);
 
         auto *config = new compio_config();
+        compio_build_default_config(config);
         config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
         config->fragmentation_threshold = threshold;
         config->fill_holes_with_zeros = false;

--- a/tests/src/test_compression_type.cpp
+++ b/tests/src/test_compression_type.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+
+#include "compio.h"
+
+#include "test_util.hpp"
+
+TEST(CompressionTypeTest, ExistingArchive) {
+    char fn[256];
+    generate_tmp_fn(fn, sizeof(fn));
+
+    // create archive with some specific compression_type
+    compio_config config;
+    compio_build_default_config(&config);
+
+    compio_build_zlib_compressor(&config.compressor);
+    compio_compression_type type = config.compressor.compression_type;
+
+    auto archive = compio_open_archive(fn, "w+", &config);
+    ASSERT_NE(archive, nullptr);
+
+    auto file = compio_open_file("A", archive);
+    ASSERT_NE(file, nullptr);
+
+    ASSERT_EQ(compio_close_file(file), 0);
+    ASSERT_EQ(compio_close_archive(archive), 0);
+
+    // check, that get_compression_type returns same compression_type
+    compio_compression_type new_type;
+    compio_get_compression_type(fn, &new_type);
+
+    ASSERT_EQ(type, new_type);
+
+    // check, that opening this archive with correct compression type is fine
+    archive = compio_open_archive(fn, "r", &config);
+    ASSERT_NE(archive, nullptr);
+    ASSERT_EQ(compio_close_archive(archive), 0);
+
+    // check, that opening this archive with another compression type will lead to an error
+    compio_build_lz4_compressor(&config.compressor);
+    ASSERT_EQ(compio_open_archive(fn, "r", &config), nullptr);
+
+    remove(fn);
+}

--- a/tests/src/test_library.cpp
+++ b/tests/src/test_library.cpp
@@ -14,7 +14,7 @@ protected:
     compio_archive *archive;
     compio_file *file;
     char fn[256];
-    bool failed;
+    bool failed = false;
 
     void SetUp() override {
         compio_build_default_config(&config);
@@ -68,7 +68,7 @@ protected:
     compio_archive *archive;
     compio_file *file;
     char fn[256];
-    bool failed;
+    bool failed = false;
 
     void SetUp() override {
         compio_build_default_config(&config);

--- a/tests/src/test_library.cpp
+++ b/tests/src/test_library.cpp
@@ -34,8 +34,10 @@ protected:
     }
 
     void TearDown() override {
-        ASSERT_EQ(compio_close_file(file), 0);
-        ASSERT_EQ(compio_close_archive(archive), 0);
+        if (file)
+            ASSERT_EQ(compio_close_file(file), 0);
+        if (archive)
+            ASSERT_EQ(compio_close_archive(archive), 0);
 
         remove(fn);
     }
@@ -43,8 +45,10 @@ protected:
     void Reset() {
         // close and open file (cursor in the beginning after opening)
 
-        ASSERT_EQ(compio_close_file(file), 0);
-        ASSERT_EQ(compio_close_archive(archive), 0);
+        if (file)
+            ASSERT_EQ(compio_close_file(file), 0);
+        if (archive)
+            ASSERT_EQ(compio_close_archive(archive), 0);
         archive = compio_open_archive(fn, "r+", &config);
         if (!archive) {
             failed = true;
@@ -84,16 +88,16 @@ protected:
     }
 
     void TearDown() override {
+        if (file)
         ASSERT_EQ(compio_close_file(file), 0);
+        if (archive)
         ASSERT_EQ(compio_close_archive(archive), 0);
 
         remove(fn);
     }
 };
 
-TEST_F(OpenedFileTest, OpenClose) {
-    ASSERT_FALSE(failed);
-}
+TEST_F(OpenedFileTest, OpenClose) { ASSERT_FALSE(failed); }
 
 TEST_F(OpenedFileTest, BasicWriteRead) {
     ASSERT_FALSE(failed);

--- a/tests/src/test_library.cpp
+++ b/tests/src/test_library.cpp
@@ -89,9 +89,9 @@ protected:
 
     void TearDown() override {
         if (file)
-        ASSERT_EQ(compio_close_file(file), 0);
+            ASSERT_EQ(compio_close_file(file), 0);
         if (archive)
-        ASSERT_EQ(compio_close_archive(archive), 0);
+            ASSERT_EQ(compio_close_archive(archive), 0);
 
         remove(fn);
     }

--- a/tests/src/test_library.cpp
+++ b/tests/src/test_library.cpp
@@ -14,6 +14,7 @@ protected:
     compio_archive *archive;
     compio_file *file;
     char fn[256];
+    bool failed;
 
     void SetUp() override {
         compio_build_default_config(&config);
@@ -21,12 +22,20 @@ protected:
         generate_tmp_fn(fn, sizeof(fn));
 
         archive = compio_open_archive(fn, "w+", &config);
+        if (!archive) {
+            failed = true;
+            FAIL() << "failed to open archive";
+        }
         file = compio_open_file("A", archive);
+        if (!file) {
+            failed = true;
+            FAIL() << "failed to open file in archive";
+        }
     }
 
     void TearDown() override {
-        compio_close_file(file);
-        compio_close_archive(archive);
+        ASSERT_EQ(compio_close_file(file), 0);
+        ASSERT_EQ(compio_close_archive(archive), 0);
 
         remove(fn);
     }
@@ -34,10 +43,18 @@ protected:
     void Reset() {
         // close and open file (cursor in the beginning after opening)
 
-        compio_close_file(file);
-        compio_close_archive(archive);
+        ASSERT_EQ(compio_close_file(file), 0);
+        ASSERT_EQ(compio_close_archive(archive), 0);
         archive = compio_open_archive(fn, "r+", &config);
+        if (!archive) {
+            failed = true;
+            FAIL() << "failed to reopen archive";
+        }
         file = compio_open_file("A", archive);
+        if (!file) {
+            failed = true;
+            FAIL() << "failed to reopen file in archive";
+        }
     }
 };
 
@@ -47,6 +64,7 @@ protected:
     compio_archive *archive;
     compio_file *file;
     char fn[256];
+    bool failed;
 
     void SetUp() override {
         compio_build_default_config(&config);
@@ -54,23 +72,31 @@ protected:
         generate_tmp_fn(fn, sizeof(fn));
 
         archive = compio_open_archive(fn, "w+", &config);
+        if (!archive) {
+            failed = true;
+            FAIL() << "failed to open archive";
+        }
         file = compio_open_file("A", archive);
+        if (!file) {
+            failed = true;
+            FAIL() << "failed to open file in archive";
+        }
     }
 
     void TearDown() override {
-        compio_close_file(file);
-        compio_close_archive(archive);
+        ASSERT_EQ(compio_close_file(file), 0);
+        ASSERT_EQ(compio_close_archive(archive), 0);
 
         remove(fn);
     }
 };
 
 TEST_F(OpenedFileTest, OpenClose) {
-    ASSERT_NE(archive, nullptr);
-    ASSERT_NE(file, nullptr);
+    ASSERT_FALSE(failed);
 }
 
 TEST_F(OpenedFileTest, BasicWriteRead) {
+    ASSERT_FALSE(failed);
     std::vector<unsigned char> in_data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
     const std::size_t size = in_data.size();
 
@@ -110,6 +136,7 @@ std::vector<unsigned char> generate_random_buffer(std::size_t size) {
 }
 
 TEST_P(WriteReadNBytesTest, RandomWriteRead) {
+    ASSERT_FALSE(failed);
     uint64_t size = GetParam();
     auto in_data = generate_random_buffer(size);
     std::vector<unsigned char> out_data(size, '?');
@@ -131,6 +158,7 @@ TEST_P(WriteReadNBytesTest, RandomWriteRead) {
 }
 
 TEST_P(WriteReadNBytesTest, RandomWriteResetRead) {
+    ASSERT_FALSE(failed);
     uint64_t size = GetParam();
     auto in_data = generate_random_buffer(size);
     std::vector<unsigned char> out_data(size, '?');
@@ -138,6 +166,7 @@ TEST_P(WriteReadNBytesTest, RandomWriteResetRead) {
     ASSERT_EQ(compio_write(in_data.data(), size, file), size);
 
     Reset();
+    ASSERT_FALSE(failed);
 
     ASSERT_EQ(compio_read(out_data.data(), size, file), size);
 
@@ -163,7 +192,9 @@ TEST_P(RWBlocksTest, ConsecutiveBlocksWriteRead) {
     generate_tmp_fn(fn, sizeof(fn));
 
     archive = compio_open_archive(fn, "w+", &config);
+    ASSERT_NE(archive, nullptr);
     file = compio_open_file("A", archive);
+    ASSERT_NE(file, nullptr);
 
     auto [n_blocks, block_size] = GetParam();
 
@@ -175,11 +206,13 @@ TEST_P(RWBlocksTest, ConsecutiveBlocksWriteRead) {
         fflush(archive->file);
     }
 
-    compio_close_file(file);
-    compio_close_archive(archive);
+    ASSERT_EQ(compio_close_file(file), 0);
+    ASSERT_EQ(compio_close_archive(archive), 0);
 
     archive = compio_open_archive(fn, "r+", &config);
+    ASSERT_NE(archive, nullptr);
     file = compio_open_file("A", archive);
+    ASSERT_NE(file, nullptr);
 
     for (std::size_t i = 0; i < n_blocks; ++i) {
         ASSERT_EQ(compio_tell(file), block_size * i) << "; iter=" << i;
@@ -190,8 +223,8 @@ TEST_P(RWBlocksTest, ConsecutiveBlocksWriteRead) {
         }
     }
 
-    compio_close_file(file);
-    compio_close_archive(archive);
+    ASSERT_EQ(compio_close_file(file), 0);
+    ASSERT_EQ(compio_close_archive(archive), 0);
 
     remove(fn);
 }
@@ -235,7 +268,9 @@ TEST_P(RandomUsageTest, RandomUsage) {
         int current_fsize = 0;
 
         archive = compio_open_archive(fn, "w+", &config);
+        ASSERT_NE(archive, nullptr);
         file = compio_open_file("A", archive);
+        ASSERT_NE(file, nullptr);
 
         for (int i = 0; i < n_operations; ++i) {
             // fprintf(stderr, "cursor=%d, current_fsize=%d\n", cursor, current_fsize);
@@ -283,8 +318,8 @@ TEST_P(RandomUsageTest, RandomUsage) {
             }
         }
 
-        compio_close_file(file);
-        compio_close_archive(archive);
+        ASSERT_EQ(compio_close_file(file), 0);
+        ASSERT_EQ(compio_close_archive(archive), 0);
     }
 
     remove(fn);
@@ -331,7 +366,9 @@ TEST_P(CustomUsageTest, CustomUsage) {
     int cursor = 0;
 
     archive = compio_open_archive(fn, "w+", &config);
+    ASSERT_NE(archive, nullptr);
     file = compio_open_file("A", archive);
+    ASSERT_NE(file, nullptr);
 
     for (const auto &operation : params.operations) {
         // fprintf(stderr, "cursor=%d, current_fsize=%d\n", cursor, current_fsize);
@@ -361,8 +398,8 @@ TEST_P(CustomUsageTest, CustomUsage) {
         }
     }
 
-    compio_close_file(file);
-    compio_close_archive(archive);
+    ASSERT_EQ(compio_close_file(file), 0);
+    ASSERT_EQ(compio_close_archive(archive), 0);
 
     remove(fn);
 }


### PR DESCRIPTION
1. Немного поменял реализацию проверки соответствия алгоритма сжатия при открытии архива (вместо того, чтобы сравнивать указатели к функциям `compress`, я храню в `struct compressor` `compression_type`, и просто сравниваю их)
2. Добавил тест на это (`test_compression_type`)
3. В `compio_open_archive` проверяю, что `allocator->load_state` возвращает `true`, а иначе возвращаю ошибку. Так же добавил во все свои тесты проверку на ошибку в `compio_open_archive` (в тестах аллокатора уже везде было). Теперь я кажется понял, почему на винде мои тесты, где архив закрывался и потом снова открывался, падали (потому что там `allocator->load_state` фейлился, и при открытии архива заново там дальше было что-то невалидное, потому что аллокатор не смог загрузиться). Теперь эти тесты фейлятся и на линуксе, потому что они падают уже на `compio_open_archive`
4. Так же проверяю, что `allocator->save_state` возвращает `true` в `compio_close_archive` (и во всех тестах проверяю на ошибки закрытия архивов и файлов). На этих моментах кажется ничего не падает, то есть `allocator->save_state` возвращает `true`

В общем нужно дебажить, почему `allocator->load_state` возвращает `false` в тестах с закрытием и открытием архива