### PR TITLE
fix: fix tests on windows

### DIFF
--- a/include/compio/allocator.hpp
+++ b/include/compio/allocator.hpp
@@ -63,7 +63,7 @@ public:
      * @brief Initialize manager with storage parameters
      * @param file_size Pointer to total file size reference
      */
-    explicit free_blocks_manager(uint64_t *file_size);
+    explicit free_blocks_manager(const uint64_t *file_size);
 
     /**
      * @brief Add new free block to the storage
@@ -125,7 +125,7 @@ public:
      * @brief Get pointer to file size reference
      * @return Raw pointer to managed file size
      */
-    uint64_t *get_file_size_ptr() const { return file_size_; }
+    const uint64_t *get_file_size_ptr() const { return file_size_; }
 
     /**
      * @brief Serialize manager state to buffer
@@ -213,7 +213,7 @@ private:
     free_block *tail_;                           /**< Tail of free blocks list */
     free_block *last_alloc_;                     /**< Last allocation position for NEXT_FIT */
     uint64_t total_free_;                        /**< Total free space in bytes */
-    uint64_t *file_size_;                        /**< Reference to total file size */
+    const uint64_t *file_size_;                        /**< Reference to total file size */
     uint8_t cached_fragmentation_;               /**< Cached fragmentation level */
     mutable bool recently_defragmented_ = false; /**< Flag for recent defragmentation */
 

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -449,6 +449,7 @@ bool free_blocks_manager::save_to_file(compio_archive *archive) {
     // Get current file position
     long pos = ftell(archive->file);
     if (pos < 0) {
+        WARNING_PRINT("warning: ftell returned error in allocator.save_state\n");
         return false;
     }
 
@@ -456,13 +457,18 @@ bool free_blocks_manager::save_to_file(compio_archive *archive) {
     if (pos < static_cast<long>(sizeof(header))) {
         pos = sizeof(header);
         if (fseek(archive->file, pos, SEEK_SET) != 0) {
+            WARNING_PRINT("warning: fseek returned error in allocator.save_state\n");
             return false;
         }
     }
 
     // Write serialized data
+    DEBUG_PRINT("[W][allocator]addr=%lu;size=%lu\n", pos, size);
     size_t written = fwrite(buffer.data(), 1, size, archive->file);
     if (written != size) {
+        WARNING_PRINT(
+            "warning: fwrite failed to write all bytes in allocator.save_state (%lu < %lu)\n",
+            written, size);
         return false;
     }
 
@@ -633,6 +639,7 @@ void block_allocator::deallocate(uint64_t offset, uint64_t size) {
         static constexpr size_t BUFFER_SIZE = 4096;
         static uint8_t zeros[BUFFER_SIZE] = {0};
 
+        DEBUG_PRINT("[W][deallocate]addr=%lu;size=%lu\n", offset, size);
         fseek(archive_->file, offset, SEEK_SET);
 
         size_t remaining = size;

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -476,9 +476,6 @@ bool free_blocks_manager::save_to_file(compio_archive *archive) {
     archive->header->allocator_state_offset = static_cast<uint64_t>(pos);
     archive->header->allocator_state_size = size;
 
-    // Explicitly write header to disk to ensure it's saved
-    readonly(archive->header, header)->write_to(archive->file, 0);
-
     // Ensure data is written to disk
     fflush(archive->file);
 

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -23,7 +23,7 @@ struct free_block;
 
 uint8_t ZEROS[4096] = {0};
 
-free_blocks_manager::free_blocks_manager(uint64_t *file_size)
+free_blocks_manager::free_blocks_manager(const uint64_t *file_size)
     : head_(nullptr),
       tail_(nullptr),
       last_alloc_(nullptr),
@@ -473,12 +473,11 @@ bool free_blocks_manager::save_to_file(compio_archive *archive) {
     }
 
     // Update header with allocator state location
-    // Use ptr() to mark header as modified so it gets written to disk
-    archive->header.ptr()->allocator_state_offset = static_cast<uint64_t>(pos);
-    archive->header.ptr()->allocator_state_size = size;
+    archive->header->allocator_state_offset = static_cast<uint64_t>(pos);
+    archive->header->allocator_state_size = size;
 
     // Explicitly write header to disk to ensure it's saved
-    archive->header->write_to(archive->file, 0);
+    readonly(archive->header, header)->write_to(archive->file, 0);
 
     // Ensure data is written to disk
     fflush(archive->file);
@@ -487,28 +486,30 @@ bool free_blocks_manager::save_to_file(compio_archive *archive) {
 }
 
 bool free_blocks_manager::load_from_file(compio_archive *archive) {
-    if (!archive || !archive->file || !archive->header) {
+    if (!archive || !archive->file || !readonly(archive->header, header)) {
         return false;
     }
 
     // Check if allocator state exists
-    if (archive->header->allocator_state_offset == 0 ||
-        archive->header->allocator_state_size == 0) {
+    if (readonly(archive->header, header)->allocator_state_offset == 0 ||
+        readonly(archive->header, header)->allocator_state_size == 0) {
         return false;
     }
 
     // Seek to allocator state position
-    if (fseek(archive->file, static_cast<long>(archive->header->allocator_state_offset),
+    if (fseek(archive->file,
+              static_cast<long>(readonly(archive->header, header)->allocator_state_offset),
               SEEK_SET) != 0) {
         return false;
     }
 
     // Create buffer for reading data
-    std::vector<uint8_t> buffer(archive->header->allocator_state_size);
+    std::vector<uint8_t> buffer(readonly(archive->header, header)->allocator_state_size);
 
     // Read allocator state data
-    size_t read = fread(buffer.data(), 1, archive->header->allocator_state_size, archive->file);
-    if (read != archive->header->allocator_state_size) {
+    size_t read = fread(buffer.data(), 1, readonly(archive->header, header)->allocator_state_size,
+                        archive->file);
+    if (read != readonly(archive->header, header)->allocator_state_size) {
         return false;
     }
 
@@ -559,12 +560,12 @@ free_block *free_blocks_manager::find_next_fit(const uint64_t size) const {
 
 block_allocator::block_allocator(compio_archive *archive)
     : archive_(archive),
-      blocks_manager_(&archive->header->file_size),
+      blocks_manager_(&readonly(archive->header, header)->file_size),
       last_fragmentation_(0) {
     if (!archive_) {
         throw std::runtime_error("Archive pointer is null");
     }
-    if (!archive_->header) {
+    if (!readonly(archive_->header, header)) {
         throw std::runtime_error("Archive header is null");
     }
 
@@ -573,7 +574,7 @@ block_allocator::block_allocator(compio_archive *archive)
     // and will be set properly when save_state() is called
 
     // Ensure we have valid initial file size
-    if (archive_->header->file_size < sizeof(header)) {
+    if (readonly(archive_->header, header)->file_size < sizeof(header)) {
         archive_->header->file_size = sizeof(header);
     }
 }
@@ -611,7 +612,7 @@ uint64_t block_allocator::allocate(uint64_t size) {
         }
 
         // If no suitable free block found, allocate at the end
-        offset = archive_->header->file_size;
+        offset = readonly(archive_->header, header)->file_size;
         archive_->header->file_size += size;
         return offset;
     } catch (const std::exception &e) {
@@ -621,11 +622,11 @@ uint64_t block_allocator::allocate(uint64_t size) {
 }
 
 void block_allocator::deallocate(uint64_t offset, uint64_t size) {
-    if (offset == UINT64_MAX || size == 0 || !archive_ || !archive_->header) {
+    if (offset == UINT64_MAX || size == 0 || !archive_ || !readonly(archive_->header, header)) {
         return;
     }
 
-    if (offset + size > archive_->header->file_size) {
+    if (offset + size > readonly(archive_->header, header)->file_size) {
         return;
     }
 
@@ -772,10 +773,10 @@ void block_allocator::perform_defragmentation() {
     fflush(archive_->file);
 
     blocks_manager_ =
-        free_blocks_manager(archive_->header->file_size ? &archive_->header->file_size : nullptr);
+        free_blocks_manager(readonly(archive_->header, header)->file_size ? &readonly(archive_->header, header)->file_size : nullptr);
 
-    if (new_offset < archive_->header->file_size) {
-        blocks_manager_.add_free_block(new_offset, archive_->header->file_size - new_offset);
+    if (new_offset < readonly(archive_->header, header)->file_size) {
+        blocks_manager_.add_free_block(new_offset, readonly(archive_->header, header)->file_size - new_offset);
     } else {
         archive_->header->file_size = new_offset;
     }

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -483,7 +483,7 @@ bool free_blocks_manager::save_to_file(compio_archive *archive) {
 }
 
 bool free_blocks_manager::load_from_file(compio_archive *archive) {
-    if (!archive || !archive->file || !readonly(archive->header, header)) {
+    if (!archive || !archive->file || !archive->header) {
         return false;
     }
 
@@ -562,7 +562,7 @@ block_allocator::block_allocator(compio_archive *archive)
     if (!archive_) {
         throw std::runtime_error("Archive pointer is null");
     }
-    if (!readonly(archive_->header, header)) {
+    if (!archive_->header) {
         throw std::runtime_error("Archive header is null");
     }
 
@@ -619,7 +619,7 @@ uint64_t block_allocator::allocate(uint64_t size) {
 }
 
 void block_allocator::deallocate(uint64_t offset, uint64_t size) {
-    if (offset == UINT64_MAX || size == 0 || !archive_ || !readonly(archive_->header, header)) {
+    if (offset == UINT64_MAX || size == 0 || !archive_ || !archive_->header) {
         return;
     }
 

--- a/src/btree.cpp
+++ b/src/btree.cpp
@@ -272,7 +272,6 @@ void btree::remove_node(shared_node &node, const tree_key &key) {
     } else {
         if (RO(node)->is_leaf)
             return;
-        const bool flag = (idx == RO(node)->num_keys);
         auto child = read_node(RO(node)->children[idx]);
         if (RO(child)->num_keys < degree) {
             // Check if we can borrow from predecessor (only if idx > 0)

--- a/src/btree.cpp
+++ b/src/btree.cpp
@@ -305,6 +305,7 @@ void btree::remove_node(shared_node &node, const tree_key &key) {
             } else {
                 // idx == 0 and idx == num_keys means this is the only child
                 // This shouldn't happen in a valid B-tree, but handle gracefully
+                WARNING_PRINT("warning: trying to remove key from empty node in b-tree::remove_node\n");
                 return;
             }
         }

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -74,10 +74,13 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
     // if w+ passed as mode, we have to clear file contents (using w+)
     // otherwise we open with a+ mode to read and write
     const char *archive_open_mode;
-    if (mode_b & mode_bit::w)
+    if (mode_b & mode_bit::w) {
         archive_open_mode = "w+";
-    else
+    } else if (mode_b & mode_bit::a) {
         archive_open_mode = "a+";
+    } else {
+        archive_open_mode = "r";
+    }
 
     FILE *file;
     file = fopen(fp, archive_open_mode);
@@ -311,6 +314,12 @@ uint64_t compio_tell(compio_file *file) { return file->cursor; }
 
 uint64_t compio_write(const void *ptr, uint64_t size, compio_file *file) {
     DEBUG_PRINT("\ncompio_write(cursor=%lu, size=%lu)\n", file->cursor, size);
+
+    if (file->archive->mode_b & mode_bit::r) {
+        WARNING_PRINT("warning: can't compio_write to read-only file\n");
+        errno = EROFS;
+        return 0;
+    }
 
     if (size == 0) {
         return 0;

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -75,11 +75,11 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
     // otherwise we open with a+ mode to read and write
     const char *archive_open_mode;
     if (mode_b & mode_bit::w) {
-        archive_open_mode = "w+";
+        archive_open_mode = "wb+";
     } else if (mode_b & mode_bit::a) {
-        archive_open_mode = "a+";
+        archive_open_mode = "ab+";
     } else {
-        archive_open_mode = "r";
+        archive_open_mode = "rb";
     }
 
     FILE *file;

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -96,7 +96,7 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
     is_new_file = is_file_empty(file);
     if (is_new_file) {
         archive->header->compression_type = c->compressor.compression_type;
-    } else if (archive->header->compression_type != c->compressor.compression_type) {
+    } else if (readonly(archive->header, header)->compression_type != c->compressor.compression_type) {
         // compression type mismatch
         errno = EINVAL;
         WARNING_PRINT("warning: compression type mismatch while opening archive\n");
@@ -151,10 +151,9 @@ compio_file *compio_open_file(const char *name, compio_archive *archive) {
         return NULL;
     }
 
-    auto file_table_item = readonly(archive->header, compio::header)->ftable.find(name);
+    auto file_table_item = readonly(archive->header, header)->ftable.find(name);
     if (file_table_item == nullptr) {
-        // if mode != "r"
-        if (!((archive->mode_b & mode_bit::r) && (!(archive->mode_b & mode_bit::plus)))) {
+        if (!(archive->mode_b & mode_bit::r)) {
             file_table_item = archive->header->ftable.add(name);
             if (file_table_item == NULL) {
                 errno = ENFILE;
@@ -255,8 +254,8 @@ int compio_close_archive(compio_archive *archive) {
     compio_flush(archive);
     delete archive->block_reader;
 
-    // 2) save allocator state to the end of the file
-    if (archive->allocator) {
+    // 2) save allocator state to the end of the file, if not read-only mode
+    if (!(archive->mode_b & mode_bit::r) && archive->allocator) {
         if (!archive->allocator->save_state(archive)) {
             WARNING_PRINT("warning: failed to save allocator state\n");
             return -3;
@@ -403,7 +402,7 @@ uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
     const auto archive = file->archive;
     const auto config = archive->config;
 
-    auto file_table_item = archive->header->ftable.find(file->name);
+    auto file_table_item = readonly(archive->header, header)->ftable.find(file->name);
     const uint64_t fsize = file_table_item->size;
     const uint64_t block_size = config->block_size;
     const uint64_t cursor = file->cursor;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -39,7 +39,7 @@ void header::read_from(FILE *file, uint64_t addr) {
 }
 
 void header::write_to(FILE *file, uint64_t addr) const {
-    DEBUG_PRINT("[W][header]addr=%lu\n", addr);
+    DEBUG_PRINT("[W][header]addr=%lu;size=%lu\n", addr, sizeof(header));
     if (fseek(file, addr, SEEK_SET))
         DEBUG_PRINT("warning: fseek failed\n");
     lendian_fwrite_member(magic_number, file);
@@ -76,7 +76,7 @@ void index_node::read_from(FILE *file, uint64_t addr) {
 }
 
 void index_node::write_to(FILE *file, uint64_t addr) const {
-    DEBUG_PRINT("[W][index_node]addr=%lu\n", addr);
+    DEBUG_PRINT("[W][index_node]addr=%lu;size=%lu\n", addr, INDEX_NODE_SIZE(tree_degree));
     if (fseek(file, addr, SEEK_SET))
         DEBUG_PRINT("warning: fseek failed\n");
     lendian_fwrite_member(is_leaf, file);
@@ -106,7 +106,7 @@ void storage_block::read_from(FILE *file, uint64_t addr) {
 }
 
 void storage_block::write_to(FILE *file, uint64_t addr) const {
-    DEBUG_PRINT("[W][storage_block]addr=%lu\n", addr);
+    DEBUG_PRINT("[W][storage_block]addr=%lu;size=%lu\n", addr, STORAGE_BLOCK_METASIZE + size);
     if (fseek(file, addr, SEEK_SET))
         DEBUG_PRINT("warning: fseek failed\n");
     lendian_fwrite_member(is_compressed, file);

--- a/src/infile_object.cpp
+++ b/src/infile_object.cpp
@@ -60,6 +60,10 @@ uint64_t lendian_fwrite(const void *ptr, uint64_t size, uint64_t nmemb, FILE *st
                       "(expected: %lu bytes, actual: %lu bytes)\n",
                       size * nmemb, ret * size);
     }
+
+    if (ferror(stream)) {
+        WARNING_PRINT("warning: ferror returned non-zero in lendian_fwrite\n");
+    }
 #ifdef COMPIO_BENCHMARK_FILE_OPERATIONS_COUNTER
     n_written_bytes += ret;
 #endif
@@ -99,6 +103,10 @@ uint64_t lendian_fread(void *ptr, uint64_t size, uint64_t nmemb, FILE *stream) {
         WARNING_PRINT("warning: failed to fread bytes from file "
                       "(expected: %lu bytes, actual: %lu bytes)\n",
                       size * nmemb, ret * size);
+    }
+
+    if (ferror(stream)) {
+        WARNING_PRINT("warning: ferror returned non-zero in lendian_fread\n");
     }
 #ifdef COMPIO_BENCHMARK_FILE_OPERATIONS_COUNTER
     n_read_bytes += ret;

--- a/src/infile_object.cpp
+++ b/src/infile_object.cpp
@@ -47,7 +47,7 @@ uint64_t lendian_fwrite(const void *ptr, uint64_t size, uint64_t nmemb, FILE *st
                 buffer[8 * i + 7] = input[4 * i];
             }
         } else {
-            throw std::invalid_argument("lendian_fwrite possible size values are 1, 2, 4, 8");
+            WARNING_PRINT("warning: lendian_fwrite possible size values are 1, 2, 4, 8 (%lu was passed)\n", size);
         }
         ret = fwrite((void *)buffer, size, nmemb, stream);
         delete buffer;
@@ -93,7 +93,7 @@ uint64_t lendian_fread(void *ptr, uint64_t size, uint64_t nmemb, FILE *stream) {
                     std::swap(output[8 * i + 3], output[8 * i + 4]);
                 }
             } else {
-                throw std::invalid_argument("lendian_fread possible size values are 1, 2, 4, 8");
+                WARNING_PRINT("warning: lendian_fread possible size values are 1, 2, 4, 8 (%lu was passed)\n", size);
             }
         }
     } else {

--- a/src/infile_object.cpp
+++ b/src/infile_object.cpp
@@ -74,27 +74,28 @@ uint64_t lendian_fread(void *ptr, uint64_t size, uint64_t nmemb, FILE *stream) {
     uint64_t ret;
     if (is_big_endian() && size != sizeof(uint8_t)) {
         ret = fread(ptr, size, nmemb, stream);
-        unsigned char *output = static_cast<unsigned char *>(ptr);
-        if (size == sizeof(uint16_t)) {
-            for (uint32_t i = 0; i < nmemb; i++) {
-                std::swap(output[2 * i], output[2 * i + 1]);
+        if (ret == nmemb) {
+            unsigned char *output = static_cast<unsigned char *>(ptr);
+            if (size == sizeof(uint16_t)) {
+                for (uint32_t i = 0; i < nmemb; i++) {
+                    std::swap(output[2 * i], output[2 * i + 1]);
+                }
+            } else if (size == sizeof(uint32_t)) {
+                for (uint32_t i = 0; i < nmemb; i++) {
+                    std::swap(output[4 * i], output[4 * i + 3]);
+                    std::swap(output[4 * i + 1], output[4 * i + 2]);
+                }
+            } else if (size == sizeof(uint64_t)) {
+                for (uint32_t i = 0; i < nmemb; i++) {
+                    std::swap(output[8 * i], output[8 * i + 7]);
+                    std::swap(output[8 * i + 1], output[8 * i + 6]);
+                    std::swap(output[8 * i + 2], output[8 * i + 5]);
+                    std::swap(output[8 * i + 3], output[8 * i + 4]);
+                }
+            } else {
+                throw std::invalid_argument("lendian_fread possible size values are 1, 2, 4, 8");
             }
-        } else if (size == sizeof(uint32_t)) {
-            for (uint32_t i = 0; i < nmemb; i++) {
-                std::swap(output[4 * i], output[4 * i + 3]);
-                std::swap(output[4 * i + 1], output[4 * i + 2]);
-            }
-        } else if (size == sizeof(uint64_t)) {
-            for (uint32_t i = 0; i < nmemb; i++) {
-                std::swap(output[8 * i], output[8 * i + 7]);
-                std::swap(output[8 * i + 1], output[8 * i + 6]);
-                std::swap(output[8 * i + 2], output[8 * i + 5]);
-                std::swap(output[8 * i + 3], output[8 * i + 4]);
-            }
-        } else {
-            throw std::invalid_argument("lendian_fread possible size values are 1, 2, 4, 8");
         }
-        return ret;
     } else {
         ret = fread(ptr, size, nmemb, stream);
     }

--- a/src/infile_object.cpp
+++ b/src/infile_object.cpp
@@ -95,8 +95,7 @@ uint64_t lendian_fread(void *ptr, uint64_t size, uint64_t nmemb, FILE *stream) {
         ret = fread(ptr, size, nmemb, stream);
     }
 
-    if (ret != nmemb && !feof(stream)) {
-        // Only warn if it's an actual error, not just EOF
+    if (ret != nmemb) {
         WARNING_PRINT("warning: failed to fread bytes from file "
                       "(expected: %lu bytes, actual: %lu bytes)\n",
                       size * nmemb, ret * size);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(compio_gtest
     src/test_allocator_edge_cases.cpp
     src/test_allocator_serialization.cpp
     src/test_compression_type.cpp
+    src/test_compressor.cpp
     src/test_library.cpp
     src/test_file_removal.cpp
 )

--- a/tests/src/test_compressor.cpp
+++ b/tests/src/test_compressor.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+#include <tuple>
+#include <vector>
+
+#include "compio.h"
+
+#include "sample_data.hpp"
+
+class CompressorTest
+    : public ::testing::TestWithParam<std::tuple<compio_compression_type, uint64_t, uint64_t>> {};
+
+TEST_P(CompressorTest, RoundTripTest) {
+    auto [compression_type, src_size, zeroes_percentage] = GetParam();
+    compio_compressor compressor;
+    compio_build_compressor_by_type(&compressor, compression_type);
+
+    std::vector<char> dec_data(src_size, 0);
+    std::copy_n(std::begin(html_data), src_size / zeroes_percentage, dec_data.begin());
+
+    uint64_t buffer_size = compressor.get_bufsize(src_size);
+    std::vector<char> c_buffer(buffer_size);
+
+    int ret = compressor.compress(c_buffer.data(), &buffer_size, dec_data.data(), src_size);
+    ASSERT_EQ(ret, 0);
+
+    std::vector<char> dec_buffer(src_size);
+    ret = compressor.decompress(dec_buffer.data(), &src_size, c_buffer.data(), buffer_size);
+    ASSERT_EQ(ret, 0);
+
+    for (std::size_t i = 0; i < src_size; ++i) {
+        ASSERT_EQ(dec_data[i], dec_buffer[i]);
+    }
+}
+
+INSTANTIATE_TEST_CASE_P(
+    CompressorTests, CompressorTest,
+    ::testing::Combine(::testing::Values(compio_compression_type::COMPIO_COMPRESS_ZLIB,
+                                         compio_compression_type::COMPIO_COMPRESS_LZ4,
+                                         compio_compression_type::COMPIO_COMPRESS_ZSTD,
+                                         compio_compression_type::COMPIO_COMPRESS_BROTLI),
+                       ::testing::Values(128, 4096, sizeof(html_data)),
+                       ::testing::Values(1, 2, 100, 10000000)));

--- a/tests/src/test_file_removal.cpp
+++ b/tests/src/test_file_removal.cpp
@@ -2,6 +2,7 @@
 #include "compio.h"
 #include "compio/allocator.hpp"
 #include "compio/compio_file.hpp"
+#include "compio/debug_print.hpp"
 #include <cstdio>
 #include <cstring>
 
@@ -27,6 +28,7 @@ TEST_F(FileRemovalTest, RemoveFileFreesBlocks) {
 
     // Get initial allocator state
     uint8_t initial_fragmentation = archive->allocator->get_fragmentation();
+    UNUSED(initial_fragmentation);
 
     // Create file and write some data
     compio_file* file = compio_open_file("test.txt", archive);


### PR DESCRIPTION
1. Пока искал баг, добавил побольше warning и debug печати
2. Так же добавил тесты на то, что все компрессоры правильно сжимают и расжимают данные (сначала думал, что в этом проблема, но оказалось нет, но тесты все равно оставлю, раз написал)
3. Запретил вызывать compio_write у архива с режимом открытия "r"
4. Убрал лишнюю запись хедера в файл в allocator.save_state (он точно записывается в файл после этого, если вызывается compio_close_archive)
5. Добавил макрос readonly к хедеру во всех местах, где он не изменяется, чтобы хедер не записывался лишний раз
6. **Основной фикс**: добавил букву b к режиму открытия файла (забыл, что на windows без него все \n будут заменятся на \r\n, и из-за этого когда мы писали сжатые данные в файл, то если там случайно попадался символ \n, то получался некорректный блок, и компрессор не мог распаковать файл) 

Теперь тесты и на windows и на linux проходят