### PR TITLE
feat: huge cache optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ Testing/
 CTestTestfile.cmake
 cmake_install.cmake
 tests/Makefile
+CMakeUserPresets.json
 
 # Logs and temporary files
 *.log

--- a/include/compio/compio_file.hpp
+++ b/include/compio/compio_file.hpp
@@ -27,7 +27,7 @@ struct compio_archive {
     const compio_config *config;                /**< Compio configuration */
     smart_infile_object<compio::header> header; /**< Read file header */
     compio::btree *index;
-    compio::storage_block_reader block_reader;
+    compio::storage_block_reader *block_reader;
 
     /**
      * @brief Parsed open mode (1 - read, 2 - write, 4 - edit, don't clear

--- a/include/compio/compio_file.hpp
+++ b/include/compio/compio_file.hpp
@@ -3,11 +3,8 @@
 
 #include <memory>
 
-#include "compio/btree.hpp"
-#include "compio/file.hpp"
 #include "compio/infile_object.hpp"
 #include "compio/storage_block_reader.hpp"
-#include "compio.h"
 
 // forward declaration
 namespace compio {

--- a/include/compio/compio_file.hpp
+++ b/include/compio/compio_file.hpp
@@ -38,9 +38,6 @@ struct compio_archive {
     compio_archive(FILE *file, uint8_t mode_b, const compio_config *config);
 
     compio::block_allocator *allocator;
-
-    std::unique_ptr<uint8_t[]> c_buffer;
-    cache::lru_cache<uint64_t, std::pair<std::shared_ptr<uint8_t[]>, uint64_t>> dec_cache;
 };
 
 /**

--- a/include/compio/file.hpp
+++ b/include/compio/file.hpp
@@ -13,27 +13,10 @@
 #include <vector>
 
 #include "compio/infile_object.hpp"
+#include "compio/tree_types.hpp"
 #include "compio.h"
 
 namespace compio {
-
-/**
- * @brief Type for key in btree
- *
- */
-typedef struct {
-    uint64_t hash; /**< last 64 bits of hashed internal file name */
-    uint64_t pos;  /**< Position of block start in uncompressed file */
-} tree_key;
-
-/**
- * @brief Type for value in btree
- *
- */
-typedef struct {
-    uint64_t addr; /**< Address of storage_block in archive file */
-    uint64_t size; /**< Original size of uncompressed block */
-} tree_val;
 
 /**
  * @brief Files table for archive header

--- a/include/compio/storage_block_reader.hpp
+++ b/include/compio/storage_block_reader.hpp
@@ -63,7 +63,7 @@ struct storage_block_reader {
      * @param addr Block address in file
      * @return Smart pointer to storage block
      */
-    std::shared_ptr<block> read_block(uint64_t addr);
+    std::shared_ptr<block> read_block(uint64_t addr, tree_key key);
 
     /**
      * @brief Create new storage block
@@ -75,21 +75,16 @@ struct storage_block_reader {
     std::shared_ptr<block> create_block(uint64_t size, tree_key key);
 
     /**
-     * @brief Remove block from cache
-     * @param addr Block address to remove
-     */
-    // void remove_block(uint64_t addr);
-
-    /**
      * @brief Clear all cached blocks
      */
-    // void clear_cache();
+    void clear_cache();
 
 private:
     FILE *file; /**< Archive file handle */
     block_allocator *allocator;
     btree *index;
     const compio_compressor *compressor;
+    cache::lru_cache<tree_key, std::shared_ptr<block>, tree_key_hash> cache;
 };
 
 } // namespace compio

--- a/include/compio/storage_block_reader.hpp
+++ b/include/compio/storage_block_reader.hpp
@@ -10,8 +10,7 @@
 
 #include "compio/allocator.hpp"
 #include "compio/btree.hpp"
-#include "compio/file.hpp"
-#include "compio/infile_object.hpp"
+#include "compio/tree_types.hpp"
 
 #include "third_party/lrucache.hpp"
 

--- a/include/compio/storage_block_reader.hpp
+++ b/include/compio/storage_block_reader.hpp
@@ -6,6 +6,7 @@
 #ifndef STORAGE_BLOCK_READER_HPP_
 #define STORAGE_BLOCK_READER_HPP_
 
+#include "compio/allocator.hpp"
 #include "compio/file.hpp"
 #include "compio/infile_object.hpp"
 
@@ -25,7 +26,7 @@ struct storage_block_reader {
      * @param file File handle to read from
      * @param max_size Maximum number of blocks to cache
      */
-    storage_block_reader(FILE *file, int max_size);
+    storage_block_reader(FILE *file, block_allocator *allocator, int max_size);
 
     /**
      * @brief Read storage block from file
@@ -59,6 +60,7 @@ private:
     FILE *file; /**< Archive file handle */
     cache::lru_cache<uint64_t, smart_infile_object<storage_block>>
         cache; /**< LRU cache for blocks */
+    block_allocator *allocator;
 };
 
 } // namespace compio

--- a/include/compio/storage_block_reader.hpp
+++ b/include/compio/storage_block_reader.hpp
@@ -6,7 +6,10 @@
 #ifndef STORAGE_BLOCK_READER_HPP_
 #define STORAGE_BLOCK_READER_HPP_
 
+#include <memory>
+
 #include "compio/allocator.hpp"
+#include "compio/btree.hpp"
 #include "compio/file.hpp"
 #include "compio/infile_object.hpp"
 
@@ -17,6 +20,7 @@ namespace compio {
 class block {
     FILE *file;
     block_allocator *allocator;
+    btree *index;
     const compio_compressor *compressor;
     tree_key key;
     uint64_t addr;
@@ -28,12 +32,12 @@ class block {
     bool is_valid;
 
 public:
-    block(FILE *file, block_allocator *allocator, const compio_compressor *compressor, tree_key key,
+    block(FILE *file, block_allocator *allocator, btree *index, const compio_compressor *compressor,
           uint64_t addr);
-    block(FILE *file, block_allocator *allocator, const compio_compressor *compressor, tree_key key,
-          uint64_t size, std::unique_ptr<uint8_t[]> &&data);
-    // block(FILE *file, block_allocator *allocator, compio_compressor *compressor, tree_key key,
-    //       uint64_t size);
+    block(FILE *file, block_allocator *allocator, btree *index, const compio_compressor *compressor,
+          tree_key key, uint64_t size, std::unique_ptr<uint8_t[]> &&data);
+    block(FILE *file, block_allocator *allocator, btree *index, const compio_compressor *compressor,
+          tree_key key, uint64_t size, bool initialize_with_zeros);
     ~block();
 
     const uint8_t *data() const;
@@ -52,7 +56,7 @@ struct storage_block_reader {
      * @param file File handle to read from
      * @param max_size Maximum number of blocks to cache
      */
-    storage_block_reader(FILE *file, block_allocator *allocator,
+    storage_block_reader(FILE *file, block_allocator *allocator, btree *index,
                          const compio_compressor *compressor, int max_size);
 
     /**
@@ -60,7 +64,7 @@ struct storage_block_reader {
      * @param addr Block address in file
      * @return Smart pointer to storage block
      */
-    smart_infile_object<storage_block> read_block(uint64_t addr);
+    std::shared_ptr<block> read_block(uint64_t addr);
 
     /**
      * @brief Create new storage block
@@ -69,25 +73,23 @@ struct storage_block_reader {
      * @param size Data size
      * @return Smart pointer to created block
      */
-    smart_infile_object<storage_block>
-    create_block(uint64_t addr, std::unique_ptr<uint8_t[]> &&data, uint64_t size);
+    std::shared_ptr<block> create_block(uint64_t size, tree_key key);
 
     /**
      * @brief Remove block from cache
      * @param addr Block address to remove
      */
-    void remove_block(uint64_t addr);
+    // void remove_block(uint64_t addr);
 
     /**
      * @brief Clear all cached blocks
      */
-    void clear_cache();
+    // void clear_cache();
 
 private:
     FILE *file; /**< Archive file handle */
-    cache::lru_cache<uint64_t, smart_infile_object<storage_block>>
-        cache; /**< LRU cache for blocks */
     block_allocator *allocator;
+    btree *index;
     const compio_compressor *compressor;
 };
 

--- a/include/compio/storage_block_reader.hpp
+++ b/include/compio/storage_block_reader.hpp
@@ -14,6 +14,32 @@
 
 namespace compio {
 
+class block {
+    FILE *file;
+    block_allocator *allocator;
+    const compio_compressor *compressor;
+    tree_key key;
+    uint64_t addr;
+    uint64_t c_size;
+    std::unique_ptr<uint8_t[]> dec_data;
+    uint64_t dec_size;
+    bool is_modified;
+    bool is_removed;
+    bool is_valid;
+
+public:
+    block(FILE *file, block_allocator *allocator, const compio_compressor *compressor, tree_key key,
+          uint64_t addr);
+    block(FILE *file, block_allocator *allocator, const compio_compressor *compressor, tree_key key,
+          uint64_t size, std::unique_ptr<uint8_t[]> &&data);
+    // block(FILE *file, block_allocator *allocator, compio_compressor *compressor, tree_key key,
+    //       uint64_t size);
+    ~block();
+
+    const uint8_t *data() const;
+    uint8_t *data();
+};
+
 /**
  * @brief Reader for storage blocks with LRU caching
  *
@@ -26,7 +52,8 @@ struct storage_block_reader {
      * @param file File handle to read from
      * @param max_size Maximum number of blocks to cache
      */
-    storage_block_reader(FILE *file, block_allocator *allocator, int max_size);
+    storage_block_reader(FILE *file, block_allocator *allocator,
+                         const compio_compressor *compressor, int max_size);
 
     /**
      * @brief Read storage block from file
@@ -61,6 +88,7 @@ private:
     cache::lru_cache<uint64_t, smart_infile_object<storage_block>>
         cache; /**< LRU cache for blocks */
     block_allocator *allocator;
+    const compio_compressor *compressor;
 };
 
 } // namespace compio

--- a/include/compio/tree_types.hpp
+++ b/include/compio/tree_types.hpp
@@ -1,0 +1,129 @@
+/**
+ * @file tree_types.hpp
+ * @brief tree_key and tree_val types
+ *
+ */
+
+#ifndef TREE_TYPES_H_
+#define TREE_TYPES_H_
+
+#include <cstdint>
+
+namespace compio {
+
+/**
+ * @brief Type for key in btree
+ *
+ */
+typedef struct {
+    uint64_t hash; /**< last 64 bits of hashed internal file name */
+    uint64_t pos;  /**< Position of block start in uncompressed file */
+} tree_key;
+
+/**
+ * @brief Type for value in btree
+ *
+ */
+typedef struct {
+    uint64_t addr; /**< Address of storage_block in archive file */
+    uint64_t size; /**< Original size of uncompressed block */
+} tree_val;
+
+/**
+ * @brief Less-than comparison for tree keys
+ * @param x First key
+ * @param y Second key
+ * @return True if x < y
+ */
+inline bool operator<(const tree_key &x, const tree_key &y) {
+    if (x.hash == y.hash)
+        return x.pos < y.pos;
+    return x.hash < y.hash;
+}
+
+/**
+ * @brief Equality comparison for tree keys
+ * @param x First key
+ * @param y Second key
+ * @return True if x == y
+ */
+inline bool operator==(const tree_key &x, const tree_key &y) {
+    return x.hash == y.hash && x.pos == y.pos;
+}
+
+/**
+ * @brief Greater-than comparison for tree keys
+ * @param x First key
+ * @param y Second key
+ * @return True if x > y
+ */
+inline bool operator>(const tree_key &x, const tree_key &y) {
+    if (x.hash == y.hash)
+        return x.pos > y.pos;
+    return x.hash > y.hash;
+}
+
+/**
+ * @brief Less-than-or-equal comparison for tree keys
+ * @param x First key
+ * @param y Second key
+ * @return True if x <= y
+ */
+inline bool operator<=(const tree_key &x, const tree_key &y) {
+    if (x.hash == y.hash)
+        return x.pos <= y.pos;
+    return x.hash <= y.hash;
+}
+
+/**
+ * @brief Greater-than-or-equal comparison for tree keys
+ * @param x First key
+ * @param y Second key
+ * @return True if x >= y
+ */
+inline bool operator>=(const tree_key &x, const tree_key &y) {
+    if (x.hash == y.hash)
+        return x.pos >= y.pos;
+    return x.hash >= y.hash;
+}
+
+/**
+ * @brief Inequality comparison for tree keys
+ * @param x First key
+ * @param y Second key
+ * @return True if x != y
+ */
+inline bool operator!=(const tree_key &x, const tree_key &y) {
+    return x.hash != y.hash || x.pos != y.pos;
+}
+
+/**
+ * @brief Add offset to tree key position
+ * @param x Original key
+ * @param size Offset to add
+ * @return New key with adjusted position
+ */
+inline tree_key operator+(const tree_key &x, uint64_t size) { return {x.hash, x.pos + size}; }
+
+/**
+ * @internal
+ * @brief Template for minimum value
+ */
+template <class T> constexpr T _min();
+
+/**
+ * @internal
+ * @brief Minimum tree_key value
+ */
+template <> constexpr tree_key _min<tree_key>() { return {0, 0}; }
+
+template <class T> constexpr T _max();
+template <> constexpr tree_key _max<tree_key>() { return {(uint64_t)-1, (uint64_t)-1}; }
+
+struct tree_key_hash {
+    size_t operator()(const tree_key &key) const { return key.hash ^ key.pos; }
+};
+
+} // namespace compio
+
+#endif // TREE_TYPES_H_

--- a/include/compio/utils.hpp
+++ b/include/compio/utils.hpp
@@ -6,8 +6,8 @@
 #ifndef UTILS_HEADER_
 #define UTILS_HEADER_
 
-#include "compio/compio_file.hpp"
-#include "compio.h"
+#include <cstdint>
+#include <cstdio>
 
 namespace compio {
 
@@ -22,97 +22,6 @@ enum mode_bit { r = 0b0001, w = 0b0010, a = 0b0100, plus = 0b1000 };
  * @return Parsed mode as bit flags
  */
 uint8_t parse_mode(const char *mode);
-
-/**
- * @brief Less-than comparison for tree keys
- * @param x First key
- * @param y Second key
- * @return True if x < y
- */
-inline bool operator<(const tree_key &x, const tree_key &y) {
-    if (x.hash == y.hash)
-        return x.pos < y.pos;
-    return x.hash < y.hash;
-}
-
-/**
- * @brief Equality comparison for tree keys
- * @param x First key
- * @param y Second key
- * @return True if x == y
- */
-inline bool operator==(const tree_key &x, const tree_key &y) {
-    return x.hash == y.hash && x.pos == y.pos;
-}
-
-/**
- * @brief Greater-than comparison for tree keys
- * @param x First key
- * @param y Second key
- * @return True if x > y
- */
-inline bool operator>(const tree_key &x, const tree_key &y) {
-    if (x.hash == y.hash)
-        return x.pos > y.pos;
-    return x.hash > y.hash;
-}
-
-/**
- * @brief Less-than-or-equal comparison for tree keys
- * @param x First key
- * @param y Second key
- * @return True if x <= y
- */
-inline bool operator<=(const tree_key &x, const tree_key &y) {
-    if (x.hash == y.hash)
-        return x.pos <= y.pos;
-    return x.hash <= y.hash;
-}
-
-/**
- * @brief Greater-than-or-equal comparison for tree keys
- * @param x First key
- * @param y Second key
- * @return True if x >= y
- */
-inline bool operator>=(const tree_key &x, const tree_key &y) {
-    if (x.hash == y.hash)
-        return x.pos >= y.pos;
-    return x.hash >= y.hash;
-}
-
-/**
- * @brief Inequality comparison for tree keys
- * @param x First key
- * @param y Second key
- * @return True if x != y
- */
-inline bool operator!=(const tree_key &x, const tree_key &y) {
-    return x.hash != y.hash || x.pos != y.pos;
-}
-
-/**
- * @brief Add offset to tree key position
- * @param x Original key
- * @param size Offset to add
- * @return New key with adjusted position
- */
-inline tree_key operator+(const tree_key &x, uint64_t size) { return {x.hash, x.pos + size}; }
-
-/**
- * @internal
- * @brief Template for minimum value
- */
-template <class T> constexpr T _min();
-
-/**
- * @internal
- * @brief Minimum tree_key value
- */
-template <> constexpr tree_key _min<tree_key>() { return {0, 0}; }
-
-template <class T> constexpr T _max();
-template <> constexpr tree_key _max<tree_key>() { return {(uint64_t)-1, (uint64_t)-1}; }
 
 uint64_t fnv1a(const char *s);
 

--- a/include/third_party/lrucache.hpp
+++ b/include/third_party/lrucache.hpp
@@ -44,7 +44,7 @@
 
 namespace cache {
 
-template <typename key_t, typename value_t> class lru_cache {
+template <typename key_t, typename value_t, typename hasher = std::hash<key_t>> class lru_cache {
 public:
     typedef typename std::pair<key_t, value_t> key_value_pair_t;
     typedef typename std::list<key_value_pair_t>::iterator list_iterator_t;
@@ -127,7 +127,7 @@ public:
 
 private:
     std::list<key_value_pair_t> _cache_items_list;
-    std::unordered_map<key_t, list_iterator_t> _cache_items_map;
+    std::unordered_map<key_t, list_iterator_t, hasher> _cache_items_map;
     size_t _max_size;
 };
 

--- a/src/btree.cpp
+++ b/src/btree.cpp
@@ -4,8 +4,8 @@
 #include <limits>
 
 #include "compio/allocator.hpp"
+#include "compio/compio_file.hpp"
 #include "compio/debug_print.hpp"
-#include "compio/utils.hpp"
 
 using namespace compio;
 

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -234,6 +234,7 @@ int compio_close_archive(compio_archive *archive) {
         WARNING_PRINT("warning: failed to close file in compio_close_archive\n");
         return -2;
     }
+    DEBUG_PRINT("[cca]: closed file\n");
 
     // 6) and delete remaining structures
     delete archive->index;
@@ -355,6 +356,8 @@ end:
 }
 
 uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
+    DEBUG_PRINT("\ncompio_read(cursor=%lu, size=%lu)\n", file->cursor, size);
+
     const auto archive = file->archive;
     const auto config = archive->config;
 
@@ -377,6 +380,14 @@ uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
 
     auto range = get_range_in_file(file, size);
     uint64_t range_idx = 0;
+
+    DEBUG_PRINT("[CR]b-tree range:\n");
+    for (const auto &[key, val] : range) {
+        UNUSED(key);
+        UNUSED(val);
+        DEBUG_PRINT("\t(key.pos=%lu) --- (val.addr=%lu, val.size=%lu)\n", key.pos, val.addr,
+                    val.size);
+    }
 
     uint8_t *p_ptr = reinterpret_cast<uint8_t *>(ptr);
 

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -47,7 +47,7 @@ compio_archive::compio_archive(FILE *file, uint8_t mode_b, const compio_config *
     : file(file),
       config(config),
       index(nullptr),
-      block_reader(file, config->cache_size__blocks),
+      block_reader(nullptr),
       mode_b(mode_b),
       allocator(nullptr),
       c_buffer(new uint8_t[config->compressor.get_bufsize(config->block_size)]),
@@ -91,7 +91,7 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
     archive = new compio_archive(file, mode_b, c);
     if (!archive) {
         WARNING_PRINT("warning: failed to allocate memory for compio_archive\n");
-        goto end1;
+        goto no_archive;
     }
 
     bool is_new_file;
@@ -102,36 +102,45 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
         // compression type mismatch
         errno = EINVAL;
         WARNING_PRINT("warning: compression type mismatch while opening archive\n");
-        goto end2;
+        goto no_allocator;
     }
 
     // initialize allocator before btree, because btree uses allocator for creating root node
     archive->allocator = new compio::block_allocator(archive);
     if (!archive->allocator) {
         WARNING_PRINT("warning: failed to allocate memory for allocator\n");
-        goto end2;
+        goto no_allocator;
+    }
+
+    archive->block_reader =
+        new compio::storage_block_reader(file, archive->allocator, c->cache_size__blocks);
+    if (!archive->block_reader) {
+        WARNING_PRINT("warning: failed to allocate memory for storage_block_reader\n");
+        goto no_block_reader;
     }
 
     archive->index = new btree(archive);
     if (!archive->index) {
         WARNING_PRINT("warning: failed to allocate memory for btree\n");
-        goto end3;
+        goto no_index;
     }
 
     if (!is_new_file && !archive->allocator->load_state(archive)) {
         WARNING_PRINT("warning: failed to load allocator state from archive\n");
-        goto end4;
+        goto no_allocator_state;
     }
 
     return archive;
 
-end4:
+no_allocator_state:
     delete archive->index;
-end3:
+no_index:
+    delete archive->block_reader;
+no_block_reader:
     delete archive->allocator;
-end2:
+no_allocator:
     delete archive;
-end1:
+no_archive:
     fclose(file);
 end:
     return NULL;
@@ -202,8 +211,9 @@ int compio_close_archive(compio_archive *archive) {
         return -1;
     }
 
-    // 1) flush cached data to file
+    // 1) flush cached data to file and delete block_reader
     compio_flush(archive);
+    delete archive->block_reader;
 
     // 2) save allocator state to the end of the file
     if (archive->allocator) {
@@ -338,7 +348,7 @@ uint64_t compio_write(const void *ptr, uint64_t size, compio_file *file) {
                     DEBUG_PRINT("[CW]compression_cache fault, allocating buffer\n");
                 }
 
-                auto block = archive->block_reader.read_block(val.addr);
+                auto block = archive->block_reader->read_block(val.addr);
 
                 uint64_t dst_size = block->original_size;
                 if (block->is_compressed) {
@@ -360,7 +370,7 @@ uint64_t compio_write(const void *ptr, uint64_t size, compio_file *file) {
             }
 
             DEBUG_PRINT("[CW]removing and deallocating block val.addr=%lu\n", val.addr);
-            archive->block_reader.remove_block(val.addr);
+            archive->block_reader->remove_block(val.addr);
             archive->allocator->deallocate(val.addr, STORAGE_BLOCK_METASIZE + c_size);
         } else {
             DEBUG_PRINT("[CW]zero-initializing new block\n");
@@ -407,7 +417,7 @@ uint64_t compio_write(const void *ptr, uint64_t size, compio_file *file) {
         tree_key new_key = {file->hash_tail, block_start};
         tree_val new_val = {addr, block_size};
 
-        auto block = archive->block_reader.create_block(addr, std::move(c_buffer), c_buffer_size);
+        auto block = archive->block_reader->create_block(addr, std::move(c_buffer), c_buffer_size);
         block->original_size = block_size;
         block->is_compressed = is_compressed;
         block->index_key = new_key;
@@ -460,7 +470,8 @@ uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
         const uint64_t block_end = block_start + block_size;
 
         if (range_idx >= range.size()) {
-            WARNING_PRINT("went out of range in compio_read (%lu >= %lu)\n", range_idx, range.size());
+            WARNING_PRINT("went out of range in compio_read (%lu >= %lu)\n", range_idx,
+                          range.size());
             goto end;
         }
 
@@ -476,7 +487,7 @@ uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
                 dec_buffer = std::shared_ptr<uint8_t[]>(new uint8_t[block_size]);
             }
 
-            const auto block = archive->block_reader.read_block(val.addr);
+            const auto block = archive->block_reader->read_block(val.addr);
 
             uint64_t dst_size = block->original_size;
             if (block->is_compressed) {
@@ -512,7 +523,7 @@ end:
 }
 
 void compio_flush(compio_archive *archive) {
-    archive->block_reader.clear_cache();
+    archive->block_reader->clear_cache();
     archive->index->reader.clear_cache();
 }
 

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -112,8 +112,8 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
         goto no_allocator;
     }
 
-    archive->block_reader =
-        new compio::storage_block_reader(file, archive->allocator, c->cache_size__blocks);
+    archive->block_reader = new compio::storage_block_reader(file, archive->allocator,
+                                                             &c->compressor, c->cache_size__blocks);
     if (!archive->block_reader) {
         WARNING_PRINT("warning: failed to allocate memory for storage_block_reader\n");
         goto no_block_reader;

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -49,9 +49,7 @@ compio_archive::compio_archive(FILE *file, uint8_t mode_b, const compio_config *
       index(nullptr),
       block_reader(nullptr),
       mode_b(mode_b),
-      allocator(nullptr),
-      c_buffer(new uint8_t[config->compressor.get_bufsize(config->block_size)]),
-      dec_cache(config->cache_size__compression) {
+      allocator(nullptr) {
     if (is_file_empty(file))
         header = smart_infile_object<compio::header>(file, 0, new compio::header());
     else
@@ -112,17 +110,17 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
         goto no_allocator;
     }
 
-    archive->block_reader = new compio::storage_block_reader(file, archive->allocator,
-                                                             &c->compressor, c->cache_size__blocks);
-    if (!archive->block_reader) {
-        WARNING_PRINT("warning: failed to allocate memory for storage_block_reader\n");
-        goto no_block_reader;
-    }
-
     archive->index = new btree(archive);
     if (!archive->index) {
         WARNING_PRINT("warning: failed to allocate memory for btree\n");
         goto no_index;
+    }
+
+    archive->block_reader = new compio::storage_block_reader(
+        file, archive->allocator, archive->index, &c->compressor, c->cache_size__blocks);
+    if (!archive->block_reader) {
+        WARNING_PRINT("warning: failed to allocate memory for storage_block_reader\n");
+        goto no_block_reader;
     }
 
     if (!is_new_file && !archive->allocator->load_state(archive)) {
@@ -133,10 +131,10 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
     return archive;
 
 no_allocator_state:
-    delete archive->index;
-no_index:
     delete archive->block_reader;
 no_block_reader:
+    delete archive->index;
+no_index:
     delete archive->allocator;
 no_allocator:
     delete archive;
@@ -308,10 +306,9 @@ uint64_t compio_write(const void *ptr, uint64_t size, compio_file *file) {
         const uint64_t block_start = i * block_size;
         const uint64_t block_end = block_start + block_size;
 
-        std::shared_ptr<uint8_t[]> dec_buffer;
+        const tree_key new_key{file->hash_tail, block_start};
+        std::shared_ptr<block> b;
 
-        // read block from file and decompress it into dec_buffer (or take decompressed data from
-        // cache)
         if (i < n_existing_blocks) {
             if (range_idx >= range.size()) {
                 // this should not happen
@@ -330,56 +327,11 @@ uint64_t compio_write(const void *ptr, uint64_t size, compio_file *file) {
                 goto end;
             }
 
-            uint64_t c_size;
             DEBUG_PRINT("[CW]want block on val.addr=%lu\n", val.addr);
-
-            if (archive->dec_cache.exists(val.addr)) {
-                auto cache_elem = archive->dec_cache.pop(val.addr);
-                dec_buffer = cache_elem.first;
-                c_size = cache_elem.second;
-                DEBUG_PRINT("[CW]compression_cache hit for val.addr=%lu\n", val.addr);
-            } else {
-                if (config->cache_size__compression > 0 && archive->dec_cache.is_full()) {
-                    // can reuse already allocated buffer
-                    dec_buffer = archive->dec_cache.pop_back().first;
-                    DEBUG_PRINT("[CW]compression_cache fault, reusing cache tail buffer\n");
-                } else {
-                    dec_buffer = std::shared_ptr<uint8_t[]>(new uint8_t[block_size]);
-                    DEBUG_PRINT("[CW]compression_cache fault, allocating buffer\n");
-                }
-
-                auto block = archive->block_reader->read_block(val.addr);
-
-                uint64_t dst_size = block->original_size;
-                if (block->is_compressed) {
-                    int ret = config->compressor.decompress(dec_buffer.get(), &dst_size,
-                                                            block->data.get(), block->size);
-                    if (ret != 0) {
-                        // invalid archive (compressed data is too big after decompression)
-                        // TODO: set appropriate errno
-                        WARNING_PRINT(
-                            "compressed data is too big after decompression (%lu is not enough)\n",
-                            dst_size);
-                        goto end;
-                    }
-                } else {
-                    std::copy_n(block->data.get(), block->size, dec_buffer.get());
-                }
-
-                c_size = block->size;
-            }
-
-            DEBUG_PRINT("[CW]removing and deallocating block val.addr=%lu\n", val.addr);
-            archive->block_reader->remove_block(val.addr);
-            archive->allocator->deallocate(val.addr, STORAGE_BLOCK_METASIZE + c_size);
+            b = archive->block_reader->read_block(val.addr);
         } else {
             DEBUG_PRINT("[CW]zero-initializing new block\n");
-            if (config->cache_size__compression > 0 && archive->dec_cache.is_full()) {
-                dec_buffer = archive->dec_cache.pop_back().first;
-            } else {
-                dec_buffer = std::shared_ptr<uint8_t[]>(new uint8_t[block_size]);
-            }
-            std::fill_n(dec_buffer.get(), block_size, 0);
+            b = archive->block_reader->create_block(block_size, new_key);
         }
 
         // copy data from ptr into dec_buffer
@@ -390,47 +342,10 @@ uint64_t compio_write(const void *ptr, uint64_t size, compio_file *file) {
                 std::max<int64_t>(0, static_cast<int64_t>(file->cursor) - block_start);
             uint64_t ptr_offset =
                 std::max<int64_t>(0, static_cast<int64_t>(block_start) - file->cursor);
-            std::copy_n(p_ptr + ptr_offset, copy_size, dec_buffer.get() + dec_offset);
+            std::copy_n(p_ptr + ptr_offset, copy_size, b->data() + dec_offset);
             written_bytes += copy_size;
             DEBUG_PRINT("[CW]copied ptr data to dec_buffer\n");
         }
-
-        // compress dec_buffer into c_buffer
-        bool is_compressed = true;
-        uint64_t c_buffer_size = config->compressor.get_bufsize(block_size);
-        auto c_buffer = std::make_unique<uint8_t[]>(c_buffer_size);
-        int ret = config->compressor.compress(c_buffer.get(), &c_buffer_size, dec_buffer.get(),
-                                              block_size);
-        if (ret != 0 || c_buffer_size > block_size) {
-            if (ret != 0) {
-                WARNING_PRINT("compressor->compress returned %d\n", ret);
-            }
-
-            is_compressed = false;
-            std::copy_n(dec_buffer.get(), block_size, c_buffer.get());
-            c_buffer_size = block_size;
-        }
-
-        // create new block
-        uint64_t addr = archive->allocator->allocate(STORAGE_BLOCK_METASIZE + c_buffer_size);
-        DEBUG_PRINT("[CW]creating block on addr=%lu\n", addr);
-        tree_key new_key = {file->hash_tail, block_start};
-        tree_val new_val = {addr, block_size};
-
-        auto block = archive->block_reader->create_block(addr, std::move(c_buffer), c_buffer_size);
-        block->original_size = block_size;
-        block->is_compressed = is_compressed;
-        block->index_key = new_key;
-
-        // insert to the tree (or update)
-        if (i < n_existing_blocks) {
-            archive->index->update(new_key, new_val);
-        } else {
-            archive->index->insert(new_key, new_val);
-        }
-
-        // save uncompressed data to cache
-        archive->dec_cache.put(addr, {dec_buffer, c_buffer_size});
     }
 
 end:
@@ -476,43 +391,14 @@ uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
         }
 
         const auto &[key, val] = range[range_idx];
-
-        std::shared_ptr<uint8_t[]> dec_buffer;
-        if (archive->dec_cache.exists(val.addr)) {
-            dec_buffer = archive->dec_cache.get(val.addr).first;
-        } else {
-            if (config->cache_size__compression > 0 && archive->dec_cache.is_full()) {
-                dec_buffer = archive->dec_cache.pop_back().first;
-            } else {
-                dec_buffer = std::shared_ptr<uint8_t[]>(new uint8_t[block_size]);
-            }
-
-            const auto block = archive->block_reader->read_block(val.addr);
-
-            uint64_t dst_size = block->original_size;
-            if (block->is_compressed) {
-                int ret = config->compressor.decompress(dec_buffer.get(), &dst_size,
-                                                        block->data.get(), block->size);
-                if (ret != 0) {
-                    // invalid archive (compressed data is too big after decompression)
-                    // TODO: set appropriate errno
-                    WARNING_PRINT(
-                        "compressed data is too big after decompression (%lu is not enough)\n",
-                        dst_size);
-                    goto end;
-                }
-                archive->dec_cache.put(val.addr, {dec_buffer, block->size});
-            } else {
-                std::copy_n(block->data.get(), block->size, dec_buffer.get());
-            }
-        }
+        const std::shared_ptr<const block> b = archive->block_reader->read_block(val.addr);
 
         int64_t copy_size =
             std::min<int64_t>(read_end, block_end) - std::max<int64_t>(read_start, block_start);
         if (copy_size > 0) {
             uint64_t dec_offset = std::max<int64_t>(0, static_cast<int64_t>(cursor) - block_start);
             uint64_t ptr_offset = std::max<int64_t>(0, static_cast<int64_t>(block_start) - cursor);
-            std::copy_n(dec_buffer.get() + dec_offset, copy_size, p_ptr + ptr_offset);
+            std::copy_n(b->data() + dec_offset, copy_size, p_ptr + ptr_offset);
             read_bytes += copy_size;
         }
     }
@@ -523,7 +409,7 @@ end:
 }
 
 void compio_flush(compio_archive *archive) {
-    archive->block_reader->clear_cache();
+    // archive->block_reader->clear_cache();
     archive->index->reader.clear_cache();
 }
 

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -329,7 +329,7 @@ uint64_t compio_write(const void *ptr, uint64_t size, compio_file *file) {
             }
 
             DEBUG_PRINT("[CW]want block on val.addr=%lu\n", val.addr);
-            b = archive->block_reader->read_block(val.addr);
+            b = archive->block_reader->read_block(val.addr, key);
         } else {
             DEBUG_PRINT("[CW]zero-initializing new block\n");
             b = archive->block_reader->create_block(block_size, new_key);
@@ -402,7 +402,7 @@ uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
         }
 
         const auto &[key, val] = range[range_idx];
-        const std::shared_ptr<const block> b = archive->block_reader->read_block(val.addr);
+        const std::shared_ptr<const block> b = archive->block_reader->read_block(val.addr, key);
 
         int64_t copy_size =
             std::min<int64_t>(read_end, block_end) - std::max<int64_t>(read_start, block_start);
@@ -420,7 +420,7 @@ end:
 }
 
 void compio_flush(compio_archive *archive) {
-    // archive->block_reader->clear_cache();
+    archive->block_reader->clear_cache();
     archive->index->reader.clear_cache();
 }
 

--- a/src/storage_block_reader.cpp
+++ b/src/storage_block_reader.cpp
@@ -4,12 +4,13 @@
 
 namespace compio {
 
-block::block(FILE *file, block_allocator *allocator, const compio_compressor *compressor,
-             tree_key key, uint64_t addr)
+block::block(FILE *file, block_allocator *allocator, btree *index,
+             const compio_compressor *compressor, uint64_t addr)
     : file(file),
       allocator(allocator),
+      index(index),
       compressor(compressor),
-      key(key),
+      key({0, 0}),
       addr(addr),
       c_size(0),
       dec_data(nullptr),
@@ -23,6 +24,7 @@ block::block(FILE *file, block_allocator *allocator, const compio_compressor *co
 
     c_size = b.size;
     dec_size = b.original_size;
+    key = b.index_key;
 
     if (b.is_compressed) {
         dec_data = std::make_unique<uint8_t[]>(dec_size);
@@ -38,10 +40,12 @@ block::block(FILE *file, block_allocator *allocator, const compio_compressor *co
     }
 }
 
-block::block(FILE *file, block_allocator *allocator, const compio_compressor *compressor,
-             tree_key key, uint64_t size, std::unique_ptr<uint8_t[]> &&data)
+block::block(FILE *file, block_allocator *allocator, btree *index,
+             const compio_compressor *compressor, tree_key key, uint64_t size,
+             std::unique_ptr<uint8_t[]> &&data)
     : file(file),
       allocator(allocator),
+      index(index),
       compressor(compressor),
       key(key),
       addr(0),
@@ -52,19 +56,23 @@ block::block(FILE *file, block_allocator *allocator, const compio_compressor *co
       is_removed(false),
       is_valid(true) {}
 
-// block::block(FILE *file, block_allocator *allocator, compio_compressor *compressor, tree_key key,
-//              uint64_t size)
-//     : block(file, allocator, compressor, key, size, std::make_unique<uint8_t[]>(size)) {}
+block::block(FILE *file, block_allocator *allocator, btree *index,
+             const compio_compressor *compressor, tree_key key, uint64_t size,
+             bool initialize_with_zeros)
+    : block(file, allocator, index, compressor, key, size, std::make_unique<uint8_t[]>(size)) {
+    if (initialize_with_zeros) {
+        std::fill_n(dec_data.get(), size, 0);
+    }
+}
 
 block::~block() {
     if (is_valid && is_modified && !is_removed) {
-        uint64_t c_buffer_size = compressor->get_bufsize(dec_size);
-        storage_block b(c_buffer_size);
+        storage_block b(compressor->get_bufsize(dec_size));
         b.original_size = dec_size;
         b.index_key = key;
 
-        int ret = compressor->compress(b.data.get(), &c_buffer_size, dec_data.get(), dec_size);
-        if (ret != 0 || c_buffer_size > dec_size) {
+        int ret = compressor->compress(b.data.get(), &b.size, dec_data.get(), dec_size);
+        if (ret != 0 || b.size > dec_size) {
             if (ret != 0) {
                 WARNING_PRINT("compressor->compress returned %d\n", ret);
             }
@@ -89,6 +97,14 @@ block::~block() {
 
         uint64_t new_addr = allocator->allocate(STORAGE_BLOCK_METASIZE + b.size);
         b.write_to(file, new_addr);
+
+        if (addr == 0) {
+            // this block was created with block_reader::create_block
+            index->insert(key, {new_addr, dec_size});
+        } else {
+            // this block was read from file with block_reader::read_block
+            index->update(key, {new_addr, dec_size});
+        }
     } else if (is_valid && is_removed && addr != 0) {
         allocator->deallocate(addr, c_size);
     }
@@ -96,43 +112,26 @@ block::~block() {
 
 const uint8_t *block::data() const { return dec_data.get(); }
 
-uint8_t *block::data() { return dec_data.get(); }
+uint8_t *block::data() {
+    is_modified = true;
+    return dec_data.get();
+}
 
-storage_block_reader::storage_block_reader(FILE *file, block_allocator *allocator,
+storage_block_reader::storage_block_reader(FILE *file, block_allocator *allocator, btree *index,
                                            const compio_compressor *compressor, int max_size)
     : file(file),
-      cache(max_size),
       allocator(allocator),
-      compressor(compressor) {}
-
-smart_infile_object<storage_block> storage_block_reader::read_block(uint64_t addr) {
-    if (!cache.exists(addr)) {
-        auto result = smart_infile_object<storage_block>(file, addr);
-        cache.put(addr, result);
-        return result;
-    } else {
-        return cache.get(addr);
-    }
+      index(index),
+      compressor(compressor) {
+    UNUSED(max_size);
 }
 
-smart_infile_object<storage_block>
-storage_block_reader::create_block(uint64_t addr, std::unique_ptr<uint8_t[]> &&data,
-                                   uint64_t size) {
-    auto result =
-        smart_infile_object<storage_block>(file, addr, new storage_block(std::move(data), size));
-    cache.put(addr, result);
-    return result;
+std::shared_ptr<block> storage_block_reader::read_block(uint64_t addr) {
+    return std::make_shared<block>(file, allocator, index, compressor, addr);
 }
 
-void storage_block_reader::remove_block(uint64_t addr) {
-    if (!cache.exists(addr)) {
-        return;
-    }
-    auto block = cache.get(addr);
-    block.remove();
-    cache.remove(addr);
+std::shared_ptr<block> storage_block_reader::create_block(uint64_t size, tree_key key) {
+    return std::make_shared<block>(file, allocator, index, compressor, key, size, true);
 }
-
-void storage_block_reader::clear_cache() { cache.clear(); }
 
 } // namespace compio

--- a/src/storage_block_reader.cpp
+++ b/src/storage_block_reader.cpp
@@ -4,9 +4,10 @@
 
 namespace compio {
 
-storage_block_reader::storage_block_reader(FILE *file, int max_size)
+storage_block_reader::storage_block_reader(FILE *file, block_allocator *allocator, int max_size)
     : file(file),
-      cache(max_size) {}
+      cache(max_size),
+      allocator(allocator) {}
 
 smart_infile_object<storage_block> storage_block_reader::read_block(uint64_t addr) {
     if (!cache.exists(addr)) {

--- a/src/storage_block_reader.cpp
+++ b/src/storage_block_reader.cpp
@@ -98,13 +98,9 @@ block::~block() {
         uint64_t new_addr = allocator->allocate(STORAGE_BLOCK_METASIZE + b.size);
         b.write_to(file, new_addr);
 
-        if (addr == 0) {
-            // this block was created with block_reader::create_block
-            index->insert(key, {new_addr, dec_size});
-        } else {
-            // this block was read from file with block_reader::read_block
-            index->update(key, {new_addr, dec_size});
-        }
+        // block already in btree thanks to storage_block_reader
+        // we just need to update it's file address
+        index->update(key, {new_addr, dec_size}); 
     } else if (is_valid && is_removed && addr != 0) {
         allocator->deallocate(addr, c_size);
     }
@@ -122,16 +118,43 @@ storage_block_reader::storage_block_reader(FILE *file, block_allocator *allocato
     : file(file),
       allocator(allocator),
       index(index),
-      compressor(compressor) {
-    UNUSED(max_size);
-}
+      compressor(compressor),
+      cache(max_size) {}
 
-std::shared_ptr<block> storage_block_reader::read_block(uint64_t addr) {
-    return std::make_shared<block>(file, allocator, index, compressor, addr);
+std::shared_ptr<block> storage_block_reader::read_block(uint64_t addr, tree_key key) {
+    DEBUG_PRINT("[sbr][read_block]: addr=%lu, key.hash=%lu, key.pos=%lu\n", addr, key.hash,
+                key.pos);
+    if (cache.exists(key)) {
+        DEBUG_PRINT("[sbr][read_block]: cache hit\n");
+        return cache.get(key);
+    }
+    DEBUG_PRINT("[sbr][read_block]: cache miss\n");
+    auto b = std::make_shared<block>(file, allocator, index, compressor, addr);
+    cache.put(key, b);
+    return b;
 }
 
 std::shared_ptr<block> storage_block_reader::create_block(uint64_t size, tree_key key) {
-    return std::make_shared<block>(file, allocator, index, compressor, key, size, true);
+    DEBUG_PRINT("[sbr][create_block]: size=%lu, key.hash=%lu, key.pos=%lu\n", size, key.hash,
+                key.pos);
+    if (cache.exists(key)) {
+        WARNING_PRINT("[storage_block_reader]: trying to create block with key (%lu, %lu), that "
+                      "already exists in cache\n",
+                      key.hash, key.pos);
+        return cache.get(key);
+    }
+    auto b = std::make_shared<block>(file, allocator, index, compressor, key, size, true);
+    cache.put(key, b);
+    
+    // adding element to btree, but without file address (we didn't allocate memory block yet)
+    // block::~block will update this element in btree with new address
+    index->insert(key, {0, size});
+    return b;
+}
+
+void storage_block_reader::clear_cache() {
+    DEBUG_PRINT("[sbr][clear_cache]\n");
+    cache.clear();
 }
 
 } // namespace compio

--- a/src/storage_block_reader.cpp
+++ b/src/storage_block_reader.cpp
@@ -4,10 +4,106 @@
 
 namespace compio {
 
-storage_block_reader::storage_block_reader(FILE *file, block_allocator *allocator, int max_size)
+block::block(FILE *file, block_allocator *allocator, const compio_compressor *compressor,
+             tree_key key, uint64_t addr)
+    : file(file),
+      allocator(allocator),
+      compressor(compressor),
+      key(key),
+      addr(addr),
+      c_size(0),
+      dec_data(nullptr),
+      dec_size(0),
+      is_modified(false),
+      is_removed(false),
+      is_valid(true) {
+
+    storage_block b;
+    b.read_from(file, addr);
+
+    c_size = b.size;
+    dec_size = b.original_size;
+
+    if (b.is_compressed) {
+        dec_data = std::make_unique<uint8_t[]>(dec_size);
+        int ret = compressor->decompress(dec_data.get(), &dec_size, b.data.get(), b.size);
+        if (ret != 0) {
+            WARNING_PRINT("compressed data is too big after decompression (%lu is not enough)\n",
+                          dec_size);
+            is_valid = false;
+            return;
+        }
+    } else {
+        dec_data = std::move(b.data);
+    }
+}
+
+block::block(FILE *file, block_allocator *allocator, const compio_compressor *compressor,
+             tree_key key, uint64_t size, std::unique_ptr<uint8_t[]> &&data)
+    : file(file),
+      allocator(allocator),
+      compressor(compressor),
+      key(key),
+      addr(0),
+      c_size(0),
+      dec_data(std::move(data)),
+      dec_size(size),
+      is_modified(true),
+      is_removed(false),
+      is_valid(true) {}
+
+// block::block(FILE *file, block_allocator *allocator, compio_compressor *compressor, tree_key key,
+//              uint64_t size)
+//     : block(file, allocator, compressor, key, size, std::make_unique<uint8_t[]>(size)) {}
+
+block::~block() {
+    if (is_valid && is_modified && !is_removed) {
+        uint64_t c_buffer_size = compressor->get_bufsize(dec_size);
+        storage_block b(c_buffer_size);
+        b.original_size = dec_size;
+        b.index_key = key;
+
+        int ret = compressor->compress(b.data.get(), &c_buffer_size, dec_data.get(), dec_size);
+        if (ret != 0 || c_buffer_size > dec_size) {
+            if (ret != 0) {
+                WARNING_PRINT("compressor->compress returned %d\n", ret);
+            }
+
+            b.is_compressed = false;
+            b.data = std::move(dec_data);
+            b.size = dec_size;
+        } else {
+            b.is_compressed = true;
+        }
+
+        if (addr != 0) {
+            // block was read from file, so addr was already allocated from allocator previously
+
+            // if (c_size >= b.size) {
+            //     // we can reuse previous memory block in file
+            // }
+
+            // though it would be better to pass this logic to allocator, and allocate memory again
+            allocator->deallocate(addr, c_size);
+        }
+
+        uint64_t new_addr = allocator->allocate(STORAGE_BLOCK_METASIZE + b.size);
+        b.write_to(file, new_addr);
+    } else if (is_valid && is_removed && addr != 0) {
+        allocator->deallocate(addr, c_size);
+    }
+}
+
+const uint8_t *block::data() const { return dec_data.get(); }
+
+uint8_t *block::data() { return dec_data.get(); }
+
+storage_block_reader::storage_block_reader(FILE *file, block_allocator *allocator,
+                                           const compio_compressor *compressor, int max_size)
     : file(file),
       cache(max_size),
-      allocator(allocator) {}
+      allocator(allocator),
+      compressor(compressor) {}
 
 smart_infile_object<storage_block> storage_block_reader::read_block(uint64_t addr) {
     if (!cache.exists(addr)) {

--- a/tests/src/test_allocator.cpp
+++ b/tests/src/test_allocator.cpp
@@ -12,33 +12,24 @@ using namespace compio;
 class BasicAllocatorTest : public ::testing::Test {
 protected:
     char fn[256];
-    FILE *file;
     compio_archive *archive;
     block_allocator *allocator;
+    compio_config config;
 
     void SetUp() override {
         generate_tmp_fn(fn, sizeof(fn));
 
-        file = fopen(fn, "w+");
-        ASSERT_TRUE(file != nullptr);
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+        config.fragmentation_threshold = 30;
+        config.fill_holes_with_zeros = false;
 
-        auto *config = new compio_config();
-        compio_build_default_config(config);
-        config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-        config->fragmentation_threshold = 30;
-        config->fill_holes_with_zeros = false;
-
-        archive = new compio_archive(file, mode_bit::w | mode_bit::r, config);
-        allocator = new block_allocator(archive);
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
     }
 
     void TearDown() override {
-        if (allocator)
-            delete allocator;
-        if (archive)
-            delete archive;
-        if (file)
-            fclose(file);
+        compio_close_archive(archive);
         remove(fn);
     }
 

--- a/tests/src/test_allocator_advanced.cpp
+++ b/tests/src/test_allocator_advanced.cpp
@@ -13,59 +13,29 @@ using namespace compio;
 // Tests for serialization/deserialization functionality
 class SerializationTest : public ::testing::Test {
 protected:
-    char fn1[256], fn2[256];
-    FILE *file1;
-    FILE *file2;
-    compio_archive *archive1;
-    compio_archive *archive2;
+    char fn[256];
+    compio_archive *archive;
     block_allocator *allocator1;
     block_allocator *allocator2;
+    compio_config config;
 
     void SetUp() override {
         // Setup first archive
-        generate_tmp_fn(fn1, sizeof(fn1));
-        file1 = fopen(fn1, "w+");
-        ASSERT_TRUE(file1 != nullptr);
+        generate_tmp_fn(fn, sizeof(fn));
 
-        auto *config1 = new compio_config();
-        compio_build_default_config(config1);
-        config1->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-        config1->fragmentation_threshold = 30;
-        config1->fill_holes_with_zeros = false;
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+        config.fragmentation_threshold = 30;
+        config.fill_holes_with_zeros = false;
 
-        archive1 = new compio_archive(file1, mode_bit::w | mode_bit::r, config1);
-        allocator1 = new block_allocator(archive1);
-
-        // Setup second archive
-        generate_tmp_fn(fn2, sizeof(fn2));
-        file2 = fopen(fn2, "w+");
-        ASSERT_TRUE(file2 != nullptr);
-
-        auto *config2 = new compio_config();
-        compio_build_default_config(config2);
-        config2->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-        config2->fragmentation_threshold = 30;
-        config2->fill_holes_with_zeros = false;
-
-        archive2 = new compio_archive(file2, mode_bit::w | mode_bit::r, config2);
-        allocator2 = new block_allocator(archive2);
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator1 = archive->allocator;
+        allocator2 = new compio::block_allocator(archive);
     }
 
     void TearDown() override {
-        if (allocator1)
-            delete allocator1;
-        if (allocator2)
-            delete allocator2;
-        if (archive1)
-            delete archive1;
-        if (archive2)
-            delete archive2;
-        if (file1)
-            fclose(file1);
-        if (file2)
-            fclose(file2);
-        remove(fn1);
-        remove(fn2);
+        compio_close_archive(archive);
+        remove(fn);
     }
 };
 
@@ -87,9 +57,9 @@ TEST_F(SerializationTest, SaveAndLoadState) {
 
     // Note: Save/Load state functionality may not be fully implemented
     // This test verifies the interface exists and handles calls gracefully
-    bool save_result = allocator1->save_state(archive1);
+    bool save_result = allocator1->save_state(archive);
     if (save_result) {
-        bool load_result = allocator2->load_state(archive1);
+        bool load_result = allocator2->load_state(archive);
         if (load_result) {
             // If both save and load succeeded, verify behavior
             uint64_t test_alloc1 = allocator1->allocate(100);
@@ -110,35 +80,26 @@ TEST_F(SerializationTest, SaveAndLoadState) {
 class ThreadSafetyTest : public ::testing::Test {
 protected:
     char fn[256];
-    FILE *file;
     compio_archive *archive;
     block_allocator *allocator;
     std::atomic<int> successful_allocations{0};
     std::atomic<int> failed_allocations{0};
+    compio_config config;
 
     void SetUp() override {
         generate_tmp_fn(fn, sizeof(fn));
 
-        file = fopen(fn, "w+");
-        ASSERT_TRUE(file != nullptr);
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+        config.fragmentation_threshold = 30;
+        config.fill_holes_with_zeros = false;
 
-        auto *config = new compio_config();
-        compio_build_default_config(config);
-        config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-        config->fragmentation_threshold = 30;
-        config->fill_holes_with_zeros = false;
-
-        archive = new compio_archive(file, mode_bit::w | mode_bit::r, config);
-        allocator = new block_allocator(archive);
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
     }
 
     void TearDown() override {
-        if (allocator)
-            delete allocator;
-        if (archive)
-            delete archive;
-        if (file)
-            fclose(file);
+        compio_close_archive(archive);
         remove(fn);
     }
 };
@@ -200,33 +161,24 @@ TEST_F(ThreadSafetyTest, ConcurrentAllocations) {
 class MemoryLeakTest : public ::testing::Test {
 protected:
     char fn[256];
-    FILE *file;
     compio_archive *archive;
     block_allocator *allocator;
+    compio_config config;
 
     void SetUp() override {
         generate_tmp_fn(fn, sizeof(fn));
 
-        file = fopen(fn, "w+");
-        ASSERT_TRUE(file != nullptr);
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+        config.fragmentation_threshold = 30;
+        config.fill_holes_with_zeros = false;
 
-        auto *config = new compio_config();
-        compio_build_default_config(config);
-        config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-        config->fragmentation_threshold = 30;
-        config->fill_holes_with_zeros = false;
-
-        archive = new compio_archive(file, mode_bit::w | mode_bit::r, config);
-        allocator = new block_allocator(archive);
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
     }
 
     void TearDown() override {
-        if (allocator)
-            delete allocator;
-        if (archive)
-            delete archive;
-        if (file)
-            fclose(file);
+        compio_close_archive(archive);
         remove(fn);
     }
 };
@@ -269,53 +221,37 @@ TEST_F(MemoryLeakTest, MassiveAllocationDeallocationCycle) {
 class FragmentationThresholdTest : public ::testing::Test {
 protected:
     char fn[256];
-    FILE *file = nullptr;
     compio_archive *archive = nullptr;
     block_allocator *allocator = nullptr;
+    compio_config config;
+    
+    void SetUp() override {
+        generate_tmp_fn(fn, sizeof(fn));
+    }
 
     void create_allocator_with_threshold(uint8_t threshold) {
         // Clean up existing resources
-        if (allocator) {
-            delete allocator;
-            allocator = nullptr;
-        }
+        delete_archive_and_allocator();
+
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+        config.fragmentation_threshold = threshold;
+        config.fill_holes_with_zeros = false;
+
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
+    }
+
+    void delete_archive_and_allocator() {
         if (archive) {
-            delete archive;
-            archive = nullptr;
+            compio_close_archive(archive);
         }
-        if (file) {
-            fclose(file);
-            file = nullptr;
-        }
-
-        generate_tmp_fn(fn, sizeof(fn));
-
-        file = fopen(fn, "w+");
-        ASSERT_TRUE(file != nullptr);
-
-        auto *config = new compio_config();
-        compio_build_default_config(config);
-        config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-        config->fragmentation_threshold = threshold;
-        config->fill_holes_with_zeros = false;
-
-        archive = new compio_archive(file, mode_bit::w | mode_bit::r, config);
-        allocator = new block_allocator(archive);
+        allocator = nullptr;
+        archive = nullptr;
     }
 
     void TearDown() override {
-        if (allocator) {
-            delete allocator;
-            allocator = nullptr;
-        }
-        if (archive) {
-            delete archive;
-            archive = nullptr;
-        }
-        if (file) {
-            fclose(file);
-            file = nullptr;
-        }
+        delete_archive_and_allocator();
         remove(fn);
     }
 };

--- a/tests/src/test_allocator_comprehensive.cpp
+++ b/tests/src/test_allocator_comprehensive.cpp
@@ -15,56 +15,39 @@ using namespace compio;
 class ComprehensiveAllocatorTest : public ::testing::Test {
 protected:
     char fn[256];
-    FILE *file;
     compio_archive *archive;
     block_allocator *allocator;
+    compio_config config;
 
     void SetUp() override {
         generate_tmp_fn(fn, sizeof(fn));
 
-        file = fopen(fn, "w+");
-        ASSERT_TRUE(file != nullptr);
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+        config.fragmentation_threshold = 30;
+        config.fill_holes_with_zeros = false;
 
-        auto *config = new compio_config();
-        compio_build_default_config(config);
-        config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-        config->fragmentation_threshold = 30;
-        config->fill_holes_with_zeros = false;
-
-        archive = new compio_archive(file, mode_bit::w | mode_bit::r, config);
-        archive->allocator = allocator = new block_allocator(archive);
-        archive->index = new btree(archive);
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
     }
 
     void TearDown() override {
-        if (archive->index)
-            delete archive->index;
-        if (allocator)
-            delete allocator;
-        if (archive)
-            delete archive;
-        if (file)
-            fclose(file);
+        compio_close_archive(archive);
         remove(fn);
     }
 
     // Helper to create allocator with specific strategy
     void recreate_allocator_with_strategy(compio_allocation_strategy strategy) {
-        if (allocator)
-            delete allocator;
-        if (archive)
-            delete archive;
+        if (archive) {
+            compio_close_archive(archive);
+        }
+        allocator = nullptr;
+        archive = nullptr;
 
-        auto *config = new compio_config();
-        compio_build_default_config(config);
-        config->allocation_strategy = strategy;
-        config->fragmentation_threshold = 30;
-        config->fill_holes_with_zeros = false;
+        config.allocation_strategy = strategy;
 
-        file = freopen(fn, "w+", file);
-        archive = new compio_archive(file, mode_bit::w | mode_bit::r, config);
-        archive->allocator = allocator = new block_allocator(archive);
-        archive->index = new btree(archive);
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
     }
 
     // Helper to verify block allocation

--- a/tests/src/test_allocator_edge_cases.cpp
+++ b/tests/src/test_allocator_edge_cases.cpp
@@ -15,33 +15,24 @@ using namespace compio;
 class BoundaryConditionTest : public ::testing::Test {
 protected:
     char fn[256];
-    FILE *file;
     compio_archive *archive;
     block_allocator *allocator;
+    compio_config config;
 
     void SetUp() override {
         generate_tmp_fn(fn, sizeof(fn));
 
-        file = fopen(fn, "w+");
-        ASSERT_TRUE(file != nullptr);
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+        config.fragmentation_threshold = 30;
+        config.fill_holes_with_zeros = false;
 
-        auto *config = new compio_config();
-        compio_build_default_config(config);
-        config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-        config->fragmentation_threshold = 30;
-        config->fill_holes_with_zeros = false;
-
-        archive = new compio_archive(file, mode_bit::w | mode_bit::r, config);
-        allocator = new block_allocator(archive);
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
     }
 
     void TearDown() override {
-        if (allocator)
-            delete allocator;
-        if (archive)
-            delete archive;
-        if (file)
-            fclose(file);
+        compio_close_archive(archive);
         remove(fn);
     }
 };
@@ -49,8 +40,8 @@ protected:
 TEST_F(BoundaryConditionTest, AllocationAtFileStart) {
     // Test allocation immediately after header
     uint64_t offset = allocator->allocate(100);
-    EXPECT_GE(offset, sizeof(header)) << "Allocation should be after header";
-    EXPECT_LT(offset, sizeof(header) + 1000) << "First allocation should be near start";
+    EXPECT_EQ(offset, sizeof(header) + INDEX_NODE_SIZE(config.b_tree_degree))
+        << "First allocation should be right after header and btree root node";
 }
 
 TEST_F(BoundaryConditionTest, ExactFitAllocation) {
@@ -110,33 +101,24 @@ TEST_F(BoundaryConditionTest, MinimumSizeAllocation) {
 class RobustnessTest : public ::testing::Test {
 protected:
     char fn[256];
-    FILE *file;
     compio_archive *archive;
     block_allocator *allocator;
+    compio_config config;
 
     void SetUp() override {
         generate_tmp_fn(fn, sizeof(fn));
 
-        file = fopen(fn, "w+");
-        ASSERT_TRUE(file != nullptr);
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+        config.fragmentation_threshold = 30;
+        config.fill_holes_with_zeros = false;
 
-        auto *config = new compio_config();
-        compio_build_default_config(config);
-        config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-        config->fragmentation_threshold = 30;
-        config->fill_holes_with_zeros = false;
-
-        archive = new compio_archive(file, mode_bit::w | mode_bit::r, config);
-        allocator = new block_allocator(archive);
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
     }
 
     void TearDown() override {
-        if (allocator)
-            delete allocator;
-        if (archive)
-            delete archive;
-        if (file)
-            fclose(file);
+        compio_close_archive(archive);
         remove(fn);
     }
 };
@@ -224,33 +206,24 @@ TEST_F(RobustnessTest, AlternatingLargeSmallAllocations) {
 class AllocationPatternTest : public ::testing::Test {
 protected:
     char fn[256];
-    FILE *file;
     compio_archive *archive;
     block_allocator *allocator;
+    compio_config config;
 
     void SetUp() override {
         generate_tmp_fn(fn, sizeof(fn));
 
-        file = fopen(fn, "w+");
-        ASSERT_TRUE(file != nullptr);
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+        config.fragmentation_threshold = 30;
+        config.fill_holes_with_zeros = false;
 
-        auto *config = new compio_config();
-        compio_build_default_config(config);
-        config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-        config->fragmentation_threshold = 30;
-        config->fill_holes_with_zeros = false;
-
-        archive = new compio_archive(file, mode_bit::w | mode_bit::r, config);
-        allocator = new block_allocator(archive);
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
     }
 
     void TearDown() override {
-        if (allocator)
-            delete allocator;
-        if (archive)
-            delete archive;
-        if (file)
-            fclose(file);
+        compio_close_archive(archive);
         remove(fn);
     }
 };
@@ -311,33 +284,24 @@ TEST_F(AllocationPatternTest, FibonacciSizeSequence) {
 class RealWorldPatternTest : public ::testing::Test {
 protected:
     char fn[256];
-    FILE *file;
     compio_archive *archive;
     block_allocator *allocator;
+    compio_config config;
 
     void SetUp() override {
         generate_tmp_fn(fn, sizeof(fn));
 
-        file = fopen(fn, "w+");
-        ASSERT_TRUE(file != nullptr);
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+        config.fragmentation_threshold = 30;
+        config.fill_holes_with_zeros = false;
 
-        auto *config = new compio_config();
-        compio_build_default_config(config);
-        config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-        config->fragmentation_threshold = 30;
-        config->fill_holes_with_zeros = false;
-
-        archive = new compio_archive(file, mode_bit::w | mode_bit::r, config);
-        allocator = new block_allocator(archive);
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
     }
 
     void TearDown() override {
-        if (allocator)
-            delete allocator;
-        if (archive)
-            delete archive;
-        if (file)
-            fclose(file);
+        compio_close_archive(archive);
         remove(fn);
     }
 };
@@ -424,36 +388,24 @@ TEST_F(RealWorldPatternTest, LogFilePattern) {
 class EfficiencyTest : public ::testing::Test {
 protected:
     char fn[256];
-    FILE *file;
     compio_archive *archive;
     block_allocator *allocator;
+    compio_config config;
 
     void SetUp() override {
         generate_tmp_fn(fn, sizeof(fn));
 
-        file = fopen(fn, "w+");
-        ASSERT_TRUE(file != nullptr);
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+        config.fragmentation_threshold = 30;
+        config.fill_holes_with_zeros = false;
 
-        auto *config = new compio_config();
-        compio_build_default_config(config);
-        config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-        config->fragmentation_threshold = 30;
-        config->fill_holes_with_zeros = false;
-
-        archive = new compio_archive(file, mode_bit::w | mode_bit::r, config);
-        archive->allocator = allocator = new block_allocator(archive);
-        archive->index = new btree(archive);
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
     }
 
     void TearDown() override {
-        if (archive->index)
-            delete archive->index;
-        if (allocator)
-            delete allocator;
-        if (archive)
-            delete archive;
-        if (file)
-            fclose(file);
+        compio_close_archive(archive);
         remove(fn);
     }
 };
@@ -522,36 +474,24 @@ TEST_F(EfficiencyTest, FragmentationMeasurement) {
 class IntegrationTest : public ::testing::Test {
 protected:
     char fn[256];
-    FILE *file;
     compio_archive *archive;
     block_allocator *allocator;
+    compio_config config;
 
     void SetUp() override {
         generate_tmp_fn(fn, sizeof(fn));
 
-        file = fopen(fn, "w+");
-        ASSERT_TRUE(file != nullptr);
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_BEST_FIT;
+        config.fragmentation_threshold = 25;
+        config.fill_holes_with_zeros = true;
 
-        auto *config = new compio_config();
-        compio_build_default_config(config);
-        config->allocation_strategy = COMPIO_ALLOC_BEST_FIT;
-        config->fragmentation_threshold = 25;
-        config->fill_holes_with_zeros = true;
-
-        archive = new compio_archive(file, mode_bit::w | mode_bit::r, config);
-        archive->allocator = allocator = new block_allocator(archive);
-        archive->index = new btree(archive);
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
     }
 
     void TearDown() override {
-        if (archive->index)
-            delete archive->index;
-        if (allocator)
-            delete allocator;
-        if (archive)
-            delete archive;
-        if (file)
-            fclose(file);
+        compio_close_archive(archive);
         remove(fn);
     }
 };

--- a/tests/src/test_allocator_serialization.cpp
+++ b/tests/src/test_allocator_serialization.cpp
@@ -12,25 +12,14 @@ using namespace compio;
 class AllocatorStateTest : public ::testing::Test {
 protected:
     char fn1[256], fn2[256];
-    FILE *file1;
-    FILE *file2;
 
     void SetUp() override {
         // Create two temporary files
         generate_tmp_fn(fn1, sizeof(fn1));
         generate_tmp_fn(fn2, sizeof(fn2));
-
-        file1 = fopen(fn1, "w+");
-        file2 = fopen(fn2, "w+");
-        ASSERT_TRUE(file1 != nullptr);
-        ASSERT_TRUE(file2 != nullptr);
     }
 
     void TearDown() override {
-        if (file1)
-            fclose(file1);
-        if (file2)
-            fclose(file2);
         remove(fn1);
         remove(fn2);
     }
@@ -38,14 +27,14 @@ protected:
 
 TEST_F(AllocatorStateTest, SaveAndLoadState) {
     // Create allocator and archive
-    auto *config = new compio_config();
-    compio_build_default_config(config);
-    config->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
-    config->fragmentation_threshold = 30;
-    config->fill_holes_with_zeros = false;
+    compio_config config;
+    compio_build_default_config(&config);
+    config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+    config.fragmentation_threshold = 30;
+    config.fill_holes_with_zeros = false;
 
-    auto *archive = new compio_archive(file1, mode_bit::w | mode_bit::r, config);
-    auto *allocator = new block_allocator(archive);
+    auto *archive = compio_open_archive(fn1, "w+", &config);
+    auto *allocator = archive->allocator;
 
     // Create state with free blocks
     uint64_t offset1 = allocator->allocate(100);
@@ -64,16 +53,11 @@ TEST_F(AllocatorStateTest, SaveAndLoadState) {
     EXPECT_TRUE(save_success) << "Should be able to save allocator state";
 
     // Close allocator and archive
-    delete allocator;
-    delete archive;
-
-    // Reopen file in read mode
-    file1 = freopen(fn1, "r+", file1);
-    ASSERT_TRUE(file1 != nullptr);
+    compio_close_archive(archive);
 
     // Create new archive in read mode - should load header
-    auto *new_archive = new compio_archive(file1, mode_bit::r, config);
-    auto *new_allocator = new block_allocator(new_archive);
+    auto *new_archive = compio_open_archive(fn1, "r", &config);
+    auto *new_allocator = new_archive->allocator;
 
     // Try to load state
     bool load_success = new_allocator->load_state(new_archive);
@@ -90,6 +74,5 @@ TEST_F(AllocatorStateTest, SaveAndLoadState) {
         EXPECT_NE(test_offset, UINT64_MAX) << "Allocator should work even without state loading";
     }
 
-    delete new_allocator;
-    delete new_archive;
+    compio_close_archive(new_archive);
 }


### PR DESCRIPTION
Сделал то, что понял, что надо будет сделать еще в конце прошлого семестра. До этого так как реализовывал кэши один за другим, получилось 2 кэша для блоков (кэш для сжатых блоков, и кэш для маппинга сжатый-расжатый блок), что очень не эффективно, потому что даже для блока, который в кэше, мы его сжимали лишний раз при каждом compio_write (мы только экономили на операциях расжатия при compio_read)

Теперь же структура кэша оптимальна: 
1. читаем блок из файла, распаковываем один раз и в кэше храним расжатую версию 
2. пока блок в кэше, меняем только расжатую версию в кэше, не обращаясь к файлу 
3. когда блок вылетает из кэша, один раз его сжимаем и отправляем в файл

Это сильно увеличивает производительность, потому что лишний раз не сжимаем данные. Пока не запускал бенчмарки, это уже потом

Из не относящегося к этому, в 9bee34abb54da4b5ec663ce086ea54730cf987cd поменял инициализацию тестов аллокатора, сделав так, чтобы там архив и аллокатор создавались только через compio_open_archive, потому что вообще конструктор compio_archive лучше не вызывать откуда-либо снаружи, ибо он не инициализирует все поля (потому что там иначе возникает циклическая зависимость с аллокатором, так как он зависит от архива, а архив зависит от б-дерева, которое зависит от аллокатора). Я это сделал конкретно сейчас, потому что я менял конструктор у одного поля в compio_archive, и мне пришлось бы во всех тестах так же менять конструктор, а это делать не хочется при каждом изменении. Просто небольшой рефактор, тесты всё так же проходят (из-за этого назначил @dkorbelainen ревьюером, чтобы видел, что я поменял в твоих тестах)