### PR TITLE
test: improve defrag/allocator test coverage, fix lazy-write test assumptions

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,10 +7,12 @@ add_executable(compio_gtest
     src/test_allocator_advanced.cpp
     src/test_allocator_edge_cases.cpp
     src/test_allocator_serialization.cpp
+    src/test_allocator_strategies.cpp
     src/test_compression_type.cpp
     src/test_compressor.cpp
     src/test_data_integrity.cpp
     src/test_defragmentation.cpp
+    src/test_defragmentation_advanced.cpp
     src/test_library.cpp
     src/test_file_removal.cpp
     src/test_btree.cpp

--- a/tests/src/test_allocator_strategies.cpp
+++ b/tests/src/test_allocator_strategies.cpp
@@ -277,7 +277,6 @@ TEST_F(StrategyStatisticsTest, StatsFieldsConsistency) {
     double expected_avg = (100.0 + 200.0 + 50.0 + 300.0) / 4.0;
     EXPECT_NEAR(stats.avg_free_region_size, expected_avg, 1.0);
 
-    EXPECT_GE(stats.fragmentation_percent, 0u);
     EXPECT_LE(stats.fragmentation_percent, 100u);
 }
 

--- a/tests/src/test_allocator_strategies.cpp
+++ b/tests/src/test_allocator_strategies.cpp
@@ -86,6 +86,10 @@ TEST_F(StrategyFragmentationTest, BestFitPreservesLargeHoles) {
         if (archive) compio_close_archive(archive);
         archive = open_archive_with_strategy(fn, s);
         EXPECT_NE(archive, nullptr);
+        if (!archive) {
+            ADD_FAILURE() << "Failed to open archive in StrategyFragmentationTest::build";
+            return 0;
+        }
         block_allocator *alloc = archive->allocator;
 
         // Layout: [hole300][sent1][hole100][sent2][hole200][sent3]

--- a/tests/src/test_allocator_strategies.cpp
+++ b/tests/src/test_allocator_strategies.cpp
@@ -1,0 +1,421 @@
+/**
+ * @file test_allocator_strategies.cpp
+ * @brief Behavioural comparison of allocation strategies.
+ *
+ * Covers gaps identified during review:
+ *  - Actual fragmentation outcome differences between BEST_FIT / FIRST_FIT /
+ *    WORST_FIT / NEXT_FIT under controlled scenarios.
+ *  - BEST_FIT leaving smaller leftover fragments than FIRST_FIT.
+ *  - WORST_FIT leaving larger leftover fragments (helps future large allocs).
+ *  - NEXT_FIT continuing from last position rather than always from head.
+ *  - Strategy state persistence: allocator survives save/reload with the
+ *    same strategy.
+ *  - Maintenance auto-trigger verified with fragmentation threshold.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <vector>
+
+#include "compio/allocator.hpp"
+#include "compio/compio_file.hpp"
+
+#include "test_util.hpp"
+
+using namespace compio;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+static compio_archive *open_archive_with_strategy(const char *fn,
+                                                   compio_allocation_strategy s,
+                                                   uint8_t frag_threshold = 100) {
+    compio_config cfg;
+    compio_build_default_config(&cfg);
+    cfg.allocation_strategy   = s;
+    cfg.fragmentation_threshold = frag_threshold;
+    cfg.fill_holes_with_zeros = false;
+    return compio_open_archive(fn, "w+", &cfg);
+}
+
+// Build a specific fragmented layout:
+//   Allocate slots of size `slot_size`, deallocate the even-indexed ones.
+//   Returns the offsets of the remaining (odd-indexed) live blocks.
+static std::vector<uint64_t> make_fragmented(block_allocator *alloc,
+                                              int n_slots, uint64_t slot_size) {
+    std::vector<uint64_t> offsets(n_slots);
+    for (int i = 0; i < n_slots; ++i)
+        offsets[i] = alloc->allocate(slot_size);
+
+    std::vector<uint64_t> live;
+    for (int i = 0; i < n_slots; ++i) {
+        if (i % 2 == 0)
+            alloc->deallocate(offsets[i], slot_size);
+        else
+            live.push_back(offsets[i]);
+    }
+    return live;
+}
+
+// ---------------------------------------------------------------------------
+// StrategyFragmentationTest
+// Verify that BEST_FIT wastes less residual space than FIRST_FIT when
+// allocating into a fragmented free list that has holes of varying sizes.
+// ---------------------------------------------------------------------------
+class StrategyFragmentationTest : public ::testing::Test {
+protected:
+    char fn[256];
+    compio_archive *archive = nullptr;
+
+    void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
+
+    void TearDown() override {
+        if (archive) compio_close_archive(archive);
+        remove(fn);
+    }
+};
+
+// Scenario: free holes of sizes 300, 100, 200 (NOT adjacent — separated by live sentinels).
+// Allocating 150 bytes:
+//   FIRST_FIT → picks first hole ≥ 150, which is 300 (lowest offset).
+//   BEST_FIT  → picks smallest hole ≥ 150, which is 200.
+// Their offsets must differ.
+TEST_F(StrategyFragmentationTest, BestFitPreservesLargeHoles) {
+    auto build = [&](compio_allocation_strategy s) -> uint64_t {
+        if (archive) compio_close_archive(archive);
+        archive = open_archive_with_strategy(fn, s);
+        EXPECT_NE(archive, nullptr);
+        block_allocator *alloc = archive->allocator;
+
+        // Layout: [hole300][sent1][hole100][sent2][hole200][sent3]
+        // Live sentinels between holes prevent merging on deallocation.
+        uint64_t h1   = alloc->allocate(300);
+        uint64_t sent1 = alloc->allocate(64);  (void)sent1; // live
+        uint64_t h2   = alloc->allocate(100);
+        uint64_t sent2 = alloc->allocate(64);  (void)sent2; // live
+        uint64_t h3   = alloc->allocate(200);
+        alloc->allocate(64); // trailing sentinel
+
+        alloc->deallocate(h1, 300);
+        alloc->deallocate(h2, 100);
+        alloc->deallocate(h3, 200);
+
+        // Allocate 150: FIRST_FIT takes h1 (lowest offset, 300 bytes).
+        //               BEST_FIT  takes h3 (smallest sufficient, 200 bytes).
+        return alloc->allocate(150);
+    };
+
+    uint64_t ff_off = build(COMPIO_ALLOC_FIRST_FIT);
+    uint64_t bf_off = build(COMPIO_ALLOC_BEST_FIT);
+
+    EXPECT_NE(ff_off, bf_off)
+        << "FIRST_FIT and BEST_FIT should pick different holes for a 150-byte alloc "
+           "when holes of 300, 100, 200 bytes exist (separated by live blocks)";
+}
+
+// WORST_FIT should pick the largest available hole.
+TEST_F(StrategyFragmentationTest, WorstFitPicksLargestHole) {
+    archive = open_archive_with_strategy(fn, COMPIO_ALLOC_WORST_FIT);
+    ASSERT_NE(archive, nullptr);
+    block_allocator *alloc = archive->allocator;
+
+    // Layout: [small100][sentinel][large400][sentinel]
+    uint64_t small_hole = alloc->allocate(100);
+    alloc->allocate(64); // live sentinel — prevents merging
+    uint64_t large_hole = alloc->allocate(400);
+    alloc->allocate(64); // trailing sentinel
+
+    alloc->deallocate(small_hole, 100);
+    alloc->deallocate(large_hole, 400);
+
+    // WORST_FIT should pick large_hole (400 bytes) for a 50-byte request.
+    uint64_t off = alloc->allocate(50);
+    EXPECT_NE(off, UINT64_MAX);
+
+    EXPECT_EQ(off, large_hole)
+        << "WORST_FIT should allocate from the largest (400-byte) hole, not the 100-byte one";
+}
+
+// BEST_FIT should pick the smallest sufficient hole.
+TEST_F(StrategyFragmentationTest, BestFitPicksSmallestSufficientHole) {
+    archive = open_archive_with_strategy(fn, COMPIO_ALLOC_BEST_FIT);
+    ASSERT_NE(archive, nullptr);
+    block_allocator *alloc = archive->allocator;
+
+    uint64_t exact_hole   = alloc->allocate(200);
+    uint64_t larger_hole  = alloc->allocate(400);
+    alloc->allocate(64); // sentinel
+
+    alloc->deallocate(exact_hole,  200);
+    alloc->deallocate(larger_hole, 400);
+
+    // BEST_FIT should pick exact_hole (200) for a 200-byte request.
+    uint64_t off = alloc->allocate(200);
+    EXPECT_EQ(off, exact_hole)
+        << "BEST_FIT should pick the 200-byte hole (exact fit) over the 400-byte hole";
+}
+
+// ---------------------------------------------------------------------------
+// NextFitTest
+// NEXT_FIT should continue searching from the last allocation point, not
+// always from the head. This means the second allocation goes into the hole
+// immediately after the first one (within the same traversal).
+// ---------------------------------------------------------------------------
+class NextFitTest : public ::testing::Test {
+protected:
+    char fn[256];
+    compio_archive *archive = nullptr;
+
+    void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
+
+    void TearDown() override {
+        if (archive) compio_close_archive(archive);
+        remove(fn);
+    }
+};
+
+TEST_F(NextFitTest, SubsequentAllocationsAdvanceInFile) {
+    archive = open_archive_with_strategy(fn, COMPIO_ALLOC_NEXT_FIT);
+    ASSERT_NE(archive, nullptr);
+    block_allocator *alloc = archive->allocator;
+
+    // Three consecutive allocations; each must have a strictly greater offset
+    // than the previous (NEXT_FIT starts after the last allocation point).
+    uint64_t a = alloc->allocate(64);
+    uint64_t b = alloc->allocate(64);
+    uint64_t c = alloc->allocate(64);
+
+    ASSERT_NE(a, UINT64_MAX);
+    ASSERT_NE(b, UINT64_MAX);
+    ASSERT_NE(c, UINT64_MAX);
+
+    EXPECT_LT(a, b) << "NEXT_FIT: b should be after a";
+    EXPECT_LT(b, c) << "NEXT_FIT: c should be after b";
+}
+
+// NEXT_FIT wraps around the free list when there is no space after the cursor.
+// Verify that after freeing the first block and exhausting space after the
+// cursor, NEXT_FIT wraps and reuses the freed head block.
+TEST_F(NextFitTest, DoesNotWrapUnnecessarily) {
+    archive = open_archive_with_strategy(fn, COMPIO_ALLOC_NEXT_FIT);
+    ASSERT_NE(archive, nullptr);
+    block_allocator *alloc = archive->allocator;
+
+    uint64_t a = alloc->allocate(64);
+    uint64_t b = alloc->allocate(64);
+    uint64_t c = alloc->allocate(64);
+    ASSERT_NE(a, UINT64_MAX);
+    ASSERT_NE(b, UINT64_MAX);
+    ASSERT_NE(c, UINT64_MAX);
+
+    // Free a (creates a hole near the head).
+    alloc->deallocate(a, 64);
+
+    // NEXT_FIT starts searching after c. The file may grow OR wrap around.
+    // Either way, the allocation must succeed.
+    uint64_t d = alloc->allocate(64);
+    ASSERT_NE(d, UINT64_MAX) << "NEXT_FIT must find space (either via wrap or file growth)";
+
+    // d must not overlap with the live blocks b and c.
+    EXPECT_FALSE(d < b + 64 && d + 64 > b) << "d overlaps with b";
+    EXPECT_FALSE(d < c + 64 && d + 64 > c) << "d overlaps with c";
+}
+
+// ---------------------------------------------------------------------------
+// StrategyStatisticsTest
+// Verify fragmentation stats fields are self-consistent after a known layout.
+// ---------------------------------------------------------------------------
+class StrategyStatisticsTest : public ::testing::Test {
+protected:
+    char fn[256];
+    compio_archive *archive = nullptr;
+
+    void SetUp() override {
+        generate_tmp_fn(fn, sizeof(fn));
+        archive = open_archive_with_strategy(fn, COMPIO_ALLOC_FIRST_FIT, 100);
+        ASSERT_NE(archive, nullptr);
+    }
+
+    void TearDown() override {
+        if (archive) compio_close_archive(archive);
+        remove(fn);
+    }
+};
+
+TEST_F(StrategyStatisticsTest, StatsFieldsConsistency) {
+    block_allocator *alloc = archive->allocator;
+
+    // Create 4 non-adjacent free holes of sizes 100, 200, 50, 300.
+    // Live sentinel blocks between holes prevent merging on deallocation.
+    uint64_t h1 = alloc->allocate(100);
+    alloc->allocate(32);  // live sentinel
+    uint64_t h2 = alloc->allocate(200);
+    alloc->allocate(32);  // live sentinel
+    uint64_t h3 = alloc->allocate(50);
+    alloc->allocate(32);  // live sentinel
+    uint64_t h4 = alloc->allocate(300);
+    alloc->allocate(32);  // trailing sentinel
+
+    alloc->deallocate(h1, 100);
+    alloc->deallocate(h2, 200);
+    alloc->deallocate(h3, 50);
+    alloc->deallocate(h4, 300);
+
+    compio_fragmentation_stats stats{};
+    ASSERT_EQ(compio_get_fragmentation_stats(archive, &stats), COMPIO_SUCCESS);
+
+    EXPECT_EQ(stats.num_free_regions, 4u);
+    EXPECT_EQ(stats.total_free_bytes, 100u + 200u + 50u + 300u);
+    EXPECT_EQ(stats.largest_free_region, 300u);
+    EXPECT_EQ(stats.smallest_free_region, 50u);
+
+    double expected_avg = (100.0 + 200.0 + 50.0 + 300.0) / 4.0;
+    EXPECT_NEAR(stats.avg_free_region_size, expected_avg, 1.0);
+
+    EXPECT_GE(stats.fragmentation_percent, 0u);
+    EXPECT_LE(stats.fragmentation_percent, 100u);
+}
+
+TEST_F(StrategyStatisticsTest, StatsAfterCoalescing) {
+    block_allocator *alloc = archive->allocator;
+
+    // Allocate three adjacent blocks and free them all → should merge.
+    uint64_t a = alloc->allocate(128);
+    uint64_t b = alloc->allocate(128);
+    uint64_t c = alloc->allocate(128);
+    alloc->allocate(64); // sentinel to prevent merging with file end
+
+    alloc->deallocate(a, 128);
+    alloc->deallocate(b, 128);
+    alloc->deallocate(c, 128);
+
+    compio_fragmentation_stats stats{};
+    ASSERT_EQ(compio_get_fragmentation_stats(archive, &stats), COMPIO_SUCCESS);
+
+    // After freeing three adjacent blocks the allocator merges them.
+    EXPECT_EQ(stats.num_free_regions, 1u) << "Three adjacent free blocks should merge into one";
+    EXPECT_EQ(stats.total_free_bytes, 384u);
+    EXPECT_EQ(stats.largest_free_region, 384u);
+    EXPECT_EQ(stats.smallest_free_region, 384u);
+    EXPECT_EQ(stats.fragmentation_percent, 0u) << "Single free region → 0% fragmentation";
+}
+
+TEST_F(StrategyStatisticsTest, NullArchiveReturnsError) {
+    compio_fragmentation_stats stats{};
+    EXPECT_EQ(compio_get_fragmentation_stats(nullptr, &stats), COMPIO_ERROR);
+}
+
+// ---------------------------------------------------------------------------
+// MaintenanceAutoTriggerTest
+// Verify that the allocator actually runs defragmentation when fragmentation
+// exceeds the configured threshold (auto-maintenance path).
+// ---------------------------------------------------------------------------
+class MaintenanceAutoTriggerTest : public ::testing::Test {
+protected:
+    char fn[256];
+
+    void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
+    void TearDown() override { remove(fn); }
+};
+
+TEST_F(MaintenanceAutoTriggerTest, MaintenanceTriggersWhenThresholdExceeded) {
+    // Low threshold so maintenance fires early.
+    compio_config cfg;
+    compio_build_default_config(&cfg);
+    cfg.fragmentation_threshold = 1;
+    cfg.fill_holes_with_zeros   = false;
+
+    compio_archive *ar = compio_open_archive(fn, "w+", &cfg);
+    ASSERT_NE(ar, nullptr);
+    block_allocator *alloc = ar->allocator;
+
+    // Create significant fragmentation.
+    make_fragmented(alloc, 20, 128);
+
+    uint8_t frag_before = alloc->get_fragmentation();
+
+    // maintenance() should trigger defrag because threshold=1 is exceeded.
+    alloc->maintenance();
+
+    uint8_t frag_after = alloc->get_fragmentation();
+
+    // Fragmentation should drop (or stay at 0) after maintenance.
+    EXPECT_LE(frag_after, frag_before)
+        << "maintenance() should reduce fragmentation when threshold is exceeded";
+
+    compio_close_archive(ar);
+}
+
+TEST_F(MaintenanceAutoTriggerTest, MaintenanceDoesNotTriggerBelowThreshold) {
+    // Very high threshold — maintenance should NOT defragment.
+    compio_config cfg;
+    compio_build_default_config(&cfg);
+    cfg.fragmentation_threshold = 99;
+    cfg.fill_holes_with_zeros   = false;
+
+    compio_archive *ar = compio_open_archive(fn, "w+", &cfg);
+    ASSERT_NE(ar, nullptr);
+    block_allocator *alloc = ar->allocator;
+
+    // Mild fragmentation — likely below threshold=99.
+    make_fragmented(alloc, 6, 128);
+
+    uint8_t frag_before = alloc->get_fragmentation();
+
+    alloc->maintenance();
+
+    uint8_t frag_after = alloc->get_fragmentation();
+
+    // With threshold=99, fragmentation below 99% should NOT trigger defrag.
+    EXPECT_EQ(frag_after, frag_before)
+        << "maintenance() should not defragment when fragmentation is below threshold";
+
+    compio_close_archive(ar);
+}
+
+// ---------------------------------------------------------------------------
+// StatePersistencePerStrategyTest
+// Allocator state survives save/reload regardless of strategy.
+// ---------------------------------------------------------------------------
+class StatePersistencePerStrategyTest : public ::testing::Test {
+protected:
+    char fn[256];
+
+    void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
+    void TearDown() override { remove(fn); }
+};
+
+TEST_F(StatePersistencePerStrategyTest, BestFitStateRoundTrip) {
+    uint64_t hole_offset = UINT64_MAX;
+    const uint64_t hole_size = 200;
+
+    {
+        compio_config cfg;
+        compio_build_default_config(&cfg);
+        cfg.allocation_strategy = COMPIO_ALLOC_BEST_FIT;
+        compio_archive *ar = compio_open_archive(fn, "w+", &cfg);
+        ASSERT_NE(ar, nullptr);
+
+        hole_offset = ar->allocator->allocate(hole_size);
+        ar->allocator->allocate(64); // sentinel
+        ar->allocator->deallocate(hole_offset, hole_size);
+
+        compio_close_archive(ar);
+    }
+
+    {
+        compio_config cfg;
+        compio_build_default_config(&cfg);
+        cfg.allocation_strategy = COMPIO_ALLOC_BEST_FIT;
+        compio_archive *ar = compio_open_archive(fn, "r+", &cfg);
+        ASSERT_NE(ar, nullptr);
+
+        // Reuse of the freed hole should still be possible.
+        uint64_t reused = ar->allocator->allocate(hole_size);
+        EXPECT_EQ(reused, hole_offset)
+            << "BEST_FIT: freed hole should be reused after reload";
+
+        compio_close_archive(ar);
+    }
+}

--- a/tests/src/test_allocator_strategies.cpp
+++ b/tests/src/test_allocator_strategies.cpp
@@ -45,8 +45,11 @@ static compio_archive *open_archive_with_strategy(const char *fn,
 static std::vector<uint64_t> make_fragmented(block_allocator *alloc,
                                               int n_slots, uint64_t slot_size) {
     std::vector<uint64_t> offsets(n_slots);
-    for (int i = 0; i < n_slots; ++i)
+    for (int i = 0; i < n_slots; ++i) {
         offsets[i] = alloc->allocate(slot_size);
+        EXPECT_NE(offsets[i], static_cast<uint64_t>(UINT64_MAX))
+            << "allocate() failed at slot " << i << "; fragmented layout not created";
+    }
 
     std::vector<uint64_t> live;
     for (int i = 0; i < n_slots; ++i) {
@@ -148,8 +151,9 @@ TEST_F(StrategyFragmentationTest, BestFitPicksSmallestSufficientHole) {
     block_allocator *alloc = archive->allocator;
 
     uint64_t exact_hole   = alloc->allocate(200);
+    alloc->allocate(64); // live sentinel — prevents exact_hole + larger_hole from merging
     uint64_t larger_hole  = alloc->allocate(400);
-    alloc->allocate(64); // sentinel
+    alloc->allocate(64); // trailing sentinel
 
     alloc->deallocate(exact_hole,  200);
     alloc->deallocate(larger_hole, 400);
@@ -179,29 +183,57 @@ protected:
     }
 };
 
-TEST_F(NextFitTest, SubsequentAllocationsAdvanceInFile) {
+// NEXT_FIT continues from the last allocation point rather than restarting
+// from the head. After consuming a hole, the cursor sits at the next hole.
+// Restoring the first hole then allocating again must pick the second hole
+// (cursor has advanced past the first), not the first (which FIRST_FIT would pick).
+TEST_F(NextFitTest, CursorAdvancesPastPreviousAllocation) {
     archive = open_archive_with_strategy(fn, COMPIO_ALLOC_NEXT_FIT);
     ASSERT_NE(archive, nullptr);
     block_allocator *alloc = archive->allocator;
 
-    // Three consecutive allocations; each must have a strictly greater offset
-    // than the previous (NEXT_FIT starts after the last allocation point).
-    uint64_t a = alloc->allocate(64);
-    uint64_t b = alloc->allocate(64);
-    uint64_t c = alloc->allocate(64);
+    // Create three non-adjacent free holes with live sentinels between them
+    // to prevent merging on deallocation.
+    uint64_t h1 = alloc->allocate(64);
+    alloc->allocate(32); // live sentinel
+    uint64_t h2 = alloc->allocate(64);
+    alloc->allocate(32); // live sentinel
+    uint64_t h3 = alloc->allocate(64);
+    alloc->allocate(32); // trailing sentinel
 
-    ASSERT_NE(a, UINT64_MAX);
-    ASSERT_NE(b, UINT64_MAX);
-    ASSERT_NE(c, UINT64_MAX);
+    ASSERT_NE(h1, UINT64_MAX);
+    ASSERT_NE(h2, UINT64_MAX);
+    ASSERT_NE(h3, UINT64_MAX);
 
-    EXPECT_LT(a, b) << "NEXT_FIT: b should be after a";
-    EXPECT_LT(b, c) << "NEXT_FIT: c should be after b";
+    // Free h1 first: it becomes the initial free list head, so last_alloc_
+    // is initialised to h1's block.
+    alloc->deallocate(h1, 64);
+    alloc->deallocate(h2, 64);
+    alloc->deallocate(h3, 64);
+    // Free list (offset-ordered): h1 → h2 → h3. Cursor = h1.
+
+    // First alloc: cursor is at h1 → picks h1. Cursor advances to h2.
+    uint64_t alloc1 = alloc->allocate(64);
+    ASSERT_NE(alloc1, UINT64_MAX);
+    EXPECT_EQ(alloc1, h1) << "NEXT_FIT first alloc should pick h1 (cursor starts there)";
+
+    // Restore h1. Free list: h1 → h2 → h3. Cursor is still at h2.
+    alloc->deallocate(h1, 64);
+
+    // Second alloc: NEXT_FIT starts at h2 (cursor has advanced past h1) and
+    // picks h2. FIRST_FIT would restart from the head and pick h1 instead.
+    uint64_t alloc2 = alloc->allocate(64);
+    ASSERT_NE(alloc2, UINT64_MAX);
+    EXPECT_EQ(alloc2, h2)
+        << "NEXT_FIT should pick h2 (cursor is past h1), not h1 (which FIRST_FIT would pick)";
+    EXPECT_NE(alloc2, h1)
+        << "NEXT_FIT must not restart from head like FIRST_FIT would";
 }
 
-// NEXT_FIT wraps around the free list when there is no space after the cursor.
-// Verify that after freeing the first block and exhausting space after the
-// cursor, NEXT_FIT wraps and reuses the freed head block.
-TEST_F(NextFitTest, DoesNotWrapUnnecessarily) {
+// NEXT_FIT wraps around the free list when the cursor is the only free entry.
+// When 'a' is freed it becomes the sole free block and last_alloc_ is
+// initialised to it; the next allocation reuses 'a' rather than extending the file.
+TEST_F(NextFitTest, ReusesFreedBlockAfterCursorWrap) {
     archive = open_archive_with_strategy(fn, COMPIO_ALLOC_NEXT_FIT);
     ASSERT_NE(archive, nullptr);
     block_allocator *alloc = archive->allocator;
@@ -213,15 +245,17 @@ TEST_F(NextFitTest, DoesNotWrapUnnecessarily) {
     ASSERT_NE(b, UINT64_MAX);
     ASSERT_NE(c, UINT64_MAX);
 
-    // Free a (creates a hole near the head).
+    // Free 'a': it becomes the first (and only) entry in the free list, so
+    // last_alloc_ is initialised to a's free block.
     alloc->deallocate(a, 64);
 
-    // NEXT_FIT starts searching after c. The file may grow OR wrap around.
-    // Either way, the allocation must succeed.
+    // NEXT_FIT starts at last_alloc_ (== a) and finds it immediately;
+    // the freed block is reused rather than the file being extended.
     uint64_t d = alloc->allocate(64);
-    ASSERT_NE(d, UINT64_MAX) << "NEXT_FIT must find space (either via wrap or file growth)";
+    ASSERT_NE(d, UINT64_MAX) << "NEXT_FIT must find space";
+    EXPECT_EQ(d, a) << "NEXT_FIT should reuse the freed block 'a'";
 
-    // d must not overlap with the live blocks b and c.
+    // 'd' must not overlap the still-live blocks b and c.
     EXPECT_FALSE(d < b + 64 && d + 64 > b) << "d overlaps with b";
     EXPECT_FALSE(d < c + 64 && d + 64 > c) << "d overlaps with c";
 }

--- a/tests/src/test_defragmentation_advanced.cpp
+++ b/tests/src/test_defragmentation_advanced.cpp
@@ -345,8 +345,13 @@ TEST_F(MultiBlockFileDefragTest, LargeFileIntactAfterDefragWithNeighbours) {
     compio_close_file(n1);
     compio_close_file(n2);
 
-    compio_remove_file(ar, "n1");
+    // Ensure allocations are fully persisted so removal actually frees blocks.
+    compio_close_archive(ar);
+    ar = compio_open_archive(fn, "r+", &cfg);
+    ASSERT_NE(ar, nullptr);
 
+    int rm_res = compio_remove_file(ar, "n1");
+    ASSERT_EQ(rm_res, COMPIO_SUCCESS);
     ASSERT_EQ(compio_defragment(ar), COMPIO_SUCCESS);
 
     compio_file *big2 = compio_open_file("big", ar);

--- a/tests/src/test_defragmentation_advanced.cpp
+++ b/tests/src/test_defragmentation_advanced.cpp
@@ -92,6 +92,10 @@ TEST_F(StatsAfterDefragTest, ZeroFreeRegionsAfterFullDefrag) {
         compio_close_file(f);
     }
 
+    // Flush caches so blocks get real on-disk addresses before removal.
+    // compio_remove_file skips deallocation for blocks with addr==0.
+    compio_flush(archive);
+
     compio_remove_file(archive, "f1");
     compio_remove_file(archive, "f3");
 
@@ -232,6 +236,8 @@ TEST_F(IncompressibleDataTest, RandomDataIntactAfterDefrag) {
     write_file("r2", d2);
 
     // Create fragmentation by erasing the middle file.
+    // Flush first so blocks have real addresses and deallocation actually occurs.
+    compio_flush(ar);
     compio_remove_file(ar, "r1");
 
     ASSERT_EQ(compio_defragment(ar), COMPIO_SUCCESS);
@@ -269,22 +275,34 @@ TEST_F(ForceDefragTest, ForcedDefragRunsRegardlessOfThreshold) {
     compio_archive *ar = open_defrag_archive(fn, 99);
     ASSERT_NE(ar, nullptr);
 
-    const std::size_t SZ = 512;
-    std::vector<uint8_t> payload(SZ, 0x77);
+    // Use incompressible random data of different sizes for "a" and "c" so
+    // the two resulting free regions have different sizes, giving variance > 0
+    // and thus fragmentation_percent > 0. File "b" is a live sentinel between them.
+    auto data_a = make_random_bytes(256, 7);
+    auto data_b = make_random_bytes(256, 8);  // sentinel — stays live
+    auto data_c = make_random_bytes(512, 9);  // different size → unequal free regions
 
-    compio_file *fa = compio_open_file("a", ar);
-    ASSERT_NE(fa, nullptr);
-    compio_write(payload.data(), SZ, fa);
-    compio_close_file(fa);
+    auto write_file = [&](const char *name, const std::vector<uint8_t> &data) {
+        compio_file *f = compio_open_file(name, ar);
+        ASSERT_NE(f, nullptr);
+        compio_write(data.data(), data.size(), f);
+        compio_close_file(f);
+    };
 
-    compio_file *fb = compio_open_file("b", ar);
-    ASSERT_NE(fb, nullptr);
-    compio_write(payload.data(), SZ, fb);
-    compio_close_file(fb);
+    write_file("a", data_a);
+    write_file("b", data_b);
+    write_file("c", data_c);
 
+    // Flush so blocks have real on-disk addresses; without this,
+    // compio_remove_file skips deallocation and fragmentation stays 0.
+    compio_flush(ar);
     compio_remove_file(ar, "a");
+    compio_remove_file(ar, "c");
 
     uint8_t frag_before = ar->allocator->get_fragmentation();
+    EXPECT_GT(frag_before, 0u)
+        << "Fragmentation must be non-zero: 'a' and 'c' create two differently-sized "
+           "free regions around 'b', giving non-zero variance (precondition for this test)";
 
     // maintenance() should NOT defrag (threshold not exceeded).
     ar->allocator->maintenance();
@@ -345,13 +363,12 @@ TEST_F(MultiBlockFileDefragTest, LargeFileIntactAfterDefragWithNeighbours) {
     compio_close_file(n1);
     compio_close_file(n2);
 
-    // Ensure allocations are fully persisted so removal actually frees blocks.
-    compio_close_archive(ar);
-    ar = compio_open_archive(fn, "r+", &cfg);
-    ASSERT_NE(ar, nullptr);
+    // Flush cached blocks so every block has a real on-disk address.
+    // This ensures compio_remove_file actually deallocates n1's blocks,
+    // creating genuine fragmentation for defrag to compact.
+    compio_flush(ar);
 
-    int rm_res = compio_remove_file(ar, "n1");
-    ASSERT_EQ(rm_res, COMPIO_SUCCESS);
+    ASSERT_EQ(compio_remove_file(ar, "n1"), COMPIO_SUCCESS);
     ASSERT_EQ(compio_defragment(ar), COMPIO_SUCCESS);
 
     compio_file *big2 = compio_open_file("big", ar);
@@ -394,6 +411,11 @@ TEST_F(RepeatedCycleTest, TenCyclesDataIntact) {
             compio_write(data.data(), SZ, f);
             compio_close_file(f);
         }
+
+        // Flush cached blocks to disk before removing files, so that
+        // compio_remove_file can deallocate real on-disk addresses and
+        // defragementation actually moves data this cycle.
+        compio_flush(ar);
 
         // Erase alternate files.
         for (int i = 0; i < FILES_PER_CYCLE; i += 2) {

--- a/tests/src/test_defragmentation_advanced.cpp
+++ b/tests/src/test_defragmentation_advanced.cpp
@@ -1,0 +1,414 @@
+/**
+ * @file test_defragmentation_advanced.cpp
+ * @brief Advanced defragmentation tests covering gaps identified in review:
+ *
+ *  - Fragmentation stats API accuracy (num_free_regions, total_free_bytes,
+ *    largest/smallest region, avg) after defragmentation.
+ *  - Verify data blocks actually move (file shrinks in bytes after defrag).
+ *  - Data integrity with incompressible (random) content.
+ *  - Defragmentation on an archive with a single multi-block file.
+ *  - Repeated write/erase/defrag cycles leave a healthy archive.
+ *  - force_defragmentation() vs maintenance() — forced path works even when
+ *    fragmentation is below the configured threshold.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "compio/allocator.hpp"
+#include "compio/compio_file.hpp"
+
+#include "test_util.hpp"
+
+using namespace compio;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+static compio_archive *open_defrag_archive(const char *fn,
+                                            uint8_t threshold = 100,
+                                            bool zeros = false) {
+    compio_config cfg;
+    compio_build_default_config(&cfg);
+    cfg.fragmentation_threshold = threshold;
+    cfg.fill_holes_with_zeros   = zeros;
+    return compio_open_archive(fn, "w+", &cfg);
+}
+
+static std::vector<uint8_t> make_random_bytes(std::size_t n, uint32_t seed = 42) {
+    std::mt19937 rng(seed);
+    std::vector<uint8_t> v(n);
+    for (auto &b : v) b = static_cast<uint8_t>(rng() & 0xFF);
+    return v;
+}
+
+static std::vector<uint8_t> read_file_bytes(compio_file *f, std::size_t size) {
+    std::vector<uint8_t> buf(size);
+    compio_seek(f, 0, COMPIO_SEEK_SET);
+    compio_read(buf.data(), size, f);
+    return buf;
+}
+
+// ---------------------------------------------------------------------------
+// StatsAfterDefragTest
+// Fragmentation stats should show 0 free regions and 0% fragmentation after
+// a full defragmentation of an otherwise empty archive.
+// ---------------------------------------------------------------------------
+class StatsAfterDefragTest : public ::testing::Test {
+protected:
+    char fn[256];
+    compio_archive *archive = nullptr;
+
+    void SetUp() override {
+        generate_tmp_fn(fn, sizeof(fn));
+        archive = open_defrag_archive(fn, 100 /*disable auto*/);
+        ASSERT_NE(archive, nullptr);
+    }
+
+    void TearDown() override {
+        if (archive) compio_close_archive(archive);
+        remove(fn);
+    }
+};
+
+TEST_F(StatsAfterDefragTest, ZeroFreeRegionsAfterFullDefrag) {
+    // Write 4 files, erase 2, defrag.
+    const int N = 4;
+    const std::size_t SZ = 512;
+    std::vector<uint8_t> payload(SZ, 0xAB);
+
+    for (int i = 0; i < N; ++i) {
+        char name[32];
+        snprintf(name, sizeof(name), "f%d", i);
+        compio_file *f = compio_open_file(name, archive);
+        ASSERT_NE(f, nullptr);
+        compio_write(payload.data(), SZ, f);
+        compio_close_file(f);
+    }
+
+    compio_remove_file(archive, "f1");
+    compio_remove_file(archive, "f3");
+
+    ASSERT_EQ(compio_defragment(archive), COMPIO_SUCCESS);
+
+    compio_fragmentation_stats stats{};
+    ASSERT_EQ(compio_get_fragmentation_stats(archive, &stats), COMPIO_SUCCESS);
+
+    EXPECT_EQ(stats.fragmentation_percent, 0u)
+        << "After defragmentation, fragmentation should be 0%";
+    EXPECT_EQ(stats.total_free_bytes, 0u)
+        << "After compacting, there should be no free bytes";
+}
+
+TEST_F(StatsAfterDefragTest, TotalFreeMatchesEraseBeforeDefrag) {
+    // Use enough data to guarantee multiple storage blocks are allocated,
+    // so that erasing leaves measurable free space tracked in the allocator.
+    const std::size_t SZ = 8192; // 8 KB > default block_size (4 KB)
+    // Use incompressible random data so blocks occupy real physical space on disk.
+    auto payload = make_random_bytes(SZ, 77);
+
+    compio_file *f1 = compio_open_file("a", archive);
+    compio_file *f2 = compio_open_file("b", archive);
+    ASSERT_NE(f1, nullptr);
+    ASSERT_NE(f2, nullptr);
+    compio_write(payload.data(), SZ, f1);
+    compio_write(payload.data(), SZ, f2);
+    compio_close_file(f1);
+    compio_close_file(f2);
+
+    // Flush the block cache so that blocks are written to disk with real
+    // physical addresses. Without this, blocks stay in the cache with addr=0
+    // and compio_remove_file skips deallocation for them.
+    compio_flush(archive);
+
+    compio_remove_file(archive, "a");
+
+    compio_fragmentation_stats before{};
+    ASSERT_EQ(compio_get_fragmentation_stats(archive, &before), COMPIO_SUCCESS);
+    EXPECT_GT(before.total_free_bytes, 0u)
+        << "Erasing an 8 KB file should add free bytes to the allocator";
+
+    ASSERT_EQ(compio_defragment(archive), COMPIO_SUCCESS);
+
+    compio_fragmentation_stats after{};
+    ASSERT_EQ(compio_get_fragmentation_stats(archive, &after), COMPIO_SUCCESS);
+    EXPECT_EQ(after.total_free_bytes, 0u)
+        << "Defrag should reclaim all free bytes";
+}
+
+// ---------------------------------------------------------------------------
+// FileShrinkTest
+// After defragmenting a fragmented archive the physical file size reported in
+// the header must be smaller than before (data blocks were compacted).
+// ---------------------------------------------------------------------------
+class FileShrinkTest : public ::testing::Test {
+protected:
+    char fn[256];
+
+    void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
+    void TearDown() override { remove(fn); }
+};
+
+TEST_F(FileShrinkTest, HeaderFileSizeShrinks) {
+    compio_archive *ar = open_defrag_archive(fn);
+    ASSERT_NE(ar, nullptr);
+
+    // Use incompressible random data so that each file occupies significant
+    // physical space. Highly compressible content (e.g. 0xCC) shrinks to
+    // ~20 bytes per block, making the before/after difference negligible.
+    const std::size_t SZ = 4096;
+
+    for (int i = 0; i < 6; ++i) {
+        auto payload = make_random_bytes(SZ, static_cast<uint32_t>(i + 1));
+        char name[32];
+        snprintf(name, sizeof(name), "file%d", i);
+        compio_file *f = compio_open_file(name, ar);
+        ASSERT_NE(f, nullptr);
+        compio_write(payload.data(), SZ, f);
+        compio_close_file(f);
+    }
+
+    // Force all cached blocks to disk so that blocks get real physical
+    // addresses before we remove files. Without this, file_size before
+    // defrag reflects an unwritten state and defrag would grow it.
+    compio_flush(ar);
+
+    compio_remove_file(ar, "file1");
+    compio_remove_file(ar, "file3");
+    compio_remove_file(ar, "file5");
+
+    // Measure after erasing (free space now exists) but before defrag.
+    uint64_t size_before_defrag = ar->header->file_size;
+
+    ASSERT_EQ(compio_defragment(ar), COMPIO_SUCCESS);
+
+    uint64_t size_after_defrag = ar->header->file_size;
+
+    EXPECT_LT(size_after_defrag, size_before_defrag)
+        << "Defragmenting should reduce the logical file size after erasing 3 of 6 files";
+
+    compio_close_archive(ar);
+}
+
+// ---------------------------------------------------------------------------
+// IncompressibleDataTest
+// Defragmentation must preserve data integrity for truly incompressible
+// (random) content, not just compressible patterns.
+// ---------------------------------------------------------------------------
+class IncompressibleDataTest : public ::testing::Test {
+protected:
+    char fn[256];
+
+    void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
+    void TearDown() override { remove(fn); }
+};
+
+TEST_F(IncompressibleDataTest, RandomDataIntactAfterDefrag) {
+    compio_archive *ar = open_defrag_archive(fn);
+    ASSERT_NE(ar, nullptr);
+
+    const std::size_t SZ = 2048;
+
+    // Write three files with distinct random content.
+    auto d0 = make_random_bytes(SZ, 1);
+    auto d1 = make_random_bytes(SZ, 2);
+    auto d2 = make_random_bytes(SZ, 3);
+
+    auto write_file = [&](const char *name, const std::vector<uint8_t> &data) {
+        compio_file *f = compio_open_file(name, ar);
+        ASSERT_NE(f, nullptr);
+        compio_write(data.data(), data.size(), f);
+        compio_close_file(f);
+    };
+
+    write_file("r0", d0);
+    write_file("r1", d1);
+    write_file("r2", d2);
+
+    // Create fragmentation by erasing the middle file.
+    compio_remove_file(ar, "r1");
+
+    ASSERT_EQ(compio_defragment(ar), COMPIO_SUCCESS);
+
+    // Verify remaining files.
+    auto check = [&](const char *name, const std::vector<uint8_t> &expected) {
+        compio_file *f = compio_open_file(name, ar);
+        ASSERT_NE(f, nullptr) << "Could not open " << name;
+        auto got = read_file_bytes(f, expected.size());
+        EXPECT_EQ(got, expected) << "Data mismatch in " << name;
+        compio_close_file(f);
+    };
+
+    check("r0", d0);
+    check("r2", d2);
+
+    compio_close_archive(ar);
+}
+
+// ---------------------------------------------------------------------------
+// ForceDefragTest
+// force_defragmentation() runs even when fragmentation is below the threshold
+// that would stop maintenance() from acting.
+// ---------------------------------------------------------------------------
+class ForceDefragTest : public ::testing::Test {
+protected:
+    char fn[256];
+
+    void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
+    void TearDown() override { remove(fn); }
+};
+
+TEST_F(ForceDefragTest, ForcedDefragRunsRegardlessOfThreshold) {
+    // Threshold = 99 → maintenance() will NOT auto-defrag mild fragmentation.
+    compio_archive *ar = open_defrag_archive(fn, 99);
+    ASSERT_NE(ar, nullptr);
+
+    const std::size_t SZ = 512;
+    std::vector<uint8_t> payload(SZ, 0x77);
+
+    compio_file *fa = compio_open_file("a", ar);
+    ASSERT_NE(fa, nullptr);
+    compio_write(payload.data(), SZ, fa);
+    compio_close_file(fa);
+
+    compio_file *fb = compio_open_file("b", ar);
+    ASSERT_NE(fb, nullptr);
+    compio_write(payload.data(), SZ, fb);
+    compio_close_file(fb);
+
+    compio_remove_file(ar, "a");
+
+    uint8_t frag_before = ar->allocator->get_fragmentation();
+
+    // maintenance() should NOT defrag (threshold not exceeded).
+    ar->allocator->maintenance();
+    uint8_t frag_maintenance = ar->allocator->get_fragmentation();
+    EXPECT_EQ(frag_maintenance, frag_before)
+        << "maintenance() should not defrag below threshold";
+
+    // force_defragmentation() MUST defrag unconditionally.
+    ar->allocator->force_defragmentation();
+    uint8_t frag_forced = ar->allocator->get_fragmentation();
+    EXPECT_EQ(frag_forced, 0u)
+        << "force_defragmentation() must always defrag";
+
+    compio_close_archive(ar);
+}
+
+// ---------------------------------------------------------------------------
+// MultiBlockFileDefragTest
+// A large file that spans many storage blocks must be fully readable after
+// defragmentation.
+// ---------------------------------------------------------------------------
+class MultiBlockFileDefragTest : public ::testing::Test {
+protected:
+    char fn[256];
+
+    void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
+    void TearDown() override { remove(fn); }
+};
+
+TEST_F(MultiBlockFileDefragTest, LargeFileIntactAfterDefragWithNeighbours) {
+    compio_config cfg;
+    compio_build_default_config(&cfg);
+    cfg.block_size            = 512;
+    cfg.block_size__minimum   = 256;
+    cfg.block_size__maximum   = 1024;
+    cfg.fragmentation_threshold = 100;
+    cfg.fill_holes_with_zeros = false;
+    compio_archive *ar = compio_open_archive(fn, "w+", &cfg);
+    ASSERT_NE(ar, nullptr);
+
+    // Large file: 16 KB (spans ~32 blocks of 512 bytes).
+    const std::size_t LARGE = 16 * 1024;
+    auto large_data = make_random_bytes(LARGE, 99);
+
+    compio_file *big = compio_open_file("big", ar);
+    ASSERT_NE(big, nullptr);
+    compio_write(large_data.data(), LARGE, big);
+    compio_close_file(big);
+
+    // Neighbour files to create real fragmentation when erased.
+    std::vector<uint8_t> small(256, 0xBB);
+    compio_file *n1 = compio_open_file("n1", ar);
+    compio_file *n2 = compio_open_file("n2", ar);
+    ASSERT_NE(n1, nullptr);
+    ASSERT_NE(n2, nullptr);
+    compio_write(small.data(), small.size(), n1);
+    compio_write(small.data(), small.size(), n2);
+    compio_close_file(n1);
+    compio_close_file(n2);
+
+    compio_remove_file(ar, "n1");
+
+    ASSERT_EQ(compio_defragment(ar), COMPIO_SUCCESS);
+
+    compio_file *big2 = compio_open_file("big", ar);
+    ASSERT_NE(big2, nullptr);
+    EXPECT_EQ(compio_get_size(big2), LARGE);
+    auto got = read_file_bytes(big2, LARGE);
+    EXPECT_EQ(got, large_data) << "16 KB file data must be intact after defrag";
+    compio_close_file(big2);
+
+    compio_close_archive(ar);
+}
+
+// ---------------------------------------------------------------------------
+// RepeatedCycleTest
+// Ten write/erase/defrag cycles should leave a stable, fully readable archive.
+// ---------------------------------------------------------------------------
+class RepeatedCycleTest : public ::testing::Test {
+protected:
+    char fn[256];
+
+    void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
+    void TearDown() override { remove(fn); }
+};
+
+TEST_F(RepeatedCycleTest, TenCyclesDataIntact) {
+    compio_archive *ar = open_defrag_archive(fn);
+    ASSERT_NE(ar, nullptr);
+
+    const std::size_t SZ = 256;
+    const int FILES_PER_CYCLE = 4;
+
+    for (int cycle = 0; cycle < 10; ++cycle) {
+        // Write FILES_PER_CYCLE files.
+        for (int i = 0; i < FILES_PER_CYCLE; ++i) {
+            char name[32];
+            snprintf(name, sizeof(name), "c%di%d", cycle, i);
+            std::vector<uint8_t> data(SZ, static_cast<uint8_t>(cycle * 10 + i));
+            compio_file *f = compio_open_file(name, ar);
+            ASSERT_NE(f, nullptr);
+            compio_write(data.data(), SZ, f);
+            compio_close_file(f);
+        }
+
+        // Erase alternate files.
+        for (int i = 0; i < FILES_PER_CYCLE; i += 2) {
+            char name[32];
+            snprintf(name, sizeof(name), "c%di%d", cycle, i);
+            compio_remove_file(ar, name);
+        }
+
+        ASSERT_EQ(compio_defragment(ar), COMPIO_SUCCESS);
+
+        // Verify surviving files.
+        for (int i = 1; i < FILES_PER_CYCLE; i += 2) {
+            char name[32];
+            snprintf(name, sizeof(name), "c%di%d", cycle, i);
+            std::vector<uint8_t> expected(SZ, static_cast<uint8_t>(cycle * 10 + i));
+            compio_file *f = compio_open_file(name, ar);
+            ASSERT_NE(f, nullptr) << "File " << name << " missing after cycle " << cycle;
+            auto got = read_file_bytes(f, SZ);
+            EXPECT_EQ(got, expected) << "Data mismatch in " << name;
+            compio_close_file(f);
+        }
+    }
+
+    compio_close_archive(ar);
+}

--- a/tests/src/test_defragmentation_advanced.cpp
+++ b/tests/src/test_defragmentation_advanced.cpp
@@ -49,7 +49,9 @@ static std::vector<uint8_t> make_random_bytes(std::size_t n, uint32_t seed = 42)
 static std::vector<uint8_t> read_file_bytes(compio_file *f, std::size_t size) {
     std::vector<uint8_t> buf(size);
     compio_seek(f, 0, COMPIO_SEEK_SET);
-    compio_read(buf.data(), size, f);
+    auto bytes_read = compio_read(buf.data(), size, f);
+    EXPECT_EQ(bytes_read, size) << "Short read in read_file_bytes: expected " << size
+                                << " bytes, got " << bytes_read;
     return buf;
 }
 


### PR DESCRIPTION
**Changes:**
- Add advanced defragmentation tests covering stats accuracy, file-size compaction, random-data integrity, forced defrag, multi-block files, and repeated cycles.
- Add allocator strategy comparison tests for FIRST/BEST/WORST/NEXT fit plus fragmentation-stats invariants, maintenance triggering, and persistence.
- Register the new test sources in `tests/CMakeLists.txt`.