### PR TITLE
feat: make max_files a per-archive configuration parameter

### DIFF
--- a/compio.h
+++ b/compio.h
@@ -19,8 +19,9 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#define COMPIO_MAX_FILES 64      /**< Default maximum number of files in archive */
-#define COMPIO_FNAME_MAX_SIZE 32 /**< File name maximum length */
+#define COMPIO_MAX_FILES 64        /**< Default maximum number of files in archive */
+#define COMPIO_MAX_FILES_LIMIT 65535 /**< Hard upper bound accepted when reading an archive header */
+#define COMPIO_FNAME_MAX_SIZE 32   /**< File name maximum length */
 
 #define COMPIO_ERROR (-1)
 #define COMPIO_SUCCESS 0
@@ -29,7 +30,7 @@
 extern "C" {
 #endif
 
-#define COMPIO_MAGIC_NUMBER 27110654
+#define COMPIO_MAGIC_NUMBER 27110655 /**< Bumped in format v2 (variable-size header) */
 
 /**
  * @brief Compression algorithm types

--- a/compio.h
+++ b/compio.h
@@ -19,7 +19,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#define COMPIO_MAX_FILES 64      /**< Maximum number of files in archive */
+#define COMPIO_MAX_FILES 64      /**< Default maximum number of files in archive */
 #define COMPIO_FNAME_MAX_SIZE 32 /**< File name maximum length */
 
 #define COMPIO_ERROR (-1)
@@ -162,6 +162,7 @@ typedef struct {
     bool fill_holes_with_zeros;      /**< Zero-fill freed blocks for sparse file optimization */
     uint8_t fragmentation_threshold; /**< Trigger defragmentation when fragmentation exceeds this
                                         percentage (1-100) */
+    int max_files; /**< Maximum number of files in a single archive (default: COMPIO_MAX_FILES) */
 } compio_config;
 
 /**

--- a/include/compio/file.hpp
+++ b/include/compio/file.hpp
@@ -41,8 +41,11 @@ struct files_table {
 };
 
 /**
- * @brief File header of fixed size
+ * @brief Archive file header
  *
+ * The on-disk size of the header is variable: it depends on @c ftable.max_files,
+ * which is stored as the first field of the files table.  Use @c disk_size()
+ * to obtain the actual byte count rather than @c sizeof(header).
  */
 struct header : public infile_object {
     int32_t magic_number; /**< Constant bytes, file signature */

--- a/include/compio/file.hpp
+++ b/include/compio/file.hpp
@@ -24,13 +24,15 @@ namespace compio {
  */
 struct files_table {
     uint64_t n_files;
+    uint32_t max_files;
     struct file {
         char name[COMPIO_FNAME_MAX_SIZE];
         uint64_t size;
     };
-    file files[COMPIO_MAX_FILES];
+    std::vector<file> files;
 
     files_table();
+    explicit files_table(uint32_t max_files);
 
     const file *find(const char *name) const;
     file *find(const char *name);
@@ -56,9 +58,13 @@ struct header : public infile_object {
      *
      */
     header();
+    explicit header(uint32_t max_files);
 
     void read_from(FILE *file, uint64_t addr) override;
     void write_to(FILE *file, uint64_t addr) const override;
+
+    /** @brief On-disk size of this header (depends on ftable.max_files) */
+    uint64_t disk_size() const;
 };
 
 /**

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -540,8 +540,9 @@ bool free_blocks_manager::save_to_file(compio_archive *archive) {
     // This ensures the region is accounted for in file_size and won't
     // be overwritten by future allocations.
     int64_t pos = static_cast<int64_t>(readonly(archive->header, header)->file_size);
-    if (pos < static_cast<int64_t>(sizeof(header))) {
-        pos = sizeof(header);
+    const auto hdr_size = static_cast<int64_t>(readonly(archive->header, header)->disk_size());
+    if (pos < hdr_size) {
+        pos = hdr_size;
     }
 
     if (fseek64(archive->file, pos, SEEK_SET) != 0) {
@@ -655,8 +656,8 @@ block_allocator::block_allocator(compio_archive *archive)
     // and will be set properly when save_state() is called
 
     // Ensure we have valid initial file size
-    if (readonly(archive_->header, header)->file_size < sizeof(header)) {
-        archive_->header->file_size = sizeof(header);
+    if (readonly(archive_->header, header)->file_size < readonly(archive_->header, header)->disk_size()) {
+        archive_->header->file_size = archive_->header->disk_size();
     }
 }
 
@@ -811,7 +812,7 @@ void block_allocator::perform_defragmentation() {
     std::sort(used_blocks.begin(), used_blocks.end(),
               [](const auto &a, const auto &b) { return a.second.addr < b.second.addr; });
 
-    uint64_t write_pos = sizeof(header);
+    uint64_t write_pos = readonly(archive_->header, header)->disk_size();
 
     // Collect final positions of placed storage blocks for gap computation.
     std::vector<std::pair<uint64_t, uint64_t>> placed_blocks;
@@ -819,7 +820,7 @@ void block_allocator::perform_defragmentation() {
     for (auto &[key, val] : used_blocks) {
         const uint64_t src = val.addr;
 
-        if (src < sizeof(header)) {
+        if (src < readonly(archive_->header, header)->disk_size()) {
             continue;
         }
 
@@ -975,7 +976,7 @@ void block_allocator::perform_defragmentation() {
     }
     std::sort(occupied.begin(), occupied.end());
 
-    uint64_t scan = sizeof(header);
+    uint64_t scan = readonly(archive_->header, header)->disk_size();
     for (auto &[occ_start, occ_size] : occupied) {
         if (occ_start > scan) {
             blocks_manager_.add_free_block(scan, occ_start - scan);

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -113,6 +113,10 @@ static bool validate_config(const compio_config *c) {
         WARNING_PRINT("warning: max_files=%d <= 0\n", c->max_files);
         return false;
     }
+    if (c->max_files > COMPIO_MAX_FILES) {
+        WARNING_PRINT("warning: max_files=%d > COMPIO_MAX_FILES=%d\n", c->max_files, COMPIO_MAX_FILES);
+        return false;
+    }
     return true;
 }
 

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -113,8 +113,9 @@ static bool validate_config(const compio_config *c) {
         WARNING_PRINT("warning: max_files=%d <= 0\n", c->max_files);
         return false;
     }
-    if (c->max_files > COMPIO_MAX_FILES) {
-        WARNING_PRINT("warning: max_files=%d > COMPIO_MAX_FILES=%d\n", c->max_files, COMPIO_MAX_FILES);
+    if (c->max_files > COMPIO_MAX_FILES_LIMIT) {
+        WARNING_PRINT("warning: max_files=%d exceeds hard limit %d\n", c->max_files,
+                      COMPIO_MAX_FILES_LIMIT);
         return false;
     }
     return true;

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -28,6 +28,7 @@ void compio_build_default_config(compio_config *result) {
     result->cache_size__blocks = 16;
     result->allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
     result->fragmentation_threshold = 30;
+    result->max_files = COMPIO_MAX_FILES;
 }
 
 int compio_get_compression_type(const char *fp, compio_compression_type *t) {
@@ -58,7 +59,8 @@ compio_archive::compio_archive(FILE *file, uint8_t mode_b, const compio_config *
       mode_b(mode_b),
       open_files_count(0) {
     if (is_file_empty(file))
-        header = smart_infile_object<compio::header>(file, 0, new compio::header());
+        header = smart_infile_object<compio::header>(file, 0,
+                     new compio::header(static_cast<uint32_t>(config->max_files)));
     else
         header = smart_infile_object<compio::header>(file, 0);
 
@@ -105,6 +107,10 @@ static bool validate_config(const compio_config *c) {
         // but still exist in local variables of some function, and if that function modifies 
         // that node, but some other function will try to read that node from file, it would get it's old version
         WARNING_PRINT("warning: cache_size__nodes=%d < 4\nplease use cache_size__nodes >= 4 ", c->cache_size__nodes);
+        return false;
+    }
+    if (c->max_files <= 0) {
+        WARNING_PRINT("warning: max_files=%d <= 0\n", c->max_files);
         return false;
     }
     return true;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -19,7 +19,7 @@ static const uint8_t index_node_signature = 67;
 static const uint8_t storage_block_signature = 171;
 
 header::header()
-    : magic_number(27110654),
+    : magic_number(COMPIO_MAGIC_NUMBER),
       index_root(0),
       file_size(0),
       ftable(),
@@ -30,7 +30,7 @@ header::header()
 }
 
 header::header(uint32_t max_files)
-    : magic_number(27110654),
+    : magic_number(COMPIO_MAGIC_NUMBER),
       index_root(0),
       file_size(0),
       ftable(max_files),
@@ -54,7 +54,10 @@ void header::read_from(FILE *file, uint64_t addr) {
         DEBUG_PRINT("warning: fseek failed\n");
     lendian_fread_member(magic_number, file);
     if (magic_number != COMPIO_MAGIC_NUMBER) {
-        WARNING_PRINT("warning: header magic_number does not match\n");
+        WARNING_PRINT("warning: header magic_number does not match "
+                      "(expected %d, got %d). "
+                      "The archive may have been created with an incompatible format version.\n",
+                      COMPIO_MAGIC_NUMBER, magic_number);
         assert(false);
     }
     lendian_fread_member(index_root, file);
@@ -63,8 +66,18 @@ void header::read_from(FILE *file, uint64_t addr) {
     lendian_fread_member(allocator_state_size, file);
     lendian_fread_member(compression_type, file);
     lendian_fread_member(ftable.max_files, file);
+    if (ftable.max_files == 0 || ftable.max_files > COMPIO_MAX_FILES_LIMIT) {
+        WARNING_PRINT("warning: header max_files=%u is out of valid range [1, %u]\n",
+                      ftable.max_files, COMPIO_MAX_FILES_LIMIT);
+        assert(false);
+    }
     ftable.files.resize(ftable.max_files);
     lendian_fread_member(ftable.n_files, file);
+    if (ftable.n_files > ftable.max_files) {
+        WARNING_PRINT("warning: header n_files=%" PRIu64 " exceeds max_files=%u\n",
+                      ftable.n_files, ftable.max_files);
+        assert(false);
+    }
     for (uint32_t i = 0; i < ftable.max_files; ++i) {
         lendian_fread(&ftable.files[i].name, 1, sizeof(ftable.files[i].name), file);
         lendian_fread_member(ftable.files[i].size, file);

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -21,11 +21,32 @@ static const uint8_t storage_block_signature = 171;
 header::header()
     : magic_number(27110654),
       index_root(0),
-      file_size(sizeof(header)),
+      file_size(0),
       ftable(),
       allocator_state_offset(0),
       allocator_state_size(0),
-      compression_type(COMPIO_COMPRESS_ZLIB) {}
+      compression_type(COMPIO_COMPRESS_ZLIB) {
+    file_size = disk_size();
+}
+
+header::header(uint32_t max_files)
+    : magic_number(27110654),
+      index_root(0),
+      file_size(0),
+      ftable(max_files),
+      allocator_state_offset(0),
+      allocator_state_size(0),
+      compression_type(COMPIO_COMPRESS_ZLIB) {
+    file_size = disk_size();
+}
+
+uint64_t header::disk_size() const {
+    // magic_number(4) + index_root(8) + file_size(8) + allocator_state_offset(8)
+    // + allocator_state_size(8) + compression_type(4) + max_files(4)
+    // + n_files(8) + files[max_files] * (32 + 8)
+    return 4 + 8 + 8 + 8 + 8 + 4 + 4 + 8 +
+           static_cast<uint64_t>(ftable.max_files) * (COMPIO_FNAME_MAX_SIZE + 8);
+}
 
 void header::read_from(FILE *file, uint64_t addr) {
     DEBUG_PRINT("[R][header]addr=%lu\n", addr);
@@ -41,15 +62,17 @@ void header::read_from(FILE *file, uint64_t addr) {
     lendian_fread_member(allocator_state_offset, file);
     lendian_fread_member(allocator_state_size, file);
     lendian_fread_member(compression_type, file);
+    lendian_fread_member(ftable.max_files, file);
+    ftable.files.resize(ftable.max_files);
     lendian_fread_member(ftable.n_files, file);
-    for (int i = 0; i < COMPIO_MAX_FILES; ++i) {
+    for (uint32_t i = 0; i < ftable.max_files; ++i) {
         lendian_fread(&ftable.files[i].name, 1, sizeof(ftable.files[i].name), file);
         lendian_fread_member(ftable.files[i].size, file);
     }
 }
 
 void header::write_to(FILE *file, uint64_t addr) const {
-    DEBUG_PRINT("[W][header]addr=%lu;size=%lu\n", addr, sizeof(header));
+    DEBUG_PRINT("[W][header]addr=%lu;size=%lu\n", addr, disk_size());
     if (fseek64(file, addr, SEEK_SET))
         DEBUG_PRINT("warning: fseek failed\n");
     lendian_fwrite_member(magic_number, file);
@@ -58,8 +81,9 @@ void header::write_to(FILE *file, uint64_t addr) const {
     lendian_fwrite_member(allocator_state_offset, file);
     lendian_fwrite_member(allocator_state_size, file);
     lendian_fwrite_member(compression_type, file);
+    lendian_fwrite_member(ftable.max_files, file);
     lendian_fwrite_member(ftable.n_files, file);
-    for (int i = 0; i < COMPIO_MAX_FILES; ++i) {
+    for (uint32_t i = 0; i < ftable.max_files; ++i) {
         lendian_fwrite(&ftable.files[i].name, 1, sizeof(ftable.files[i].name), file);
         lendian_fwrite_member(ftable.files[i].size, file);
     }
@@ -246,7 +270,10 @@ storage_block::storage_block(std::unique_ptr<uint8_t[]> &&data, uint64_t size)
 storage_block::storage_block(uint64_t size)
     : storage_block(std::unique_ptr<uint8_t[]>(new uint8_t[size]), size) {}
 
-files_table::files_table() : n_files(0) {}
+files_table::files_table() : n_files(0), max_files(COMPIO_MAX_FILES), files(COMPIO_MAX_FILES) {}
+
+files_table::files_table(uint32_t max_files)
+    : n_files(0), max_files(max_files), files(max_files) {}
 
 const files_table::file *files_table::find(const char *name) const {
     for (uint64_t i = 0; i < n_files; ++i)
@@ -263,7 +290,7 @@ files_table::file *files_table::find(const char *name) {
 }
 
 files_table::file *files_table::add(const char *name) {
-    if (n_files >= COMPIO_MAX_FILES)
+    if (n_files >= max_files)
         return NULL;
     strncpy(files[n_files].name, name, COMPIO_FNAME_MAX_SIZE);
     files[n_files].size = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(compio_gtest
     src/test_btree_get_block.cpp
     src/test_insert_erase.cpp
     src/test_segregated_allocator.cpp
+    src/test_max_files.cpp
 )
 
 target_link_libraries(compio_gtest PRIVATE compio GTest::GTest GTest::Main)

--- a/tests/src/test_allocator.cpp
+++ b/tests/src/test_allocator.cpp
@@ -36,7 +36,7 @@ protected:
     // Helper to verify block allocation
     bool verify_allocation(uint64_t offset, size_t size) {
         UNUSED(size);
-        return offset != UINT64_MAX && offset >= sizeof(header);
+        return offset != UINT64_MAX && offset >= archive->header->disk_size();
     }
 };
 

--- a/tests/src/test_allocator_comprehensive.cpp
+++ b/tests/src/test_allocator_comprehensive.cpp
@@ -53,7 +53,7 @@ protected:
     // Helper to verify block allocation
     bool verify_allocation(uint64_t offset, size_t size) {
         UNUSED(size);
-        return offset != UINT64_MAX && offset >= sizeof(header);
+        return offset != UINT64_MAX && offset >= archive->header->disk_size();
     }
 
     // Helper to verify blocks don't overlap
@@ -494,7 +494,7 @@ TEST_F(ErrorHandlingTest, InvalidDeallocations) {
     // These operations should not crash the program
     EXPECT_NO_THROW(allocator->deallocate(0, 100));
     EXPECT_NO_THROW(allocator->deallocate(UINT64_MAX, 100));
-    EXPECT_NO_THROW(allocator->deallocate(sizeof(header) / 2, 100));
+    EXPECT_NO_THROW(allocator->deallocate(archive->header->disk_size() / 2, 100));
 }
 
 TEST_F(ErrorHandlingTest, ExtremeAllocationSizes) {

--- a/tests/src/test_allocator_edge_cases.cpp
+++ b/tests/src/test_allocator_edge_cases.cpp
@@ -40,7 +40,7 @@ protected:
 TEST_F(BoundaryConditionTest, AllocationAtFileStart) {
     // Test allocation immediately after header
     uint64_t offset = allocator->allocate(100);
-    EXPECT_EQ(offset, sizeof(header) + INDEX_NODE_SIZE(config.b_tree_degree))
+    EXPECT_EQ(offset, archive->header->disk_size() + INDEX_NODE_SIZE(config.b_tree_degree))
         << "First allocation should be right after header and btree root node";
 }
 
@@ -426,7 +426,7 @@ TEST_F(EfficiencyTest, SpaceUtilizationEfficiency) {
     }
 
     uint64_t actual_file_size = archive->header->file_size;
-    uint64_t expected_min_size = sizeof(header) + target_data;
+    uint64_t expected_min_size = archive->header->disk_size() + target_data;
 
     // Calculate overhead percentage
     double overhead_ratio = double(actual_file_size - expected_min_size) / target_data;

--- a/tests/src/test_max_files.cpp
+++ b/tests/src/test_max_files.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include "compio.h"
+#include "compio/compio_file.hpp"
+#include "compio/file.hpp"
+
+#include "test_util.hpp"
+
+using namespace compio;
+
+class MaxFilesTest : public ::testing::Test {
+protected:
+    char fn[256];
+
+    void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
+
+    void TearDown() override { remove(fn); }
+};
+
+TEST_F(MaxFilesTest, DiskSizeReflectsMaxFiles) {
+    compio_config cfg;
+    compio_build_default_config(&cfg);
+    cfg.max_files = 128;
+
+    compio_archive *ar = compio_open_archive(fn, "w+", &cfg);
+    ASSERT_NE(ar, nullptr);
+
+    const uint64_t expected =
+        4 + 8 + 8 + 8 + 8 + 4 + 4 + 8 +
+        static_cast<uint64_t>(128) * (COMPIO_FNAME_MAX_SIZE + 8);
+    EXPECT_EQ(ar->header->disk_size(), expected);
+    EXPECT_EQ(ar->header->ftable.max_files, 128u);
+
+    compio_close_archive(ar);
+}
+
+TEST_F(MaxFilesTest, MaxFilesPersistsAcrossReopen) {
+    const uint32_t custom_max = 256;
+
+    {
+        compio_config cfg;
+        compio_build_default_config(&cfg);
+        cfg.max_files = static_cast<int>(custom_max);
+
+        compio_archive *ar = compio_open_archive(fn, "w+", &cfg);
+        ASSERT_NE(ar, nullptr);
+
+        compio_file *f = compio_open_file("hello", ar);
+        ASSERT_NE(f, nullptr);
+        const char data[] = "world";
+        compio_write(data, sizeof(data), f);
+        compio_close_file(f);
+
+        compio_close_archive(ar);
+    }
+
+    {
+        compio_config cfg;
+        compio_build_default_config(&cfg);
+
+        compio_archive *ar = compio_open_archive(fn, "r", &cfg);
+        ASSERT_NE(ar, nullptr);
+
+        EXPECT_EQ(ar->header->ftable.max_files, custom_max)
+            << "max_files should be read back from disk unchanged";
+
+        const uint64_t expected =
+            4 + 8 + 8 + 8 + 8 + 4 + 4 + 8 +
+            static_cast<uint64_t>(custom_max) * (COMPIO_FNAME_MAX_SIZE + 8);
+        EXPECT_EQ(ar->header->disk_size(), expected);
+
+        compio_close_archive(ar);
+    }
+}
+
+TEST_F(MaxFilesTest, DefaultMaxFilesMatchesConstant) {
+    compio_config cfg;
+    compio_build_default_config(&cfg);
+
+    compio_archive *ar = compio_open_archive(fn, "w+", &cfg);
+    ASSERT_NE(ar, nullptr);
+
+    EXPECT_EQ(ar->header->ftable.max_files, static_cast<uint32_t>(COMPIO_MAX_FILES));
+
+    compio_close_archive(ar);
+}


### PR DESCRIPTION
This PR changes the archive format to make `max_files` a per-archive runtime parameter stored in the on-disk header, replacing the compile-time `COMPIO_MAX_FILES` limit so archives can be created with different file table capacities.

**Changes:**
- Add `max_files` to `compio_config` and persist it in the archive header; compute header on-disk size via `header::disk_size()`.
- Replace the fixed-size files table array with a `std::vector`, sized by `max_files`.
- Update allocator logic and tests to use runtime header sizing instead of `sizeof(header)`.