### PR TITLE
feat: implement thread safety for archive operations

### DIFF
--- a/include/compio/allocator.hpp
+++ b/include/compio/allocator.hpp
@@ -375,9 +375,7 @@ public:
      * @brief Get detailed fragmentation statistics
      * @return Structure with fragmentation metrics
      */
-    [[nodiscard]] free_blocks_manager::fragmentation_stats get_fragmentation_stats() const {
-        return blocks_manager_.get_fragmentation_stats();
-    }
+    [[nodiscard]] free_blocks_manager::fragmentation_stats get_fragmentation_stats() const;
 
     /**
      * @brief Initialize allocator with archive configuration
@@ -415,14 +413,14 @@ public:
      * @param archive Target archive
      * @return True if save was successful
      */
-    bool save_state(compio_archive *archive) { return blocks_manager_.save_to_file(archive); }
+    bool save_state(compio_archive *archive);
 
     /**
      * @brief Load allocator state from archive
      * @param archive Source archive
      * @return True if load was successful
      */
-    bool load_state(compio_archive *archive) { return blocks_manager_.load_from_file(archive); }
+    bool load_state(compio_archive *archive);
 
 private:
     compio_archive *archive_;            /**< Associated archive */

--- a/include/compio/btree.hpp
+++ b/include/compio/btree.hpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 
 #include "compio/allocator.hpp"
@@ -38,7 +39,7 @@ struct node_reader {
      * @param tree_degree The degree of the B-Tree (branching factor)
      * @param max_size Maximum number of nodes to cache
      */
-    node_reader(FILE *file, uint64_t tree_degree, uint64_t max_size);
+    node_reader(FILE *file, uint64_t tree_degree, uint64_t max_size, std::mutex *io_mutex);
 
     /**
      * @brief Read a node from the specified address
@@ -90,6 +91,7 @@ private:
     uint64_t tree_degree;
     /** @brief File handle for reading/writing nodes */
     FILE *file;
+    std::mutex *io_mutex;
     /** @brief LRU cache for storing frequently accessed nodes */
     cache::lru_cache<uint64_t, shared_node> cache;
 };
@@ -119,7 +121,7 @@ struct btree {
      * @param cache_size Maximum number of nodes to cache for performance optimization
      */
     btree(uint64_t degree, bool is_readonly, smart_infile_object<header> archive_header,
-          block_allocator *allocator, FILE *file, uint64_t cache_size);
+          block_allocator *allocator, FILE *file, uint64_t cache_size, std::mutex *io_mutex);
 
     /**
      * @brief Insert a key-value pair into the B-Tree

--- a/include/compio/compio_file.hpp
+++ b/include/compio/compio_file.hpp
@@ -2,6 +2,8 @@
 #define COMPIO_FILE_HEADER_
 
 #include <memory>
+#include <shared_mutex>
+#include <mutex>
 
 #include "compio/infile_object.hpp"
 #include "compio/storage_block_reader.hpp"
@@ -14,6 +16,11 @@ struct btree;
 } // namespace compio
 
 struct compio_archive {
+    std::shared_mutex mutex;
+    std::mutex io_mutex;
+    std::mutex header_mutex;
+    std::mutex allocator_mutex;
+
     FILE *file;
     const compio_config config;
     smart_infile_object<compio::header> header;

--- a/include/compio/infile_object.hpp
+++ b/include/compio/infile_object.hpp
@@ -18,6 +18,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <type_traits>
+#include <atomic>
+#include <mutex>
 
 /**
  * @brief Macro to create a const reference to a smart_infile_object
@@ -131,12 +133,13 @@ private:
      * smart_infile_object instances to share the same underlying data.
      */
     struct storage {
-        int ref_count; /**< Reference count for shared ownership */
+        std::atomic<int> ref_count; /**< Reference count for shared ownership */
         bool modified; /**< Flag indicating if data has been modified */
         bool removed;  /**< Flag indicating if object should be removed */
         T *data;       /**< Pointer to the actual object data */
         FILE *file;    /**< File stream */
         uint64_t addr; /**< File address where object is stored */
+        std::mutex *io_mutex;
 
         /**
          * @brief Construct storage with existing data
@@ -149,13 +152,14 @@ private:
          * @param addr File address where object is stored
          * @param data Pointer to existing object data
          */
-        storage(FILE *file, uint64_t addr, T *data)
+        storage(FILE *file, uint64_t addr, T *data, std::mutex *io_mutex = nullptr)
             : ref_count(1),
               modified(true),
               removed(false),
               data(data),
               file(file),
-              addr(addr) {}
+              addr(addr),
+              io_mutex(io_mutex) {}
 
         /**
          * @brief Construct storage by reading from file
@@ -167,7 +171,7 @@ private:
          * @param file File stream to read from
          * @param addr File address where object data is stored
          */
-        storage(FILE *file, uint64_t addr) : storage(file, addr, new T()) {
+        storage(FILE *file, uint64_t addr, std::mutex *io_mutex = nullptr) : storage(file, addr, new T(), io_mutex) {
             modified = false;
             read();
         }
@@ -190,14 +194,28 @@ private:
          *
          * Calls the object's read_from method to load data from file.
          */
-        void read() { data->read_from(file, addr); }
+        void read() {
+            if (io_mutex) {
+                std::lock_guard<std::mutex> lock(*io_mutex);
+                data->read_from(file, addr);
+            } else {
+                data->read_from(file, addr);
+            }
+        }
 
         /**
          * @brief Write object data to file
          *
          * Calls the object's write_to method to save data to file.
          */
-        void write() { data->write_to(file, addr); }
+        void write() {
+            if (io_mutex) {
+                std::lock_guard<std::mutex> lock(*io_mutex);
+                data->write_to(file, addr);
+            } else {
+                data->write_to(file, addr);
+            }
+        }
     };
 
     storage *S; /**< Pointer to the shared storage structure */
@@ -220,7 +238,7 @@ public:
      * @param addr File address where object is stored
      * @param data Pointer to existing object data (ownership is transferred)
      */
-    smart_infile_object(FILE *file, uint64_t addr, T *data) : S(new storage(file, addr, data)) {}
+    smart_infile_object(FILE *file, uint64_t addr, T *data, std::mutex *io_mutex = nullptr) : S(new storage(file, addr, data, io_mutex)) {}
 
     /**
      * @brief Construct by reading from file
@@ -232,7 +250,7 @@ public:
      * @param file File stream to read from
      * @param addr File address where object data is stored
      */
-    smart_infile_object(FILE *file, uint64_t addr) : S(new storage(file, addr)) {}
+    smart_infile_object(FILE *file, uint64_t addr, std::mutex *io_mutex = nullptr) : S(new storage(file, addr, io_mutex)) {}
 
     /**
      * @brief Copy constructor

--- a/include/compio/infile_object.hpp
+++ b/include/compio/infile_object.hpp
@@ -260,7 +260,9 @@ public:
      *
      * @param other The smart_infile_object to copy from
      */
-    smart_infile_object(const smart_infile_object &other) { *this = other; }
+    smart_infile_object(const smart_infile_object &other) : S(other.S) {
+        if (S) S->ref_count.fetch_add(1);
+    }
 
     /**
      * @brief Move constructor
@@ -270,7 +272,9 @@ public:
      *
      * @param other The smart_infile_object to move from
      */
-    smart_infile_object(smart_infile_object &&other) { *this = other; }
+    smart_infile_object(smart_infile_object &&other) noexcept : S(other.S) {
+        other.S = nullptr;
+    }
 
     /**
      * @brief Copy assignment operator
@@ -283,8 +287,14 @@ public:
      * @return Reference to this object
      */
     smart_infile_object &operator=(const smart_infile_object &other) {
-        S = other.S;
-        ++S->ref_count;
+        if (this != &other) {
+            storage *new_S = other.S;
+            if (new_S) new_S->ref_count.fetch_add(1);
+            if (S && S->ref_count.fetch_sub(1) == 1) {
+                delete S;
+            }
+            S = new_S;
+        }
         return *this;
     }
 
@@ -297,7 +307,7 @@ public:
      * @param other The smart_infile_object to move from
      * @return Reference to this object
      */
-    smart_infile_object &operator=(smart_infile_object &&other) {
+    smart_infile_object &operator=(smart_infile_object &&other) noexcept {
         std::swap(S, other.S);
         return *this;
     }
@@ -309,10 +319,8 @@ public:
      * count reaches zero, the storage (and the contained object) is destroyed.
      */
     ~smart_infile_object() {
-        if (S != nullptr) {
-            --S->ref_count;
-            if (S->ref_count == 0)
-                delete S;
+        if (S && S->ref_count.fetch_sub(1) == 1) {
+            delete S;
         }
     }
 

--- a/include/compio/storage_block_reader.hpp
+++ b/include/compio/storage_block_reader.hpp
@@ -15,6 +15,8 @@
 
 #include "third_party/lrucache.hpp"
 
+#include <mutex>
+
 namespace compio {
 
 struct context_t {
@@ -22,6 +24,7 @@ struct context_t {
     block_allocator *allocator;
     btree *index;
     const compio_compressor *compressor;
+    std::mutex *io_mutex;
     /**
      * @brief Temporary in-memory substitution for BTree, to avoid excess BTree operations
      *
@@ -269,7 +272,7 @@ public:
      * @param max_size Maximum number of blocks to keep in the LRU cache
      */
     storage_block_reader(FILE *file, block_allocator *allocator, btree *index,
-                         const compio_compressor *compressor, int max_size);
+                         const compio_compressor *compressor, int max_size, std::mutex *io_mutex);
 
     /**
      * @brief Read a block from file or cache

--- a/include/third_party/lrucache.hpp
+++ b/include/third_party/lrucache.hpp
@@ -42,6 +42,7 @@
 #include <cstddef>
 #include <list>
 #include <map>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 
@@ -56,6 +57,7 @@ public:
     lru_cache(size_t max_size) : _max_size(max_size), _hit_count(0), _total_count(0) {}
 
     void put(const key_t &key, const value_t &value) {
+        std::lock_guard<std::mutex> lock(_mutex);
         auto it = _cache_items_map.find(key);
         _cache_items_list.push_front(key_value_pair_t(key, value));
         if (it != _cache_items_map.end()) {
@@ -72,7 +74,8 @@ public:
         }
     }
 
-    std::optional<const value_t *> get(const key_t &key) {
+    std::optional<value_t> get(const key_t &key) {
+        std::lock_guard<std::mutex> lock(_mutex);
         ++_total_count;
         auto it = _cache_items_map.find(key);
         if (it == _cache_items_map.end()) {
@@ -80,15 +83,17 @@ public:
         } else {
             ++_hit_count;
             _cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
-            return &it->second->second;
+            return it->second->second;
         }
     }
 
     bool exists(const key_t &key) const {
+        std::lock_guard<std::mutex> lock(_mutex);
         return _cache_items_map.find(key) != _cache_items_map.end();
     }
 
     void remove(const key_t &key) {
+        std::lock_guard<std::mutex> lock(_mutex);
         auto it = _cache_items_map.find(key);
         if (it == _cache_items_map.end()) {
             throw std::range_error("There is no such key in cache");
@@ -99,13 +104,18 @@ public:
     }
 
     void clear() {
+        std::lock_guard<std::mutex> lock(_mutex);
         _cache_items_map.clear();
         _cache_items_list.clear();
     }
 
-    bool is_full() { return _cache_items_map.size() >= _max_size; }
+    bool is_full() { 
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _cache_items_map.size() >= _max_size; 
+    }
 
     value_t pop_back() {
+        std::lock_guard<std::mutex> lock(_mutex);
         if (_cache_items_map.size() == 0) {
             throw std::range_error("Trying to pop back from empty cache");
         }
@@ -118,6 +128,7 @@ public:
     }
 
     value_t pop(const key_t &key) {
+        std::lock_guard<std::mutex> lock(_mutex);
         auto it = _cache_items_map.find(key);
         if (it == _cache_items_map.end()) {
             throw std::range_error("There is no such key in cache");
@@ -129,10 +140,14 @@ public:
         }
     }
 
-    size_t size() const { return _cache_items_map.size(); }
+    size_t size() const { 
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _cache_items_map.size(); 
+    }
 
     template <typename addition_t>
     void add_to_range(addition_t addition, const key_t &key_min, const key_t &key_max) {
+        std::lock_guard<std::mutex> lock(_mutex);
         auto it_start = _cache_items_map.lower_bound(key_min);
         auto it_end = _cache_items_map.upper_bound(key_max);
 
@@ -156,6 +171,7 @@ public:
     }
 
     double get_hit_probability() const {
+        std::lock_guard<std::mutex> lock(_mutex);
         return static_cast<double>(_hit_count) / _total_count;
     }
 
@@ -164,6 +180,7 @@ public:
     size_t _max_size;
     size_t _hit_count;
     size_t _total_count;
+    mutable std::mutex _mutex;
 };
 
 } // namespace cache

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -12,7 +12,10 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#include <mutex>
 #include <vector>
+
+#include "compio/compio_file.hpp"
 
 #ifdef _WIN32
 #include <io.h>   // _chsize_s, _fileno
@@ -662,13 +665,23 @@ block_allocator::block_allocator(compio_archive *archive)
 }
 
 uint8_t block_allocator::get_fragmentation() const {
+    if (!archive_) return 0;
+    std::lock_guard<std::mutex> lock(archive_->allocator_mutex);
     return blocks_manager_.get_cached_fragmentation();
+}
+
+free_blocks_manager::fragmentation_stats block_allocator::get_fragmentation_stats() const {
+    if (!archive_) return {};
+    std::lock_guard<std::mutex> lock(archive_->allocator_mutex);
+    return blocks_manager_.get_fragmentation_stats();
 }
 
 uint64_t block_allocator::allocate(uint64_t size) {
     if (size == 0) {
         return UINT64_MAX;
     }
+
+    std::lock_guard<std::mutex> lock(archive_->allocator_mutex);
 
     try {
         // Convert allocation strategy from config to internal enum
@@ -694,11 +707,14 @@ uint64_t block_allocator::allocate(uint64_t size) {
         }
 
         // If no suitable free block found, allocate at the end
-        offset = readonly(archive_->header, header)->file_size;
-        if (offset > UINT64_MAX - size) {
-            return UINT64_MAX;
+        {
+            std::lock_guard<std::mutex> h_lock(archive_->header_mutex);
+            offset = readonly(archive_->header, header)->file_size;
+            if (offset > UINT64_MAX - size) {
+                return UINT64_MAX;
+            }
+            archive_->header->file_size += size;
         }
-        archive_->header->file_size += size;
         return offset;
     } catch (const std::exception &e) {
         std::cerr << "Allocation failed: " << e.what() << std::endl;
@@ -711,6 +727,7 @@ void block_allocator::deallocate(uint64_t offset, uint64_t size) {
         return;
     }
 
+    std::lock_guard<std::mutex> lock(archive_->allocator_mutex);
     if (size > UINT64_MAX - offset ||
         offset + size > readonly(archive_->header, header)->file_size) {
         return;
@@ -765,6 +782,26 @@ void block_allocator::maintenance() {
     }
 
     last_fragmentation_ = blocks_manager_.get_cached_fragmentation();
+}
+
+bool block_allocator::save_state(compio_archive *archive) {
+    if (!archive) {
+        return false;
+    }
+    std::lock_guard<std::mutex> alloc_lock(archive->allocator_mutex);
+    std::lock_guard<std::mutex> head_lock(archive->header_mutex);
+    std::lock_guard<std::mutex> io_lock(archive->io_mutex);
+    return blocks_manager_.save_to_file(archive);
+}
+
+bool block_allocator::load_state(compio_archive *archive) {
+    if (!archive) {
+        return false;
+    }
+    std::lock_guard<std::mutex> alloc_lock(archive->allocator_mutex);
+    std::lock_guard<std::mutex> head_lock(archive->header_mutex);
+    std::lock_guard<std::mutex> io_lock(archive->io_mutex);
+    return blocks_manager_.load_from_file(archive);
 }
 
 // Private methods

--- a/src/btree.cpp
+++ b/src/btree.cpp
@@ -13,26 +13,27 @@ using namespace compio;
 
 #define RO(x) readonly(x, index_node)
 
-node_reader::node_reader(FILE *file, uint64_t tree_degree, uint64_t max_size)
+node_reader::node_reader(FILE *file, uint64_t tree_degree, uint64_t max_size, std::mutex *io_mutex)
     : tree_degree(tree_degree),
       file(file),
+      io_mutex(io_mutex),
       cache(max_size) {}
 
 shared_node node_reader::read_node(uint64_t addr) {
     auto node = cache.get(addr);
     if (!node.has_value()) {
-        auto result = shared_node(file, addr, new index_node(tree_degree));
+        auto result = shared_node(file, addr, new index_node(tree_degree), io_mutex);
         result.read();     // read from file (because constructor with obj& does not read)
         result.unmodify(); // constructor with obj& sets modified=true
         cache.put(addr, result);
         return result;
     } else {
-        return *node.value();
+        return node.value();
     }
 }
 
 shared_node node_reader::create_node(uint64_t addr) {
-    auto result = shared_node(file, addr, new index_node(tree_degree));
+    auto result = shared_node(file, addr, new index_node(tree_degree), io_mutex);
     cache.put(addr, result);
     return result;
 }
@@ -50,12 +51,12 @@ void node_reader::clear_cache() { cache.clear(); }
 double node_reader::get_cache_hit_probability() const { return cache.get_hit_probability(); }
 
 btree::btree(uint64_t degree, bool is_readonly, smart_infile_object<header> archive_header,
-             block_allocator *allocator, FILE *file, uint64_t cache_size)
+             block_allocator *allocator, FILE *file, uint64_t cache_size, std::mutex *io_mutex)
     : degree(degree),
       is_readonly(is_readonly),
       archive_header(archive_header),
       allocator(allocator),
-      reader(file, degree, cache_size) {
+      reader(file, degree, cache_size, io_mutex) {
     if (readonly(archive_header, header)->index_root != 0)
         return;
 

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -276,6 +276,10 @@ int compio_remove_file(compio_archive *archive, const char *name) {
     if (!archive) {
         return -1;
     }
+    if (!name) {
+        errno = EINVAL;
+        return -1;
+    }
     std::unique_lock<std::shared_mutex> lock(archive->mutex);
     size_t name_len = strlen(name);
     if (name_len > COMPIO_FNAME_MAX_SIZE) {

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -854,11 +854,11 @@ uint64_t compio_insert(const void *ptr, uint64_t size, compio_file *file) {
 }
 
 uint64_t compio_erase(uint64_t size, compio_file *file) {
-    DEBUG_PRINT("\ncompio_erase(cursor=%lu, size=%lu)\n", file->cursor, size);
-
     if (!file || !file->archive) {
         return 0;
     }
+    DEBUG_PRINT("\ncompio_erase(cursor=%lu, size=%lu)\n", file->cursor, size);
+
     std::unique_lock<std::shared_mutex> lock(file->archive->mutex);
 
 #ifdef COMPIO_DISABLE_INSERT_ERASE

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -60,9 +60,9 @@ compio_archive::compio_archive(FILE *file, uint8_t mode_b, const compio_config *
       open_files_count(0) {
     if (is_file_empty(file))
         header = smart_infile_object<compio::header>(file, 0,
-                     new compio::header(static_cast<uint32_t>(config->max_files)));
+                     new compio::header(static_cast<uint32_t>(config->max_files)), &io_mutex);
     else
-        header = smart_infile_object<compio::header>(file, 0);
+        header = smart_infile_object<compio::header>(file, 0, &io_mutex);
 
     // btree constructor is called in compio_open_archive to break
     // the dependence cycle (archive -> index -> allocator -> archive)
@@ -189,7 +189,7 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
     }
 
     archive->index = new btree(c->b_tree_degree, mode_b & mode_bit::r, archive->header,
-                               archive->allocator, file, c->cache_size__nodes);
+                               archive->allocator, file, c->cache_size__nodes, &archive->io_mutex);
     if (!archive->index) {
         WARNING_PRINT("warning: failed to allocate memory for btree\n");
         goto no_index;
@@ -197,7 +197,7 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
 
     archive->block_reader = new compio::storage_block_reader(
         file, archive->allocator, archive->index,
-        &archive->config.compressor, archive->config.cache_size__blocks);
+        &archive->config.compressor, archive->config.cache_size__blocks, &archive->io_mutex);
     if (!archive->block_reader) {
         WARNING_PRINT("warning: failed to allocate memory for storage_block_reader\n");
         goto no_block_reader;
@@ -225,6 +225,10 @@ end:
 }
 
 compio_file *compio_open_file(const char *name, compio_archive *archive) {
+    if (!archive) {
+        return NULL;
+    }
+    std::unique_lock<std::shared_mutex> lock(archive->mutex);
     size_t name_len = strlen(name);
     if (name_len > COMPIO_FNAME_MAX_SIZE) {
         errno = ENAMETOOLONG;
@@ -265,6 +269,10 @@ compio_file *compio_open_file(const char *name, compio_archive *archive) {
 }
 
 int compio_remove_file(compio_archive *archive, const char *name) {
+    if (!archive) {
+        return -1;
+    }
+    std::unique_lock<std::shared_mutex> lock(archive->mutex);
     size_t name_len = strlen(name);
     if (name_len > COMPIO_FNAME_MAX_SIZE) {
         errno = ENAMETOOLONG;
@@ -319,6 +327,7 @@ int compio_get_fragmentation_stats(compio_archive *archive, compio_fragmentation
     if (!archive || !stats) {
         return COMPIO_ERROR;
     }
+    std::shared_lock<std::shared_mutex> lock(archive->mutex);
 
     if (!archive->allocator) {
         return COMPIO_ERROR;
@@ -343,6 +352,7 @@ int compio_defragment(compio_archive *archive) {
         WARNING_PRINT("warning: passed nullptr into compio_defragment\n");
         return COMPIO_ERROR;
     }
+    std::unique_lock<std::shared_mutex> lock(archive->mutex);
 
     if (archive->mode_b & mode_bit::r) {
         WARNING_PRINT("warning: compio_defragment called on read-only archive\n");
@@ -364,12 +374,13 @@ int compio_defragment(compio_archive *archive) {
 }
 
 int compio_close_file(compio_file *file) {
-    if (!file) {
+    if (!file || !file->archive) {
         WARNING_PRINT("warning: passed nullptr into compio_close_file\n");
         return -1;
     }
+    std::unique_lock<std::shared_mutex> lock(file->archive->mutex);
 
-    if (file->archive && file->archive->open_files_count > 0) {
+    if (file->archive->open_files_count > 0) {
         file->archive->open_files_count--;
     }
 
@@ -490,8 +501,8 @@ static void validate_tree(btree *index, compio_file *file, bool allow_empty = fa
 #endif
 }
 
-uint64_t compio_write(const void *ptr, uint64_t size, compio_file *file) {
-    DEBUG_PRINT("\ncompio_write(cursor=%lu, size=%lu, file_size=%lu)\n", file->cursor, size, file->size);
+static uint64_t compio_write_impl(const void *ptr, uint64_t size, compio_file *file) {
+    DEBUG_PRINT("\ncompio_write_impl(cursor=%lu, size=%lu, file_size=%lu)\n", file->cursor, size, file->size);
 
     const auto archive = file->archive;
     const auto block_reader = archive->block_reader;
@@ -648,8 +659,21 @@ uint64_t compio_write(const void *ptr, uint64_t size, compio_file *file) {
     return size;
 }
 
+uint64_t compio_write(const void *ptr, uint64_t size, compio_file *file) {
+    if (!file || !file->archive) {
+        return 0;
+    }
+    std::unique_lock<std::shared_mutex> lock(file->archive->mutex);
+    return compio_write_impl(ptr, size, file);
+}
+
 uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
     DEBUG_PRINT("\ncompio_read(cursor=%lu, size=%lu, file_size=%lu)\n", file->cursor, size, file->size);
+
+    if (!file || !file->archive) {
+        return 0;
+    }
+    std::shared_lock<std::shared_mutex> lock(file->archive->mutex);
 
     const auto *archive = file->archive;
     const auto block_reader = archive->block_reader;
@@ -725,6 +749,11 @@ uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
 uint64_t compio_insert(const void *ptr, uint64_t size, compio_file *file) {
     DEBUG_PRINT("\ncompio_insert(cursor=%lu, size=%lu)\n", file->cursor, size);
 
+    if (!file || !file->archive) {
+        return 0;
+    }
+    std::unique_lock<std::shared_mutex> lock(file->archive->mutex);
+
 #ifdef COMPIO_DISABLE_INSERT_ERASE
     WARNING_PRINT("warning: insert operations are disabled (COMPIO_DISABLE_INSERT_ERASE)\n");
     return 0;
@@ -732,7 +761,7 @@ uint64_t compio_insert(const void *ptr, uint64_t size, compio_file *file) {
 
     // behave the same as compio_write, when inserting after file end
     if (file->cursor >= file->size) {
-        return compio_write(ptr, size, file);
+        return compio_write_impl(ptr, size, file);
     }
 
     auto *archive = file->archive;
@@ -822,6 +851,11 @@ uint64_t compio_insert(const void *ptr, uint64_t size, compio_file *file) {
 
 uint64_t compio_erase(uint64_t size, compio_file *file) {
     DEBUG_PRINT("\ncompio_erase(cursor=%lu, size=%lu)\n", file->cursor, size);
+
+    if (!file || !file->archive) {
+        return 0;
+    }
+    std::unique_lock<std::shared_mutex> lock(file->archive->mutex);
 
 #ifdef COMPIO_DISABLE_INSERT_ERASE
     WARNING_PRINT("warning: erase operations are disabled (COMPIO_DISABLE_INSERT_ERASE)\n");
@@ -945,6 +979,7 @@ uint64_t compio_erase(uint64_t size, compio_file *file) {
 
 void compio_flush(compio_archive *archive) {
     if (!archive) return;
+    std::unique_lock<std::shared_mutex> lock(archive->mutex);
     if (archive->block_reader) archive->block_reader->clear_cache();
     if (archive->index) archive->index->clear_cache();
 }

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -668,11 +668,11 @@ uint64_t compio_write(const void *ptr, uint64_t size, compio_file *file) {
 }
 
 uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
-    DEBUG_PRINT("\ncompio_read(cursor=%lu, size=%lu, file_size=%lu)\n", file->cursor, size, file->size);
-
     if (!file || !file->archive) {
         return 0;
     }
+
+    DEBUG_PRINT("\ncompio_read(cursor=%lu, size=%lu, file_size=%lu)\n", file->cursor, size, file->size);
     std::shared_lock<std::shared_mutex> lock(file->archive->mutex);
 
     const auto *archive = file->archive;

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -228,6 +228,10 @@ compio_file *compio_open_file(const char *name, compio_archive *archive) {
     if (!archive) {
         return NULL;
     }
+    if (!name) {
+        errno = EINVAL;
+        return NULL;
+    }
     std::unique_lock<std::shared_mutex> lock(archive->mutex);
     size_t name_len = strlen(name);
     if (name_len > COMPIO_FNAME_MAX_SIZE) {

--- a/src/infile_object.cpp
+++ b/src/infile_object.cpp
@@ -52,7 +52,7 @@ uint64_t lendian_fwrite(const void *ptr, uint64_t size, uint64_t nmemb, FILE *st
                 size);
         }
         ret = fwrite((void *)buffer, size, nmemb, stream);
-        delete buffer;
+        delete[] buffer;
     } else {
         ret = fwrite(ptr, size, nmemb, stream);
     }

--- a/src/storage_block_reader.cpp
+++ b/src/storage_block_reader.cpp
@@ -1,6 +1,7 @@
 #include "compio/storage_block_reader.hpp"
 
 #include <cassert>
+#include <mutex>
 
 #include "compio/debug_print.hpp"
 
@@ -27,7 +28,12 @@ block::block(context_t &context, const tree_key &key, uint64_t addr)
       _is_valid(true) {
 
     storage_block b;
-    b.read_from(context.file, addr);
+    {
+        std::unique_lock<std::mutex> lock;
+        if (context.io_mutex)
+            lock = std::unique_lock<std::mutex>(*context.io_mutex);
+        b.read_from(context.file, addr);
+    }
 
     _c_size = b.size;
     _size = b.original_size;
@@ -105,7 +111,12 @@ block::~block() {
             "[B][destructor]: writing to file "
             "(new_addr=%lu,addr=%lu,original_size=%lu,size=%lu,is_compressed=%d,key.pos=%lu)\n",
             new_addr, _addr, b.original_size, b.size, b.is_compressed, _key.pos);
-        b.write_to(context.file, new_addr);
+        if (context.io_mutex) {
+            std::lock_guard<std::mutex> lock(*context.io_mutex);
+            b.write_to(context.file, new_addr);
+        } else {
+            b.write_to(context.file, new_addr);
+        }
 
         // block already in btree thanks to storage_block_reader
         // we just need to update it's file address
@@ -179,9 +190,10 @@ uint64_t block::addr() const { return _addr; }
 uint64_t block::c_size() const { return _c_size; }
 
 storage_block_reader::storage_block_reader(FILE *file, block_allocator *allocator, btree *index,
-                                           const compio_compressor *compressor, int max_size)
+                                           const compio_compressor *compressor, int max_size,
+                                           std::mutex *io_mutex)
     : cache(max_size),
-      context({file, allocator, index, compressor, {}, false}) {}
+      context({file, allocator, index, compressor, io_mutex, {}, false}) {}
 
 std::shared_ptr<block> storage_block_reader::read_block(uint64_t addr, tree_key key) {
     DEBUG_PRINT("[SBR][read_block]: addr=%lu, key.hash=%lu, key.pos=%lu\n", addr, key.hash,
@@ -189,7 +201,7 @@ std::shared_ptr<block> storage_block_reader::read_block(uint64_t addr, tree_key 
     auto b_cached = cache.get(key);
     if (b_cached.has_value()) {
         DEBUG_PRINT("[SBR][read_block]: cache hit\n");
-        return *b_cached.value();
+        return b_cached.value();
     }
     DEBUG_PRINT("[SBR][read_block]: cache miss\n");
     if (context.is_temporary_index_enabled) {
@@ -222,7 +234,7 @@ std::shared_ptr<block> storage_block_reader::create_block(uint64_t size, tree_ke
         WARNING_PRINT("warning: trying to create block with key (%lu, %lu), that "
                       "already exists in storage_block_reader.cache\n",
                       key.hash, key.pos);
-        return *b_cached.value();
+        return b_cached.value();
     }
     auto b = std::make_shared<block>(context, key, size, false);
     cache.put(key, b);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(compio_gtest
     src/test_insert_erase.cpp
     src/test_segregated_allocator.cpp
     src/test_max_files.cpp
+    src/test_concurrency.cpp
 )
 
 target_link_libraries(compio_gtest PRIVATE compio GTest::GTest GTest::Main)

--- a/tests/src/test_concurrency.cpp
+++ b/tests/src/test_concurrency.cpp
@@ -1,0 +1,115 @@
+#include <gtest/gtest.h>
+#include <compio.h>
+#include <thread>
+#include <vector>
+#include <atomic>
+#include <random>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+class ConcurrencyTest : public ::testing::Test {
+protected:
+    std::string test_file = "concurrency_test.compio";
+    compio_archive* archive = nullptr;
+
+    void SetUp() override {
+        if (fs::exists(test_file)) {
+            fs::remove(test_file);
+        }
+        compio_config config;
+        compio_build_default_config(&config);
+        config.block_size = 4096;
+        archive = compio_open_archive(test_file.c_str(), "w+", &config);
+        ASSERT_NE(archive, nullptr);
+    }
+
+    void TearDown() override {
+        if (archive) {
+            compio_close_archive(archive);
+            archive = nullptr;
+        }
+        if (fs::exists(test_file)) {
+            fs::remove(test_file);
+        }
+    }
+};
+
+TEST_F(ConcurrencyTest, ConcurrentReadWriteDifferentFiles) {
+    const int num_files = 10;
+    const int num_threads = 4;
+    const int ops_per_thread = 100;
+    std::atomic<bool> running{true};
+
+    // Pre-create files
+    for (int i = 0; i < num_files; ++i) {
+        std::string fname = "file_" + std::to_string(i);
+        compio_file* f = compio_open_file(fname.c_str(), archive);
+        ASSERT_NE(f, nullptr);
+        compio_close_file(f);
+    }
+
+    auto worker = [&](int id) {
+        std::mt19937 rng(id);
+        std::vector<uint8_t> buffer(1024);
+        
+        for (int i = 0; i < ops_per_thread; ++i) {
+            int file_idx = rng() % num_files;
+            std::string fname = "file_" + std::to_string(file_idx);
+            
+            // Open file (thread-safe now)
+            compio_file* f = compio_open_file(fname.c_str(), archive);
+            if (!f) continue;
+
+            // Write or Read
+            if (rng() % 2 == 0) {
+                // Write
+                std::fill(buffer.begin(), buffer.end(), (uint8_t)rng());
+                compio_write(buffer.data(), buffer.size(), f);
+            } else {
+                // Read
+                compio_read(buffer.data(), buffer.size(), f);
+            }
+
+            compio_close_file(f);
+        }
+    };
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back(worker, i);
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+}
+
+TEST_F(ConcurrencyTest, ConcurrentReadSameFile) {
+    const std::string fname = "shared_file";
+    {
+        compio_file* f = compio_open_file(fname.c_str(), archive);
+        std::vector<uint8_t> data(1024 * 1024, 'A');
+        compio_write(data.data(), data.size(), f);
+        compio_close_file(f);
+    }
+
+    const int num_readers = 4;
+    std::vector<std::thread> threads;
+
+    for (int i = 0; i < num_readers; ++i) {
+        threads.emplace_back([&]() {
+            compio_file* f = compio_open_file(fname.c_str(), archive);
+            ASSERT_NE(f, nullptr);
+            std::vector<uint8_t> buf(1024);
+            for(int j=0; j<100; ++j) {
+                compio_read(buf.data(), buf.size(), f);
+            }
+            compio_close_file(f);
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+}

--- a/tests/src/test_concurrency.cpp
+++ b/tests/src/test_concurrency.cpp
@@ -42,7 +42,6 @@ TEST_F(ConcurrencyTest, ConcurrentReadWriteDifferentFiles) {
     const int num_files = 10;
     const int num_threads = 4;
     const int ops_per_thread = 100;
-    std::atomic<bool> running{true};
 
     // Pre-create files
     for (int i = 0; i < num_files; ++i) {

--- a/tests/src/test_concurrency.cpp
+++ b/tests/src/test_concurrency.cpp
@@ -99,13 +99,17 @@ TEST_F(ConcurrencyTest, ConcurrentReadSameFile) {
 
     const int num_readers = 4;
     std::vector<std::thread> threads;
+    std::atomic<bool> failure{false};
 
     for (int i = 0; i < num_readers; ++i) {
         threads.emplace_back([&]() {
             compio_file* f = compio_open_file(fname.c_str(), archive);
-            ASSERT_NE(f, nullptr);
+            if (!f) {
+                failure.store(true, std::memory_order_relaxed);
+                return;
+            }
             std::vector<uint8_t> buf(1024);
-            for(int j=0; j<100; ++j) {
+            for (int j = 0; j < 100; ++j) {
                 compio_read(buf.data(), buf.size(), f);
             }
             compio_close_file(f);
@@ -115,6 +119,8 @@ TEST_F(ConcurrencyTest, ConcurrentReadSameFile) {
     for (auto& t : threads) {
         t.join();
     }
+
+    ASSERT_FALSE(failure.load(std::memory_order_relaxed));
 }
 
 TEST_F(ConcurrencyTest, ConcurrentInsertEraseFlush) {

--- a/tests/src/test_concurrency.cpp
+++ b/tests/src/test_concurrency.cpp
@@ -5,18 +5,20 @@
 #include <atomic>
 #include <random>
 #include <filesystem>
+#include <string>
 
 namespace fs = std::filesystem;
 
 class ConcurrencyTest : public ::testing::Test {
 protected:
-    std::string test_file = "concurrency_test.compio";
+    std::string test_file;
     compio_archive* archive = nullptr;
 
     void SetUp() override {
-        // Use a unique temporary filename to avoid collisions across concurrent test runs.
-        fs::path tmp_path = fs::temp_directory_path() / fs::unique_path("concurrency_test-%%%%-%%%%.compio");
+        static std::atomic<int> counter{0};
+        auto tmp_path = fs::temp_directory_path() / ("concurrency_test_" + std::to_string(counter++) + ".compio");
         test_file = tmp_path.string();
+        
         if (fs::exists(test_file)) {
             fs::remove(test_file);
         }
@@ -122,8 +124,8 @@ TEST_F(ConcurrencyTest, ConcurrentReadSameFile) {
     ASSERT_FALSE(failure.load(std::memory_order_relaxed));
 }
 
-TEST_F(ConcurrencyTest, ConcurrentInsertEraseFlush) {
-    const int num_keys = 32;
+TEST_F(ConcurrencyTest, ConcurrentFileOperations) {
+    const int num_keys = 10; 
     const int num_threads = 4;
     const int ops_per_thread = 200;
 
@@ -131,19 +133,19 @@ TEST_F(ConcurrencyTest, ConcurrentInsertEraseFlush) {
         std::mt19937 rng(id + 1234);
         for (int i = 0; i < ops_per_thread; ++i) {
             int key_idx = rng() % num_keys;
-            std::string name = "ie_file_" + std::to_string(key_idx);
+            std::string name = "file_op_" + std::to_string(key_idx);
 
-            // Randomly choose between insert, erase, and flush.
             int op = rng() % 3;
             if (op == 0) {
-                // Insert a directory entry / file record.
-                (void)compio_insert(name.c_str(), archive);
+                // Create/Open
+                compio_file* f = compio_open_file(name.c_str(), archive);
+                if (f) compio_close_file(f);
             } else if (op == 1) {
-                // Erase a directory entry / file record.
-                (void)compio_erase(name.c_str(), archive);
+                // Remove
+                compio_remove_file(archive, name.c_str());
             } else {
-                // Flush archive metadata/state.
-                (void)compio_flush(archive);
+                // Flush
+                compio_flush(archive);
             }
         }
     };
@@ -156,20 +158,5 @@ TEST_F(ConcurrencyTest, ConcurrentInsertEraseFlush) {
 
     for (auto &t : threads) {
         t.join();
-    }
-
-    // Final flush to ensure all pending operations are committed.
-    (void)compio_flush(archive);
-
-    // Basic invariant check: each key is either absent or can be opened/closed.
-    for (int key_idx = 0; key_idx < num_keys; ++key_idx) {
-        std::string name = "ie_file_" + std::to_string(key_idx);
-        compio_file *f = compio_open_file(name.c_str(), archive);
-        if (f != nullptr) {
-            // If the entry exists, we should be able to perform a simple operation on it.
-            std::vector<uint8_t> buf(16, 0);
-            (void)compio_read(buf.data(), buf.size(), f);
-            compio_close_file(f);
-        }
     }
 }

--- a/tests/src/test_concurrency.cpp
+++ b/tests/src/test_concurrency.cpp
@@ -116,3 +116,55 @@ TEST_F(ConcurrencyTest, ConcurrentReadSameFile) {
         t.join();
     }
 }
+
+TEST_F(ConcurrencyTest, ConcurrentInsertEraseFlush) {
+    const int num_keys = 32;
+    const int num_threads = 4;
+    const int ops_per_thread = 200;
+
+    auto worker = [&](int id) {
+        std::mt19937 rng(id + 1234);
+        for (int i = 0; i < ops_per_thread; ++i) {
+            int key_idx = rng() % num_keys;
+            std::string name = "ie_file_" + std::to_string(key_idx);
+
+            // Randomly choose between insert, erase, and flush.
+            int op = rng() % 3;
+            if (op == 0) {
+                // Insert a directory entry / file record.
+                (void)compio_insert(name.c_str(), archive);
+            } else if (op == 1) {
+                // Erase a directory entry / file record.
+                (void)compio_erase(name.c_str(), archive);
+            } else {
+                // Flush archive metadata/state.
+                (void)compio_flush(archive);
+            }
+        }
+    };
+
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back(worker, i);
+    }
+
+    for (auto &t : threads) {
+        t.join();
+    }
+
+    // Final flush to ensure all pending operations are committed.
+    (void)compio_flush(archive);
+
+    // Basic invariant check: each key is either absent or can be opened/closed.
+    for (int key_idx = 0; key_idx < num_keys; ++key_idx) {
+        std::string name = "ie_file_" + std::to_string(key_idx);
+        compio_file *f = compio_open_file(name.c_str(), archive);
+        if (f != nullptr) {
+            // If the entry exists, we should be able to perform a simple operation on it.
+            std::vector<uint8_t> buf(16, 0);
+            (void)compio_read(buf.data(), buf.size(), f);
+            compio_close_file(f);
+        }
+    }
+}

--- a/tests/src/test_concurrency.cpp
+++ b/tests/src/test_concurrency.cpp
@@ -14,6 +14,9 @@ protected:
     compio_archive* archive = nullptr;
 
     void SetUp() override {
+        // Use a unique temporary filename to avoid collisions across concurrent test runs.
+        fs::path tmp_path = fs::temp_directory_path() / fs::unique_path("concurrency_test-%%%%-%%%%.compio");
+        test_file = tmp_path.string();
         if (fs::exists(test_file)) {
             fs::remove(test_file);
         }


### PR DESCRIPTION
- Add `std::shared_mutex` to `compio_archive` for concurrent read access
- Add `io_mutex` for serializing low-level file operations
- Protect `compio_read`, `compio_write`, `compio_insert`, `compio_erase`, `compio_flush`
- Protect `compio_open_file` and `compio_close_file`
- Make `lru_cache` thread-safe
- Add multithreaded test coverage