### PR TITLE
CI: Add GitHub Actions workflow and fix Windows build/test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+          - os: windows-latest
+            triplet: x64-windows
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
+
+      - name: Initialize vcpkg submodule
+        run: |
+          git submodule init
+          git submodule update
 
       - name: Cache vcpkg packages
         uses: actions/cache@v4
@@ -38,13 +45,17 @@ jobs:
         run: .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
         shell: pwsh
 
+      - name: Install dependencies via vcpkg
+        run: ./vcpkg/vcpkg install --triplet ${{ matrix.triplet }}
+        shell: bash
+
       - name: Configure CMake
         run: >
           cmake -B build -S .
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
           -DVCPKG_INSTALLED_DIR=${{ github.workspace }}/vcpkg_installed
-          -DVCPKG_TARGET_TRIPLET=${{ runner.os == 'Windows' && 'x64-windows' || 'x64-linux' }}
+          -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
 
       - name: Build
         run: cmake --build build --config Release --parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: ["ci", "main", "develop"]
+  pull_request:
+    branches: ["main", "develop"]
+
+jobs:
+  build:
+    name: Build & Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Cache vcpkg packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/vcpkg_installed
+          key: vcpkg-${{ matrix.os }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.os }}-
+
+      - name: Bootstrap vcpkg (Linux)
+        if: runner.os == 'Linux'
+        run: ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+      - name: Bootstrap vcpkg (Windows)
+        if: runner.os == 'Windows'
+        run: .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
+        shell: pwsh
+
+      - name: Configure CMake
+        run: >
+          cmake -B build -S .
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+          -DVCPKG_INSTALLED_DIR=${{ github.workspace }}/vcpkg_installed
+          -DVCPKG_TARGET_TRIPLET=${{ runner.os == 'Windows' && 'x64-windows' || 'x64-linux' }}
+
+      - name: Build
+        run: cmake --build build --config Release --parallel
+
+      - name: Run tests
+        run: ctest --test-dir build --build-config Release --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,14 @@ jobs:
         run: .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
         shell: pwsh
 
-      - name: Install dependencies via vcpkg
-        run: ${{ github.workspace }}/vcpkg/vcpkg install --triplet ${{ matrix.triplet }}
+      - name: Install dependencies via vcpkg (Linux)
+        if: runner.os == 'Linux'
+        run: ./vcpkg/vcpkg install --triplet ${{ matrix.triplet }}
+
+      - name: Install dependencies via vcpkg (Windows)
+        if: runner.os == 'Windows'
+        run: .\vcpkg\vcpkg.exe install --triplet ${{ matrix.triplet }}
+        shell: pwsh
 
       - name: Configure CMake
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,7 @@ jobs:
         shell: pwsh
 
       - name: Install dependencies via vcpkg
-        run: ./vcpkg/vcpkg install --triplet ${{ matrix.triplet }}
-        shell: bash
+        run: ${{ github.workspace }}/vcpkg/vcpkg install --triplet ${{ matrix.triplet }}
 
       - name: Configure CMake
         run: >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,32 +51,32 @@ endif()
 
 if (COMPIO_WARNING_PRINT)
     message("Building with COMPIO_WARNING_PRINT")
-    add_compile_options(-DCOMPIO_WARNING_PRINT)
+    add_compile_definitions(COMPIO_WARNING_PRINT)
 endif()
 
 if (COMPIO_DEBUG_PRINT)
     message("Building with COMPIO_DEBUG_PRINT")
-    add_compile_options(-DCOMPIO_DEBUG_PRINT)
+    add_compile_definitions(COMPIO_DEBUG_PRINT)
 endif()
 
 if (COMPIO_BENCHMARK_FILE_OPERATIONS_COUNTER)
     message("Building with COMPIO_BENCHMARK_FILE_OPERATIONS_COUNTER")
-    add_compile_options(-DCOMPIO_BENCHMARK_FILE_OPERATIONS_COUNTER)
+    add_compile_definitions(COMPIO_BENCHMARK_FILE_OPERATIONS_COUNTER)
 endif()
 
 if (COMPIO_BENCHMARK_BLOCKS_COUNTER)
     message("Building with COMPIO_BENCHMARK_BLOCKS_COUNTER")
-    add_compile_options(-DCOMPIO_BENCHMARK_BLOCKS_COUNTER)
+    add_compile_definitions(COMPIO_BENCHMARK_BLOCKS_COUNTER)
 endif()
 
 if (COMPIO_BENCHMARK_COMPRESSION_BYTES)
     message("Building with COMPIO_BENCHMARK_COMPRESSION_BYTES")
-    add_compile_options(-DCOMPIO_BENCHMARK_COMPRESSION_BYTES)
+    add_compile_definitions(COMPIO_BENCHMARK_COMPRESSION_BYTES)
 endif()
 
 if (COMPIO_DISABLE_INSERT_ERASE)
     message("Building with COMPIO_DISABLE_INSERT_ERASE")
-    add_compile_options(-DCOMPIO_DISABLE_INSERT_ERASE)
+    add_compile_definitions(COMPIO_DISABLE_INSERT_ERASE)
 endif()
 
 
@@ -101,7 +101,7 @@ endif()
 
 # --- Library target
 
-add_library(compio SHARED
+add_library(compio STATIC
     src/allocator.cpp
     src/btree.cpp
     src/compio.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,8 @@ endif()
 
 # --- Subdirectories
 
+enable_testing()
+
 add_subdirectory(tests)
 add_subdirectory(benchmarks)
 add_subdirectory(examples)

--- a/benchmarks/custom/compression_drift_benchmark.cpp
+++ b/benchmarks/custom/compression_drift_benchmark.cpp
@@ -68,12 +68,12 @@ struct DriftParams {
 // ratio close to 1.0 = incompressible (random data)
 void generate_data_with_ratio(std::vector<uint8_t>& data, double compress_ratio, std::mt19937& gen) {
     std::uniform_real_distribution<double> prob(0.0, 1.0);
-    std::uniform_int_distribution<uint8_t> byte_dist(0, 255);
+    std::uniform_int_distribution<int> byte_dist(0, 255);
 
     for (auto& byte : data) {
         if (prob(gen) < compress_ratio) {
             // Random byte (incompressible)
-            byte = byte_dist(gen);
+            byte = static_cast<uint8_t>(byte_dist(gen));
         } else {
             // Zero (highly compressible)
             byte = 0;

--- a/benchmarks/custom/fragmentation_benchmark.cpp
+++ b/benchmarks/custom/fragmentation_benchmark.cpp
@@ -71,8 +71,8 @@ struct FragmentationParams {
 
 // Generate highly compressible data (repeated patterns)
 void generate_compressible_data(std::vector<uint8_t>& data, std::mt19937& gen) {
-    std::uniform_int_distribution<uint8_t> pattern_dist(0, 15);
-    uint8_t pattern = pattern_dist(gen);
+    std::uniform_int_distribution<int> pattern_dist(0, 15);
+    uint8_t pattern = static_cast<uint8_t>(pattern_dist(gen));
 
     // Fill with repeated pattern
     for (size_t i = 0; i < data.size(); i++) {
@@ -82,9 +82,9 @@ void generate_compressible_data(std::vector<uint8_t>& data, std::mt19937& gen) {
 
 // Generate incompressible data (random)
 void generate_incompressible_data(std::vector<uint8_t>& data, std::mt19937& gen) {
-    std::uniform_int_distribution<uint8_t> dist(0, 255);
+    std::uniform_int_distribution<int> dist(0, 255);
     for (auto& byte : data) {
-        byte = dist(gen);
+        byte = static_cast<uint8_t>(dist(gen));
     }
 }
 

--- a/benchmarks/src/allocator_benchmark.cpp
+++ b/benchmarks/src/allocator_benchmark.cpp
@@ -13,9 +13,9 @@
 
 /// Generates random incompressible data for testing.
 static void fill_random_data(std::vector<uint8_t>& data, std::mt19937& gen) {
-    std::uniform_int_distribution<uint8_t> dist(0, 255);
+    std::uniform_int_distribution<int> dist(0, 255);
     for (auto& byte : data) {
-        byte = dist(gen);
+        byte = static_cast<uint8_t>(dist(gen));
     }
 }
 

--- a/benchmarks/src/benchmarks_main.cpp
+++ b/benchmarks/src/benchmarks_main.cpp
@@ -31,7 +31,6 @@ void build_config(int argc, char **argv) {
 
 int main(int argc, char **argv) {
     build_config(argc, argv);
-    benchmark::MaybeReenterWithoutASLR(argc, argv);
     benchmark::Initialize(&argc, argv);
     benchmark::RunSpecifiedBenchmarks();
     benchmark::Shutdown();

--- a/examples/compression_persistence_test.c
+++ b/examples/compression_persistence_test.c
@@ -3,12 +3,28 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
 
 #include "compio.h"
 
+static void get_temp_path(char *buf, size_t buf_size, const char *filename) {
+#ifdef _WIN32
+    char tmp_dir[MAX_PATH];
+    GetTempPathA(MAX_PATH, tmp_dir);
+    snprintf(buf, buf_size, "%s%s", tmp_dir, filename);
+#else
+    snprintf(buf, buf_size, "/tmp/%s", filename);
+#endif
+}
+
 int main() {
-    const char *archive_path = "/tmp/test_compression_persistence.cmp";
+    char archive_path[512];
+    get_temp_path(archive_path, sizeof(archive_path), "test_compression_persistence.cmp");
     const char *test_data = "This is test data to verify compression persistence!";
     size_t data_size = strlen(test_data) + 1;
 

--- a/tests/src/test_data_integrity.cpp
+++ b/tests/src/test_data_integrity.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <vector>
 
@@ -18,7 +19,9 @@ protected:
     compio_config config;
 
     void SetUp() override {
-        snprintf(archive_name, sizeof(archive_name), "/tmp/test_integrity_%d.compio", rand());
+        auto tmp = std::filesystem::temp_directory_path() /
+                   ("test_integrity_" + std::to_string(rand()) + ".compio");
+        snprintf(archive_name, sizeof(archive_name), "%s", tmp.string().c_str());
         compio_build_default_config(&config);
         archive = nullptr;
     }


### PR DESCRIPTION
- Add `.github/workflows/ci.yml` with a matrix build for Linux and Windows
- Use vcpkg submodule for dependency management (gtest, benchmark, brotli, lz4, zstd, zlib)
- Cache `vcpkg_installed` to speed up repeated runs
- Split vcpkg bootstrap/install steps by OS (bash vs pwsh)
- Move `enable_testing()` to the root `CMakeLists.txt` so `ctest` discovers tests

**MSVC compatibility fixes** (`4ee9db0` – `9295615`)
- Replace `std::uniform_int_distribution<uint8_t>` with `<int>` + `static_cast`
  (UB per C++ standard; MSVC rejects it)
- Switch `compio` from `SHARED` to `STATIC` to fix LNK1181 linker errors
  on all dependent targets (tests, benchmarks, examples, util)
- Replace `add_compile_options(-DFOO)` with `add_compile_definitions(FOO)`
  (`-DFOO` is GCC/Clang syntax; CMake's `add_compile_definitions` is cross-platform)
- Replace hardcoded `/tmp/` paths with `std::filesystem::temp_directory_path()`
  (C++17) in tests and `GetTempPathA()` in C examples — fixes all 6
  `DataIntegrityTest` failures on Windows