### PR TITLE
feat & docs: middle deletion logic in fragmentation benchmark, documentation

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,123 @@
+# Compio Benchmarks
+
+Comprehensive benchmark suite for testing Compio library performance and fragmentation characteristics.
+
+## Available Benchmarks
+
+### 1. **Main Performance Benchmarks** (`compio_benchmarks`)
+Google Benchmark-based performance tests for core operations.
+
+**What it tests:**
+- Consecutive read/write performance
+- Random read/write performance
+- Allocator performance across different strategies
+
+**Run:**
+```bash
+cd build/benchmarks
+./compio_benchmarks
+```
+
+### 2. **Fragmentation Benchmark** (`fragmentation_benchmark`)
+Advanced parametric grid testing for memory fragmentation under realistic workloads.
+
+**What it tests:**
+- 4 allocation strategies (FIRST_FIT, BEST_FIT, WORST_FIT, NEXT_FIT)
+- 6 block sizes (512B - 16KB)
+- 5 compression ratios (10% - 90% compressible data)
+- 6 deletion patterns (aggressive small/large/mixed, random/middle)
+- **Total: 720 test configurations**
+
+**Key metrics:**
+- Overhead percentage (wasted space)
+- Fragmentation level (0-100)
+- Free region count
+- Files created/deleted/rewritten
+
+**Run:**
+```bash
+cd build/benchmarks
+./fragmentation_benchmark                    # default: fragmentation_results.*
+./fragmentation_benchmark my_test            # custom: my_test.csv, my_test_report.txt
+```
+
+**Output:**
+- `fragmentation_results.csv` - detailed data for all 720 tests
+- `fragmentation_results_report.txt` - human-readable summary with rankings
+
+**Key findings:**
+- **BEST_FIT** shows lowest fragmentation
+
+- **Deletion pattern matters**: Random deletion creates more fragmentation
+- **Optimal block size**: 4-8 KB gives best balance
+
+### 3. **File Size Benchmark** (`fsize_benchmark`)
+Tests archive size efficiency across different configurations.
+
+**Run:**
+```bash
+cd build/benchmarks
+./fsize_benchmark
+```
+
+### 4. **Random Usage Benchmark** (`random_usage`)
+Simulates realistic mixed workload patterns.
+
+**Run:**
+```bash
+cd build/benchmarks
+./random_usage
+```
+
+## Quick Start
+
+### Build all benchmarks:
+```bash
+cd build
+cmake ..
+make compio_benchmarks fragmentation_benchmark fsize_benchmark random_usage
+```
+
+### Run fragmentation benchmark:
+```bash
+cd build/benchmarks
+./fragmentation_benchmark
+```
+
+### Analyze results:
+```bash
+cd benchmarks
+./analyze_fragmentation.sh
+```
+
+Or specify custom CSV file:
+```bash
+./analyze_fragmentation.sh /path/to/custom_results.csv
+```
+
+## Interpreting Results
+
+### Fragmentation Benchmark Results
+
+**Overhead Percentage:**
+- `< 20%`: Excellent - minimal wasted space
+- `20-40%`: Good - acceptable fragmentation
+- `40-60%`: Poor - significant waste
+- `> 60%`: Critical - severe fragmentation
+
+**Free Regions Count:**
+- Lower is better (more contiguous free space)
+- High count indicates scattered small gaps
+
+**Strategy Selection Guide:**
+- **BEST_FIT**: Best for minimizing wasted space (recommended for most cases)
+- **FIRST_FIT**: Fast, reasonable overhead
+- **WORST_FIT**: Useful when future large allocations expected
+- **NEXT_FIT**: Generally worst, but can help in cyclic access patterns
+
+## Output Files
+
+All benchmarks output to `build/benchmarks/`:
+- `fragmentation_results.csv` - raw data (720 rows)
+- `fragmentation_results_report.txt` - formatted analysis
+- Performance benchmark results go to stdout (redirect to save)

--- a/benchmarks/analyze_fragmentation.sh
+++ b/benchmarks/analyze_fragmentation.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Quick analyzer for fragmentation benchmark CSV results
+# Usage: ./analyze_fragmentation.sh [csv_file]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_CSV="${SCRIPT_DIR}/../build/benchmarks/fragmentation_results.csv"
+
+CSV_FILE="${1:-$DEFAULT_CSV}"
+
+if [ ! -f "$CSV_FILE" ]; then
+    echo "Error: CSV file not found: $CSV_FILE"
+    echo ""
+    echo "Usage: $0 [csv_file]"
+    echo ""
+    echo "Default location: build/benchmarks/fragmentation_results.csv"
+    echo "Run fragmentation_benchmark first to generate the CSV file:"
+    echo "  cd build/benchmarks && ./fragmentation_benchmark"
+    exit 1
+fi
+
+echo "╔════════════════════════════════════════════════════════════╗"
+echo "║       FRAGMENTATION BENCHMARK - QUICK ANALYSIS             ║"
+echo "╚════════════════════════════════════════════════════════════╝"
+echo ""
+echo "Analyzing: $CSV_FILE"
+echo ""
+
+# Strategy comparison
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "ALLOCATION STRATEGY COMPARISON"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+awk -F',' 'NR>1 {
+    oh[$2]+=$16; cnt[$2]++; time[$2]+=$20
+}
+END {
+    for (s in oh) {
+        printf "%-12s  Avg Overhead: %6.2f%%  Avg Time: %6.2f ms  Tests: %d\n",
+               s, oh[s]/cnt[s], time[s]/cnt[s], cnt[s]
+    }
+}' "$CSV_FILE" | sort -t: -k2 -n
+
+echo ""
+
+# Deletion strategy impact
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "DELETION STRATEGY IMPACT"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+awk -F',' 'NR>1 {
+    if ($7=="Yes") {
+        yes_oh+=$16; yes_del+=$10; yes_frag+=$18; yes_cnt++
+    } else {
+        no_oh+=$16; no_del+=$10; no_frag+=$18; no_cnt++
+    }
+}
+END {
+    printf "Delete from Middle:  Overhead: %6.2f%%  Deleted: %5.1f  Frag Slots: %5.2f  Tests: %d\n",
+           yes_oh/yes_cnt, yes_del/yes_cnt, yes_frag/yes_cnt, yes_cnt
+    printf "Random Deletion:     Overhead: %6.2f%%  Deleted: %5.1f  Frag Slots: %5.2f  Tests: %d\n",
+           no_oh/no_cnt, no_del/no_cnt, no_frag/no_cnt, no_cnt
+    printf "\nImpact: Random deletion creates %.1fx more overhead\n", (no_oh/no_cnt)/(yes_oh/yes_cnt)
+}' "$CSV_FILE"
+
+echo ""
+
+# Block size impact
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "BLOCK SIZE IMPACT"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+awk -F',' 'NR>1 {
+    oh[$1]+=$16; waste[$1]+=$15; cnt[$1]++
+}
+END {
+    for (bs in oh) {
+        printf "Block %6s bytes:  Avg Overhead: %6.2f%%  Avg Wasted: %8.2f KB  Tests: %d\n",
+               bs, oh[bs]/cnt[bs], waste[bs]/cnt[bs]/1024, cnt[bs]
+    }
+}' "$CSV_FILE" | sort -t: -k1 -n
+
+echo ""
+
+# Compression impact
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "COMPRESSION PROBABILITY IMPACT"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+awk -F',' 'NR>1 {
+    oh[$3]+=$16; cnt[$3]++
+}
+END {
+    for (cp in oh) {
+        printf "Compress Prob %3.0f%%:  Avg Overhead: %6.2f%%  Tests: %d\n",
+               cp*100, oh[cp]/cnt[cp], cnt[cp]
+    }
+}' "$CSV_FILE" | sort -t: -k1 -n
+
+echo ""
+
+# Best and worst cases
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "EXTREME CASES"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Find best case (minimum overhead)
+echo "Best case (minimum overhead):"
+awk -F',' 'NR==1 {for(i=1;i<=NF;i++) h[$i]=i; next}
+NR==2 {min=$h["OverheadPercent"]; minline=$0}
+NR>2 && $h["OverheadPercent"]<min {min=$h["OverheadPercent"]; minline=$0}
+END {
+    split(minline, f, ",");
+    printf "  Strategy: %s, BlockSize: %s, Overhead: %.2f%%, Deleted: %s files\n",
+           f[h["Strategy"]], f[h["BlockSize"]], f[h["OverheadPercent"]], f[h["FilesDeleted"]]
+}' "$CSV_FILE"
+
+# Find worst case (maximum overhead)
+echo "Worst case (maximum overhead):"
+awk -F',' 'NR==1 {for(i=1;i<=NF;i++) h[$i]=i; next}
+NR==2 {max=$h["OverheadPercent"]; maxline=$0}
+NR>2 && $h["OverheadPercent"]>max {max=$h["OverheadPercent"]; maxline=$0}
+END {
+    split(maxline, f, ",");
+    printf "  Strategy: %s, BlockSize: %s, Overhead: %.2f%%, Deleted: %s files\n",
+           f[h["Strategy"]], f[h["BlockSize"]], f[h["OverheadPercent"]], f[h["FilesDeleted"]]
+}' "$CSV_FILE"
+
+echo ""
+
+# Summary statistics
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "OVERALL STATISTICS"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+awk -F',' 'NR>1 {
+    sum_oh+=$16; sum_del+=$10; sum_time+=$20; cnt++
+    if($16<20) excellent++
+    else if($16<40) good++
+    else if($16<60) poor++
+    else critical++
+}
+END {
+    printf "Total tests:          %d\n", cnt
+    printf "Avg overhead:         %.2f%%\n", sum_oh/cnt
+    printf "Avg files deleted:    %.1f\n", sum_del/cnt
+    printf "Avg test time:        %.2f ms\n", sum_time/cnt
+    printf "\nOverhead distribution:\n"
+    printf "  Excellent (<20%%):   %d (%.1f%%)\n", excellent, excellent/cnt*100
+    printf "  Good (20-40%%):      %d (%.1f%%)\n", good, good/cnt*100
+    printf "  Poor (40-60%%):      %d (%.1f%%)\n", poor, poor/cnt*100
+    printf "  Critical (>60%%):    %d (%.1f%%)\n", critical, critical/cnt*100
+}' "$CSV_FILE"
+
+echo ""
+

--- a/benchmarks/custom/fragmentation_benchmark.cpp
+++ b/benchmarks/custom/fragmentation_benchmark.cpp
@@ -821,6 +821,12 @@ int main(int argc, char* argv[]) {
     std::cout << "ADVANCED FRAGMENTATION TESTING SUITE\n";
     std::cout << "========================================\n\n";
 
+    std::cout << "Metrics explanation:\n";
+    std::cout << "  OH (Overhead)    - Wasted space percentage due to fragmentation\n";
+    std::cout << "  Del (Deleted)    - Number of files deleted to create fragmentation\n";
+    std::cout << "  ETA              - Estimated Time to complete All tests (seconds)\n";
+    std::cout << "  avg              - Running average overhead across all tests\n\n";
+
     std::cout << "Generating comprehensive test grid...\n";
     auto param_grid = generate_parameter_grid();
     std::cout << "Total configurations: " << param_grid.size() << "\n";
@@ -843,12 +849,27 @@ int main(int argc, char* argv[]) {
     int test_num = 0;
     int progress_step = std::max(1, static_cast<int>(param_grid.size() / 20));
 
+    double total_overhead = 0.0;
+    int overhead_count = 0;
+
     for (const auto& params : param_grid) {
         test_num++;
 
         if (test_num % progress_step == 0 || test_num == 1 || test_num == static_cast<int>(param_grid.size())) {
+            // Calculate ETA
+            auto now = std::chrono::high_resolution_clock::now();
+            auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(now - start_time).count();
+            double avg_time_per_test = test_num > 0 ? static_cast<double>(elapsed) / test_num : 0;
+            int remaining_tests = param_grid.size() - test_num;
+            int eta_seconds = static_cast<int>(avg_time_per_test * remaining_tests);
+
             std::cout << "[" << std::setw(3) << (test_num * 100 / param_grid.size()) << "%] "
-                      << test_num << "/" << param_grid.size() << " ... " << std::flush;
+                      << test_num << "/" << param_grid.size();
+
+            if (test_num > 1 && eta_seconds > 0) {
+                std::cout << " (ETA: " << eta_seconds << "s)";
+            }
+            std::cout << " ... " << std::flush;
         }
 
         std::string temp_file = "temp_frag_test_" + std::to_string(test_num) + ".compio";
@@ -857,10 +878,14 @@ int main(int argc, char* argv[]) {
 
         results.push_back({params, result});
 
+        total_overhead += result.overhead_percent;
+        overhead_count++;
+
         if (test_num % progress_step == 0 || test_num == static_cast<int>(param_grid.size())) {
-            std::cout << "Overhead: " << std::fixed << std::setprecision(1) << result.overhead_percent << "%, "
-                      << "Frag: " << result.fragmentation_level << ", "
-                      << "Deleted: " << result.files_deleted << " files\n";
+            double current_avg = total_overhead / overhead_count;
+            std::cout << "OH: " << std::fixed << std::setprecision(1) << result.overhead_percent << "% "
+                      << "(avg: " << current_avg << "%), "
+                      << "Del: " << result.files_deleted << "\n";
         }
     }
 

--- a/benchmarks/custom/fragmentation_benchmark.cpp
+++ b/benchmarks/custom/fragmentation_benchmark.cpp
@@ -233,49 +233,56 @@ FragmentationResult run_fragmentation_test(const FragmentationParams& params, co
     size_t min_deletions = static_cast<size_t>(files.size() * params.min_delete_ratio);
 
     if (params.delete_from_middle) {
-        // Delete from physical middle third of created files
-        // (files are created sequentially, so index order approximates physical order)
+
+        // Strategy: Delete files with GAPS between them from middle region
+        // This creates fragmentation: small free regions scattered throughout middle
+        // Unlike deleting consecutive files which creates ONE large free block
+
         size_t start_idx = files.size() / 3;
         size_t end_idx = 2 * files.size() / 3;
 
-        // IMPORTANT: We want to delete min_delete_ratio of ALL files, but ONLY from the middle third
-        // So we need to delete aggressively from the middle to reach the target
-
-        // Collect all candidates from middle third
+        // Collect candidates from middle third, respecting size-based deletion probabilities
         std::vector<size_t> middle_candidates;
         for (size_t i = start_idx; i < end_idx; i++) {
-            middle_candidates.push_back(i);
-        }
-
-        // Shuffle to randomize which files from middle we delete
-        std::shuffle(middle_candidates.begin(), middle_candidates.end(), gen);
-
-        // Delete files from middle until we reach min_deletions
-        // This ensures we ACTUALLY delete the target percentage, all from the middle
-        for (size_t idx : middle_candidates) {
-            if (indices_to_delete.size() >= min_deletions) break;
-
-            // Apply size-based probability as a filter
             double delete_prob = 0.0;
-            switch (files[idx].size_category) {
+            switch (files[i].size_category) {
                 case SMALL: delete_prob = params.delete_prob_small; break;
                 case MEDIUM: delete_prob = params.delete_prob_medium; break;
                 case LARGE: delete_prob = params.delete_prob_large; break;
             }
 
-            // If probability is high (>0.5), always delete; otherwise use probability
-            if (delete_prob > 0.5 || prob_dist(gen) < delete_prob * 2.0) {
+            // Use probability to select which files are candidates
+            if (prob_dist(gen) < delete_prob) {
+                middle_candidates.push_back(i);
+            }
+        }
+
+        // Shuffle to randomize which candidates we take
+        std::shuffle(middle_candidates.begin(), middle_candidates.end(), gen);
+
+        // Take as many as we can from candidates, but ensure we meet min_deletions
+        for (size_t idx : middle_candidates) {
+            if (indices_to_delete.size() >= min_deletions) break;
+            indices_to_delete.push_back(idx);
+        }
+
+        // If we don't have enough candidates, expand to ALL middle files to meet quota
+        if (indices_to_delete.size() < min_deletions) {
+            std::vector<size_t> all_middle;
+            for (size_t i = start_idx; i < end_idx; i++) {
+                if (std::find(indices_to_delete.begin(), indices_to_delete.end(), i) == indices_to_delete.end()) {
+                    all_middle.push_back(i);
+                }
+            }
+            std::shuffle(all_middle.begin(), all_middle.end(), gen);
+            for (size_t idx : all_middle) {
+                if (indices_to_delete.size() >= min_deletions) break;
                 indices_to_delete.push_back(idx);
             }
         }
 
-        // If still not enough, just take remaining files from middle to meet quota
-        for (size_t idx : middle_candidates) {
-            if (indices_to_delete.size() >= min_deletions) break;
-            if (std::find(indices_to_delete.begin(), indices_to_delete.end(), idx) == indices_to_delete.end()) {
-                indices_to_delete.push_back(idx);
-            }
-        }
+        // Sort indices to delete them in order (this creates gaps if we skip some)
+        std::sort(indices_to_delete.begin(), indices_to_delete.end());
     } else {
         // Random deletion across all files
         for (size_t i = 0; i < files.size(); i++) {


### PR DESCRIPTION
- Replace consecutive deletion with probability-based scattered deletion
- Apply size-based deletion probabilities to middle region candidates
- Ensure minimum deletion ratio is met by expanding to all middle files
- Add README.md for benchmarks
- Add analyze_fragmentation.sh
- Improve fragmentation benchmark output with metrics explanation