### PR TITLE
feat!: smart open and header validation

### DIFF
--- a/compio.h
+++ b/compio.h
@@ -151,8 +151,8 @@ typedef enum {
 typedef struct {
     compio_compressor compressor; /**< Compressor for data blocks */
 
-    int b_tree_degree;       /**< B-Tree branching factor (typically 3-10) */
-    int block_size;          /**< Block size for splitting files (in bytes) */
+    int b_tree_degree;       /**< B-Tree branching factor (typically 3-10). Set to 0 to auto-detect on open. */
+    int block_size;          /**< Block size for splitting files (in bytes). Set to 0 to auto-detect on open. */
     int block_size__minimum; /** Minimum size of an uncompressed block */
     int block_size__maximum; /** Maximum size of an uncompressed block */
 
@@ -163,7 +163,7 @@ typedef struct {
     bool fill_holes_with_zeros;      /**< Zero-fill freed blocks for sparse file optimization */
     uint8_t fragmentation_threshold; /**< Trigger defragmentation when fragmentation exceeds this
                                         percentage (1-100) */
-    int max_files; /**< Maximum number of files in a single archive (default: COMPIO_MAX_FILES) */
+    int max_files; /**< Maximum number of files in a single archive (default: COMPIO_MAX_FILES). Set to 0 to auto-detect on open. */
 } compio_config;
 
 /**

--- a/include/compio/file.hpp
+++ b/include/compio/file.hpp
@@ -55,6 +55,8 @@ struct header : public infile_object {
     uint64_t allocator_state_offset;
     uint64_t allocator_state_size;
     uint32_t compression_type; /**< Type of compression algorithm used */
+    uint32_t block_size;       /**< Size of data blocks */
+    uint32_t b_tree_degree;    /**< Degree of B-Tree index */
 
     /**
      * @brief Construct default header

--- a/include/compio/infile_object.hpp
+++ b/include/compio/infile_object.hpp
@@ -141,6 +141,12 @@ private:
         uint64_t addr; /**< File address where object is stored */
         std::mutex *io_mutex;
 
+        // NOTE: We use std::atomic<int> for ref_count and fetch_add/fetch_sub
+        // for thread safety. The destructor is only called when fetch_sub(1)
+        // returns 1 (meaning the count dropped from 1 to 0).
+        // This prevents double-delete race conditions.
+
+
         /**
          * @brief Construct storage with existing data
          *

--- a/include/compio/storage_block_reader.hpp
+++ b/include/compio/storage_block_reader.hpp
@@ -287,6 +287,11 @@ public:
     storage_block_reader(FILE *file, block_allocator *allocator, btree *index,
                          const compio_compressor *compressor, int max_size, std::mutex *io_mutex);
 
+    storage_block_reader(const storage_block_reader &) = delete;
+    storage_block_reader &operator=(const storage_block_reader &) = delete;
+    storage_block_reader(storage_block_reader &&) = delete;
+    storage_block_reader &operator=(storage_block_reader &&) = delete;
+
     /**
      * @brief Read a block from file or cache
      *

--- a/include/compio/storage_block_reader.hpp
+++ b/include/compio/storage_block_reader.hpp
@@ -71,6 +71,9 @@ struct context_t {
     std::atomic<int> temp_index_refcount = 0;
     std::mutex temp_index_mutex;
 
+    context_t(const context_t&) = delete;
+    context_t& operator=(const context_t&) = delete;
+
     context_t(FILE *file, block_allocator *allocator, btree *index,
               const compio_compressor *compressor, std::mutex *io_mutex)
         : file(file),

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -342,7 +342,7 @@ void free_blocks_manager::defragment() {
 void free_blocks_manager::print_list() const {
     free_block *current = head_;
     while (current) {
-        DEBUG_PRINT("Block: %lu, %lu\n", current->offset, current->size);
+        DEBUG_PRINT("Block: %" PRIu64 ", %" PRIu64 "\n", current->offset, current->size);
         current = current->next;
     }
 }
@@ -743,7 +743,7 @@ void block_allocator::deallocate(uint64_t offset, uint64_t size) {
         static constexpr size_t BUFFER_SIZE = 4096;
         static uint8_t zeros[BUFFER_SIZE] = {0};
 
-        DEBUG_PRINT("[W][deallocate]addr=%lu;size=%lu\n", offset, size);
+        DEBUG_PRINT("[W][deallocate]addr=%" PRIu64 ";size=%" PRIu64 "\n", offset, size);
         fseek64(archive_->file, offset, SEEK_SET);
 
         size_t remaining = size;

--- a/src/btree.cpp
+++ b/src/btree.cpp
@@ -202,18 +202,18 @@ void btree::_get_range(shared_node &node, const tree_key &key_min, const tree_ke
 std::vector<std::pair<tree_key, tree_val>> btree::get_range(const tree_key &key_min,
                                                             const tree_key &key_max) {
     if (key_max <= key_min) {
-        WARNING_PRINT("warning: btree::get_range received invalid range bounds (key_min={%lu,%lu} "
-                      ">= {%lu,%lu}=key_max)\n",
+        WARNING_PRINT("warning: btree::get_range received invalid range bounds (key_min={%" PRIu64 ",%" PRIu64 "} "
+                      ">= {%" PRIu64 ",%" PRIu64 "}=key_max)\n",
                       key_min.hash, key_min.pos, key_max.hash, key_max.pos);
         return {};
     }
     std::vector<std::pair<tree_key, tree_val>> result;
     auto root = read_root();
     _get_range(root, key_min, key_max, result);
-    DEBUG_PRINT("[BTREE]: get_range(key_min={...,%lu},key_max={...,%lu}) ->\n", key_min.pos,
+    DEBUG_PRINT("[BTREE]: get_range(key_min={...,%" PRIu64 "},key_max={...,%" PRIu64 "}) ->\n", key_min.pos,
                 key_max.pos);
     for (const auto &[key, val] : result) {
-        DEBUG_PRINT("\t{...,%lu} -> {%lu,%lu}\n", key.pos, val.addr, val.size);
+        DEBUG_PRINT("\t{...,%" PRIu64 "} -> {%" PRIu64 ",%" PRIu64 "}\n", key.pos, val.addr, val.size);
     }
     return result;
 }
@@ -244,7 +244,7 @@ bool btree::_update(shared_node &node, const tree_key &key, const tree_val &new_
 }
 
 void btree::update(const tree_key &key, const tree_val &new_value) {
-    DEBUG_PRINT("[BTREE]: update(key={...,%lu},new_value={%lu,%lu})\n", key.pos, new_value.addr,
+    DEBUG_PRINT("[BTREE]: update(key={...,%" PRIu64 "},new_value={%" PRIu64 ",%" PRIu64 "})\n", key.pos, new_value.addr,
                 new_value.size);
     auto root = read_root();
     if (!_update(root, key, new_value)) {
@@ -262,12 +262,12 @@ std::optional<tree_val> btree::get(const tree_key &key) {
 
         if (idx < RO(current)->num_keys && RO(current)->keys[idx] == key) {
             const auto val = RO(current)->values[idx];
-            DEBUG_PRINT("[BTREE]: get(key={...,%lu}) -> {%lu,%lu}\n", key.pos, val.addr, val.size);
+            DEBUG_PRINT("[BTREE]: get(key={...,%" PRIu64 "}) -> {%" PRIu64 ",%" PRIu64 "}\n", key.pos, val.addr, val.size);
             return val;
         } else if (!RO(current)->is_leaf) {
             current = read_child(current, idx);
         } else {
-            DEBUG_PRINT("[BTREE]: get(key={...,%lu}) -> nullopt\n", key.pos);
+            DEBUG_PRINT("[BTREE]: get(key={...,%" PRIu64 "}) -> nullopt\n", key.pos);
             return std::nullopt;
         }
     }
@@ -279,15 +279,15 @@ std::optional<std::pair<tree_key, tree_val>> btree::get_block(const tree_key &ke
     assert(range.size() < 2);
     if (!range.empty()) {
         if (key == range[0].first) {
-            DEBUG_PRINT("[BTREE]: get_block(key={...,%lu}) -> nullopt\n", key.pos);
+            DEBUG_PRINT("[BTREE]: get_block(key={...,%" PRIu64 "}) -> nullopt\n", key.pos);
             return std::nullopt;
         } else {
-            DEBUG_PRINT("[BTREE]: get_block(key={...,%lu}) -> (key={...,%lu},val={%lu,%lu})\n",
+            DEBUG_PRINT("[BTREE]: get_block(key={...,%" PRIu64 "}) -> (key={...,%" PRIu64 "},val={%" PRIu64 ",%" PRIu64 "})\n",
                         key.pos, range[0].first.pos, range[0].second.addr, range[0].second.size);
             return range[0];
         }
     } else {
-        DEBUG_PRINT("[BTREE]: get_block(key={...,%lu}) -> nullopt\n", key.pos);
+        DEBUG_PRINT("[BTREE]: get_block(key={...,%" PRIu64 "}) -> nullopt\n", key.pos);
         return std::nullopt;
     }
 }
@@ -328,11 +328,11 @@ void btree::_add_to_range(shared_node &node, int64_t addition, const tree_key &k
 }
 
 void btree::add_to_range(int64_t addition, const tree_key &key_min, const tree_key &key_max) {
-    DEBUG_PRINT("[BTREE]: add_to_range(addition=%ld,key_min={...,%lu},key_max={...,%lu})\n",
+    DEBUG_PRINT("[BTREE]: add_to_range(addition=%" PRId64 ",key_min={...,%" PRIu64 "},key_max={...,%" PRIu64 "})\n",
                 addition, key_min.pos, key_max.pos);
     if (key_min > key_max) {
         WARNING_PRINT("warning: passed invalid range into btree::add_pos_to_keys_in_range "
-                      "(key_min={...,%lu} > {...,%lu}=key_max)\n",
+                      "(key_min={...,%" PRIu64 "} > {...,%" PRIu64 "}=key_max)\n",
                       key_min.pos, key_max.pos);
         return;
     }
@@ -352,7 +352,7 @@ void btree::_print(shared_node node, uint64_t depth) {
             auto val = node->values[i];
             UNUSED(key);
             UNUSED(val);
-            DEBUG_PRINT("%s{%lu, %lu} -> {%lu, %lu}\n", std::string(depth * 2, ' ').c_str(),
+            DEBUG_PRINT("%s{%" PRIu64 ", %" PRIu64 "} -> {%" PRIu64 ", %" PRIu64 "}\n", std::string(depth * 2, ' ').c_str(),
                         key.hash, key.pos, val.addr, val.size);
         }
     }
@@ -396,7 +396,7 @@ std::vector<uint64_t> btree::collect_node_addresses(uint64_t &node_size) {
 }
 
 void btree::split_child(shared_node &parent, shared_node &child, const uint64_t idx) {
-    DEBUG_PRINT("[BTREE]: split_child(parent.addr=%ld, child.addr=%ld, idx=%ld)\n", parent.addr(), child.addr(), idx);
+    DEBUG_PRINT("[BTREE]: split_child(parent.addr=%" PRIu64 ", child.addr=%" PRIu64 ", idx=%zu)\n", parent.addr(), child.addr(), idx);
     auto new_node = create_node();
 
     new_node->is_leaf = child->is_leaf;
@@ -570,7 +570,7 @@ void btree::free_node(const shared_node &node) {
 shared_node btree::create_node() { return reader.create_node(allocate_node()); }
 
 shared_node btree::read_node(uint64_t addr) {
-    DEBUG_PRINT("[BTREE][read_node]: addr=%lu\n", addr);
+    DEBUG_PRINT("[BTREE][read_node]: addr=%" PRIu64 "\n", addr);
     auto node = reader.read_node(addr);
     RO(node)->validate();
     return node;

--- a/src/btree.cpp
+++ b/src/btree.cpp
@@ -1,7 +1,9 @@
+#define __STDC_FORMAT_MACROS
 #include "compio/btree.hpp"
 
 #include <algorithm>
 #include <cassert>
+#include <cinttypes>
 #include <limits>
 #include <optional>
 

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -174,11 +174,28 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
     }
     if (is_new_file) {
         archive->header->compression_type = c->compressor.compression_type;
+        archive->header->block_size = c->block_size;
+        archive->header->b_tree_degree = c->b_tree_degree;
     } else if (readonly(archive->header, header)->compression_type !=
                c->compressor.compression_type) {
         // compression type mismatch
         errno = EINVAL;
         WARNING_PRINT("warning: compression type mismatch while opening archive\n");
+        goto no_allocator;
+    } else if (readonly(archive->header, header)->block_size != static_cast<uint32_t>(c->block_size)) {
+        errno = EINVAL;
+        WARNING_PRINT("warning: block_size mismatch while opening archive (file=%u, config=%d)\n",
+                      readonly(archive->header, header)->block_size, c->block_size);
+        goto no_allocator;
+    } else if (readonly(archive->header, header)->b_tree_degree != static_cast<uint32_t>(c->b_tree_degree)) {
+        errno = EINVAL;
+        WARNING_PRINT("warning: b_tree_degree mismatch while opening archive (file=%u, config=%d)\n",
+                      readonly(archive->header, header)->b_tree_degree, c->b_tree_degree);
+        goto no_allocator;
+    } else if (readonly(archive->header, header)->ftable.max_files != static_cast<uint32_t>(c->max_files)) {
+        errno = EINVAL;
+        WARNING_PRINT("warning: max_files mismatch while opening archive (file=%u, config=%d)\n",
+                      readonly(archive->header, header)->ftable.max_files, c->max_files);
         goto no_allocator;
     }
 

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -531,7 +531,7 @@ int compio_seek(compio_file *file, int64_t offset, uint8_t origin) {
     }
 
     file->cursor = new_cursor;
-    DEBUG_PRINT("\ncompio_seek(new_cursor=%ld)\n", new_cursor);
+    DEBUG_PRINT("\ncompio_seek(new_cursor=%" PRId64 ")\n", new_cursor);
     return 0;
 }
 
@@ -550,7 +550,7 @@ static void validate_no_gaps_in_range(const std::vector<std::pair<tree_key, tree
 
 static void validate_tree(btree *index, compio_file *file, bool allow_empty = false) {
 #ifndef NDEBUG
-    DEBUG_PRINT("[VALIDATE_TREE]: current btree state for file with hash=%lu:\n", file->hash);
+    DEBUG_PRINT("[VALIDATE_TREE]: current btree state for file with hash=%" PRIu64 ":\n", file->hash);
     auto file_range = index->get_range(tree_key{file->hash, 0}, tree_key{file->hash, UINT64_MAX});
     if (!allow_empty) {
         assert(!file_range.empty());
@@ -817,7 +817,7 @@ uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
 }
 
 uint64_t compio_insert(const void *ptr, uint64_t size, compio_file *file) {
-    DEBUG_PRINT("\ncompio_insert(cursor=%lu, size=%lu)\n", file->cursor, size);
+    DEBUG_PRINT("\ncompio_insert(cursor=%" PRIu64 ", size=%" PRIu64 ")\n", file->cursor, size);
 
     if (!file || !file->archive) {
         return 0;
@@ -973,7 +973,7 @@ uint64_t compio_erase(uint64_t size, compio_file *file) {
 
     block_reader->enable_temporary_index();
     for (const auto &[key, val] : range) {
-        DEBUG_PRINT("[CE]reading block ({%lu,%lu}-{%lu,%lu})\n", key.hash, key.pos, val.addr,
+        DEBUG_PRINT("[CE]reading block ({%" PRIu64 ",%" PRIu64 "}-{%" PRIu64 ",%" PRIu64 "})\n", key.hash, key.pos, val.addr,
                     val.size);
         const auto b = block_reader->read_block(val.addr, key);
         if (!b) {
@@ -994,12 +994,12 @@ uint64_t compio_erase(uint64_t size, compio_file *file) {
         const uint64_t erase_start_offset = block_erase_start - block_start;
         const uint64_t erase_end_offset = block_erase_end - block_start;
 
-        DEBUG_PRINT("[CE]block=(%lu, %lu), erase=(%lu, %lu) -> block_erase=(%lu, %lu)\n",
+        DEBUG_PRINT("[CE]block=(%" PRIu64 ", %" PRIu64 "), erase=(%" PRIu64 ", %" PRIu64 ") -> block_erase=(%" PRIu64 ", %" PRIu64 ")\n",
                     block_start, block_end, erase_start, erase_end, block_erase_start,
                     block_erase_end);
         const uint64_t left_size = erase_start_offset;
         const uint64_t right_size = block_end - block_erase_end;
-        DEBUG_PRINT("[CE]---left_size=%lu, erase_size=%lu, right_size=%lu\n", left_size,
+        DEBUG_PRINT("[CE]---left_size=%" PRIu64 ", erase_size=%" PRIu64 ", right_size=%" PRIu64 "\n", left_size,
                     block_erase_size, right_size);
 
         // TODO: merge with adjacent block if new size is small
@@ -1007,16 +1007,16 @@ uint64_t compio_erase(uint64_t size, compio_file *file) {
         if (block_erase_size < b->size()) {
             // keep block in btree, but update key.pos and val.size
             if (right_size > 0) {
-                DEBUG_PRINT("[CE]---copying %lu bytes from offset=%lu to offset=%lu\n", right_size,
+                DEBUG_PRINT("[CE]---copying %" PRIu64 " bytes from offset=%" PRIu64 " to offset=%" PRIu64 "\n", right_size,
                             erase_end_offset, erase_start_offset);
                 std::copy(b->data() + erase_end_offset, b->data() + b->size(),
                           b->data() + erase_start_offset);
             }
-            DEBUG_PRINT("[CE]---shrinking from size=%lu to size=%lu\n", b->size(),
+            DEBUG_PRINT("[CE]---shrinking from size=%" PRIu64 " to size=%" PRIu64 "\n", b->size(),
                         b->size() - block_erase_size);
             b->shrink(b->size() - block_erase_size);
             if (left_size == 0) {
-                DEBUG_PRINT("[CE]---moving by offset=%lu\n", block_erase_size);
+                DEBUG_PRINT("[CE]---moving by offset=%" PRIu64 "\n", block_erase_size);
                 archive->index->add_to_range(block_erase_size, key, key);
                 if (!block_reader->cache_contains(key)) {
                     // if out block not in cache (if cache_size=0), then block_reader->add_to_range

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -76,8 +76,8 @@ compio_archive::compio_archive(FILE *file, uint8_t mode_b, const compio_config *
 
 bool compio_archive::is_readonly() const { return mode_b & mode_bit::r; }
 
-static bool validate_config(const compio_config *c) {
-    if (c->block_size <= 0) {
+static bool validate_config(const compio_config *c, bool allow_zeros = false) {
+    if (c->block_size <= 0 && !allow_zeros) {
         WARNING_PRINT("warning: block_size=%d <= 0\n", c->block_size);
         return false;
     }
@@ -85,17 +85,19 @@ static bool validate_config(const compio_config *c) {
         WARNING_PRINT("warning: block_size__minimum=%d < 0\n", c->block_size__minimum);
         return false;
     }
-    if (c->block_size__minimum > c->block_size) {
-        WARNING_PRINT("warning: block_size__minimum=%d > block_size=%d\n", c->block_size__minimum,
-                      c->block_size);
-        return false;
+    if (!allow_zeros) {
+        if (c->block_size__minimum > c->block_size) {
+            WARNING_PRINT("warning: block_size__minimum=%d > block_size=%d\n", c->block_size__minimum,
+                        c->block_size);
+            return false;
+        }
+        if (c->block_size__maximum < c->block_size * 2) {
+            WARNING_PRINT("warning: block_size__maximum=%d < block_size*2=%d\n", c->block_size__maximum,
+                        c->block_size * 2);
+            return false;
+        }
     }
-    if (c->block_size__maximum < c->block_size * 2) {
-        WARNING_PRINT("warning: block_size__maximum=%d < block_size*2=%d\n", c->block_size__maximum,
-                      c->block_size * 2);
-        return false;
-    }
-    if (c->b_tree_degree <= 0) {
+    if (c->b_tree_degree <= 0 && !allow_zeros) {
         WARNING_PRINT("warning: b_tree_degree=%d <= 0\n", c->b_tree_degree);
         return false;
     }
@@ -110,7 +112,7 @@ static bool validate_config(const compio_config *c) {
         WARNING_PRINT("warning: cache_size__nodes=%d < 4\nplease use cache_size__nodes >= 4 ", c->cache_size__nodes);
         return false;
     }
-    if (c->max_files <= 0) {
+    if (c->max_files <= 0 && !allow_zeros) {
         WARNING_PRINT("warning: max_files=%d <= 0\n", c->max_files);
         return false;
     }
@@ -123,7 +125,7 @@ static bool validate_config(const compio_config *c) {
 }
 
 compio_archive *compio_open_archive(const char *fp, const char *mode, const compio_config *c) {
-    if (!validate_config(c)) {
+    if (!validate_config(c, true)) {
         errno = EINVAL;
         goto end;
     }
@@ -161,6 +163,16 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
 
     bool is_new_file;
     is_new_file = is_file_empty(file);
+
+    if (is_new_file) {
+        // For new files, we must have valid configuration (no zeros allowed)
+        if (!validate_config(c, false)) {
+            errno = EINVAL;
+            WARNING_PRINT("warning: cannot create new archive with zero parameters (auto-detect requires existing file)\n");
+            goto no_allocator;
+        }
+    }
+
     if (!is_new_file) {
         // Validate that file is large enough to contain a complete header
         fseek64(file, 0, SEEK_END);
@@ -176,27 +188,56 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
         archive->header->compression_type = c->compressor.compression_type;
         archive->header->block_size = c->block_size;
         archive->header->b_tree_degree = c->b_tree_degree;
-    } else if (readonly(archive->header, header)->compression_type !=
-               c->compressor.compression_type) {
-        // compression type mismatch
-        errno = EINVAL;
-        WARNING_PRINT("warning: compression type mismatch while opening archive\n");
-        goto no_allocator;
-    } else if (readonly(archive->header, header)->block_size != static_cast<uint32_t>(c->block_size)) {
-        errno = EINVAL;
-        WARNING_PRINT("warning: block_size mismatch while opening archive (file=%u, config=%d)\n",
-                      readonly(archive->header, header)->block_size, c->block_size);
-        goto no_allocator;
-    } else if (readonly(archive->header, header)->b_tree_degree != static_cast<uint32_t>(c->b_tree_degree)) {
-        errno = EINVAL;
-        WARNING_PRINT("warning: b_tree_degree mismatch while opening archive (file=%u, config=%d)\n",
-                      readonly(archive->header, header)->b_tree_degree, c->b_tree_degree);
-        goto no_allocator;
-    } else if (readonly(archive->header, header)->ftable.max_files != static_cast<uint32_t>(c->max_files)) {
-        errno = EINVAL;
-        WARNING_PRINT("warning: max_files mismatch while opening archive (file=%u, config=%d)\n",
-                      readonly(archive->header, header)->ftable.max_files, c->max_files);
-        goto no_allocator;
+    } else {
+        // "Smart Open" logic:
+        // If config specifies 0 for a parameter, we use the value from the file.
+        // Otherwise, we enforce the config value (validation).
+
+        const auto& hdr = *readonly(archive->header, header);
+        
+        // 1. Compression Type
+        if (hdr.compression_type != c->compressor.compression_type) {
+             // For compression, we can't just "adopt" it because we need the function pointers
+             // in c->compressor to match. If the user passed a compressor that doesn't match
+             // the file's type, it's a hard error unless we implement a way to auto-switch compressors.
+             // For now, we keep the existing strict check.
+            errno = EINVAL;
+            WARNING_PRINT("warning: compression type mismatch while opening archive\n");
+            goto no_allocator;
+        }
+
+        // 2. Block Size
+        if (c->block_size == 0) {
+             // Auto-detect
+             // We cast away constness because compio_archive stores a local copy of config,
+             // and we need to update that copy to reflect the file's reality.
+             const_cast<compio_config&>(archive->config).block_size = hdr.block_size;
+        } else if (hdr.block_size != static_cast<uint32_t>(c->block_size)) {
+            errno = EINVAL;
+            WARNING_PRINT("warning: block_size mismatch while opening archive (file=%u, config=%d)\n",
+                          hdr.block_size, c->block_size);
+            goto no_allocator;
+        }
+
+        // 3. B-Tree Degree
+        if (c->b_tree_degree == 0) {
+             const_cast<compio_config&>(archive->config).b_tree_degree = hdr.b_tree_degree;
+        } else if (hdr.b_tree_degree != static_cast<uint32_t>(c->b_tree_degree)) {
+            errno = EINVAL;
+            WARNING_PRINT("warning: b_tree_degree mismatch while opening archive (file=%u, config=%d)\n",
+                          hdr.b_tree_degree, c->b_tree_degree);
+            goto no_allocator;
+        }
+
+        // 4. Max Files
+        if (c->max_files == 0) {
+             const_cast<compio_config&>(archive->config).max_files = hdr.ftable.max_files;
+        } else if (hdr.ftable.max_files != static_cast<uint32_t>(c->max_files)) {
+            errno = EINVAL;
+            WARNING_PRINT("warning: max_files mismatch while opening archive (file=%u, config=%d)\n",
+                          hdr.ftable.max_files, c->max_files);
+            goto no_allocator;
+        }
     }
 
     // initialize allocator before btree, because btree uses allocator for creating root node

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -221,7 +221,10 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
 
         // 3. B-Tree Degree
         if (c->b_tree_degree == 0) {
+             // Auto-detect: adopt the degree from the file and update both the archive
+             // config and the local config pointer used later in this function.
              const_cast<compio_config&>(archive->config).b_tree_degree = hdr.b_tree_degree;
+             const_cast<compio_config*>(c)->b_tree_degree = static_cast<int>(hdr.b_tree_degree);
         } else if (hdr.b_tree_degree != static_cast<uint32_t>(c->b_tree_degree)) {
             errno = EINVAL;
             WARNING_PRINT("warning: b_tree_degree mismatch while opening archive (file=%u, config=%d)\n",

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -325,7 +325,8 @@ compio_file *compio_open_file(const char *name, compio_archive *archive) {
         file->cursor = 0;
 
     file->archive = archive;
-    strncpy(file->name, name, COMPIO_FNAME_MAX_SIZE);
+    strncpy(file->name, name, COMPIO_FNAME_MAX_SIZE - 1);
+    file->name[COMPIO_FNAME_MAX_SIZE - 1] = '\0';
 
     file->hash = fnv1a(name);
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -314,7 +314,8 @@ files_table::file *files_table::find(const char *name) {
 files_table::file *files_table::add(const char *name) {
     if (n_files >= max_files)
         return NULL;
-    strncpy(files[n_files].name, name, COMPIO_FNAME_MAX_SIZE);
+    strncpy(files[n_files].name, name, COMPIO_FNAME_MAX_SIZE - 1);
+    files[n_files].name[COMPIO_FNAME_MAX_SIZE - 1] = '\0';
     files[n_files].size = 0;
     return &files[n_files++];
 }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -54,7 +54,7 @@ uint64_t header::disk_size() const {
 }
 
 void header::read_from(FILE *file, uint64_t addr) {
-    DEBUG_PRINT("[R][header]addr=%lu\n", addr);
+    DEBUG_PRINT("[R][header]addr=%" PRIu64 "\n", addr);
     if (fseek64(file, addr, SEEK_SET))
         DEBUG_PRINT("warning: fseek failed\n");
     lendian_fread_member(magic_number, file);
@@ -92,7 +92,7 @@ void header::read_from(FILE *file, uint64_t addr) {
 }
 
 void header::write_to(FILE *file, uint64_t addr) const {
-    DEBUG_PRINT("[W][header]addr=%lu;size=%lu\n", addr, disk_size());
+    DEBUG_PRINT("[W][header]addr=%" PRIu64 ";size=%" PRIu64 "\n", addr, disk_size());
     if (fseek64(file, addr, SEEK_SET))
         DEBUG_PRINT("warning: fseek failed\n");
     lendian_fwrite_member(magic_number, file);
@@ -146,7 +146,7 @@ void index_node::read_from(FILE *file, uint64_t addr) {
 }
 
 void index_node::write_to(FILE *file, uint64_t addr) const {
-    DEBUG_PRINT("[W][index_node]addr=%" PRIu64 ";size=%lu\n", addr, (unsigned long)INDEX_NODE_SIZE(tree_degree));
+    DEBUG_PRINT("[W][index_node]addr=%" PRIu64 ";size=%" PRIu64 "\n", addr, (uint64_t)INDEX_NODE_SIZE(tree_degree));
     validate();
     if (fseek64(file, addr, SEEK_SET))
         DEBUG_PRINT("warning: fseek failed\n");
@@ -202,7 +202,7 @@ void index_node::validate() const {
             if (prev_end > keys[i].pos) {
                 DEBUG_PRINT("[NODE_VALIDATE]: node state:\n");
                 for (std::size_t j = 0; j < num_keys; ++j) {
-                    DEBUG_PRINT("\t{%lu,%lu} -> {%lu,%lu}\n", keys[j].hash, keys[j].pos,
+                    DEBUG_PRINT("\t{%" PRIu64 ",%" PRIu64 "} -> {%" PRIu64 ",%" PRIu64 "}\n", keys[j].hash, keys[j].pos,
                                 values[j].addr, values[j].size);
                 }
             }
@@ -213,7 +213,7 @@ void index_node::validate() const {
 }
 
 void storage_block::read_from(FILE *file, uint64_t addr) {
-    DEBUG_PRINT("[R][storage_block]addr=%lu\n", addr);
+    DEBUG_PRINT("[R][storage_block]addr=%" PRIu64 "\n", addr);
     assert(addr != 0);
     if (fseek64(file, addr, SEEK_SET))
         DEBUG_PRINT("warning: fseek failed\n");
@@ -230,7 +230,7 @@ void storage_block::read_from(FILE *file, uint64_t addr) {
     // Cap block size to prevent OOM on corrupted files
     static constexpr uint64_t MAX_BLOCK_SIZE = 256ULL * 1024 * 1024; // 256 MB
     if (size > MAX_BLOCK_SIZE) {
-        WARNING_PRINT("warning: storage_block size %" PRIu64 " exceeds limit at addr=%lu\n", size, addr);
+        WARNING_PRINT("warning: storage_block size %" PRIu64 " exceeds limit at addr=%" PRIu64 "\n", size, addr);
         size = 0;
         return;
     }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -25,7 +25,9 @@ header::header()
       ftable(),
       allocator_state_offset(0),
       allocator_state_size(0),
-      compression_type(COMPIO_COMPRESS_ZLIB) {
+      compression_type(COMPIO_COMPRESS_ZLIB),
+      block_size(0),
+      b_tree_degree(0) {
     file_size = disk_size();
 }
 
@@ -36,15 +38,18 @@ header::header(uint32_t max_files)
       ftable(max_files),
       allocator_state_offset(0),
       allocator_state_size(0),
-      compression_type(COMPIO_COMPRESS_ZLIB) {
+      compression_type(COMPIO_COMPRESS_ZLIB),
+      block_size(0),
+      b_tree_degree(0) {
     file_size = disk_size();
 }
 
 uint64_t header::disk_size() const {
     // magic_number(4) + index_root(8) + file_size(8) + allocator_state_offset(8)
-    // + allocator_state_size(8) + compression_type(4) + max_files(4)
+    // + allocator_state_size(8) + compression_type(4) + block_size(4) + b_tree_degree(4)
+    // + max_files(4)
     // + n_files(8) + files[max_files] * (32 + 8)
-    return 4 + 8 + 8 + 8 + 8 + 4 + 4 + 8 +
+    return 4 + 8 + 8 + 8 + 8 + 4 + 4 + 4 + 4 + 8 +
            static_cast<uint64_t>(ftable.max_files) * (COMPIO_FNAME_MAX_SIZE + 8);
 }
 
@@ -65,6 +70,8 @@ void header::read_from(FILE *file, uint64_t addr) {
     lendian_fread_member(allocator_state_offset, file);
     lendian_fread_member(allocator_state_size, file);
     lendian_fread_member(compression_type, file);
+    lendian_fread_member(block_size, file);
+    lendian_fread_member(b_tree_degree, file);
     lendian_fread_member(ftable.max_files, file);
     if (ftable.max_files == 0 || ftable.max_files > COMPIO_MAX_FILES_LIMIT) {
         WARNING_PRINT("warning: header max_files=%u is out of valid range [1, %u]\n",
@@ -94,6 +101,8 @@ void header::write_to(FILE *file, uint64_t addr) const {
     lendian_fwrite_member(allocator_state_offset, file);
     lendian_fwrite_member(allocator_state_size, file);
     lendian_fwrite_member(compression_type, file);
+    lendian_fwrite_member(block_size, file);
+    lendian_fwrite_member(b_tree_degree, file);
     lendian_fwrite_member(ftable.max_files, file);
     lendian_fwrite_member(ftable.n_files, file);
     for (uint32_t i = 0; i < ftable.max_files; ++i) {

--- a/src/storage_block_reader.cpp
+++ b/src/storage_block_reader.cpp
@@ -1,3 +1,4 @@
+#define __STDC_FORMAT_MACROS
 #include "compio/storage_block_reader.hpp"
 
 #include <cassert>
@@ -197,7 +198,7 @@ storage_block_reader::storage_block_reader(FILE *file, block_allocator *allocato
                                            const compio_compressor *compressor, int max_size,
                                            std::mutex *io_mutex)
     : cache(max_size),
-      context(file, allocator, index, compressor, io_mutex) {}
+      context{file, allocator, index, compressor, io_mutex} {}
 
 std::shared_ptr<block> storage_block_reader::read_block(uint64_t addr, tree_key key) {
     DEBUG_PRINT("[SBR][read_block]: addr=%" PRIu64 ", key.hash=%" PRIu64 ", key.pos=%" PRIu64 "\n", addr, key.hash,

--- a/src/storage_block_reader.cpp
+++ b/src/storage_block_reader.cpp
@@ -210,12 +210,13 @@ std::shared_ptr<block> storage_block_reader::read_block(uint64_t addr, tree_key 
     DEBUG_PRINT("[SBR][read_block]: cache miss\n");
     
     if (context.temp_index_refcount.load(std::memory_order_acquire) > 0) {
+        // Only lock if temporary index is active (double-checked optimization)
         std::lock_guard<std::mutex> lock(context.temp_index_mutex);
         // check in temporary index first
         auto it = context.temporary_index.find(key);
         if (it != context.temporary_index.end()) {
             addr = it->second;
-            DEBUG_PRINT("[SBR][read_block]: getting addr from temporary_index: addr=%" PRIu64 "\n", addr);
+            DEBUG_PRINT("[SBR][read_block]: getting addr from temporary_index: addr=%" PRIu64 "\n", (uint64_t)addr);
         }
 #ifndef NDEBUG
             auto val = context.index->get(key);
@@ -243,13 +244,13 @@ std::shared_ptr<block> storage_block_reader::read_block(uint64_t addr, tree_key 
 }
 
 std::shared_ptr<block> storage_block_reader::create_block(uint64_t size, tree_key key) {
-    DEBUG_PRINT("[SBR][create_block]: size=%" PRIu64 ", key.hash=%" PRIu64 ", key.pos=%" PRIu64 "\n", size, key.hash,
-                key.pos);
+    DEBUG_PRINT("[SBR][create_block]: size=%" PRIu64 ", key.hash=%" PRIu64 ", key.pos=%" PRIu64 "\n", 
+                (uint64_t)size, (uint64_t)key.hash, (uint64_t)key.pos);
     auto b_cached = cache.get(key);
     if (b_cached.has_value()) {
         WARNING_PRINT("warning: trying to create block with key (%" PRIu64 ", %" PRIu64 "), that "
                       "already exists in storage_block_reader.cache\n",
-                      key.hash, key.pos);
+                      (uint64_t)key.hash, (uint64_t)key.pos);
         return b_cached.value();
     }
     auto b = std::make_shared<block>(context, key, size, false);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(compio_gtest
     src/test_concurrency.cpp
     src/test_concurrency_advanced.cpp
     src/test_header_validation.cpp
+    src/test_max_files_scalability.cpp
 )
 
 target_link_libraries(compio_gtest PRIVATE compio GTest::GTest GTest::Main)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(compio_gtest
     src/test_max_files.cpp
     src/test_concurrency.cpp
     src/test_concurrency_advanced.cpp
+    src/test_header_validation.cpp
 )
 
 target_link_libraries(compio_gtest PRIVATE compio GTest::GTest GTest::Main)

--- a/tests/src/test_header_validation.cpp
+++ b/tests/src/test_header_validation.cpp
@@ -78,3 +78,32 @@ TEST_F(HeaderValidationTest, ValidateBTreeDegreeMismatch) {
     EXPECT_EQ(archive, nullptr);
     if (archive) compio_close_archive(archive);
 }
+
+TEST_F(HeaderValidationTest, SmartOpenAutoDetect) {
+    compio_config config;
+    compio_build_default_config(&config);
+    config.max_files = 10;
+    config.block_size = 4096;
+    config.b_tree_degree = 8;
+
+    // Create archive with specific parameters
+    auto* archive = compio_open_archive(filename.c_str(), "w", &config);
+    ASSERT_NE(archive, nullptr);
+    compio_close_archive(archive);
+
+    // Now open with all zeroes (auto-detect)
+    config.max_files = 0;
+    config.block_size = 0;
+    config.b_tree_degree = 0;
+
+    // Open for reading - should succeed and adopt values
+    archive = compio_open_archive(filename.c_str(), "r", &config);
+    ASSERT_NE(archive, nullptr) << "Smart Open failed to auto-detect parameters";
+    
+    // Verify that the archive adopted the file's parameters
+    EXPECT_EQ(archive->config.max_files, 10);
+    EXPECT_EQ(archive->config.block_size, 4096);
+    EXPECT_EQ(archive->config.b_tree_degree, 8);
+    
+    if (archive) compio_close_archive(archive);
+}

--- a/tests/src/test_header_validation.cpp
+++ b/tests/src/test_header_validation.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+#include "compio.h"
+#include "compio/file.hpp" // for header details (optional)
+#include "compio/compio_file.hpp"
+
+// We need access to internal archive struct for verification if needed, 
+// but integration test via public API is sufficient for validation check.
+
+class HeaderValidationTest : public ::testing::Test {
+protected:
+    std::string filename = "test_header_val.compio";
+
+    void SetUp() override {
+        remove(filename.c_str());
+    }
+
+    void TearDown() override {
+        // cleanup
+        remove(filename.c_str());
+    }
+};
+
+TEST_F(HeaderValidationTest, ValidateMaxFilesMismatch) {
+    compio_config config;
+    compio_build_default_config(&config);
+    config.max_files = 10;
+    config.block_size = 4096;
+
+    // Create archive
+    auto* archive = compio_open_archive(filename.c_str(), "w", &config);
+    ASSERT_NE(archive, nullptr);
+    compio_close_archive(archive);
+
+    // Try open with different max_files
+    config.max_files = 64;
+    archive = compio_open_archive(filename.c_str(), "r", &config);
+    
+    // Expect failure due to mismatch
+    EXPECT_EQ(archive, nullptr);
+    if (archive) compio_close_archive(archive);
+}
+
+TEST_F(HeaderValidationTest, ValidateBlockSizeMismatch) {
+    compio_config config;
+    compio_build_default_config(&config);
+    config.max_files = 10;
+    config.block_size = 4096;
+
+    // Create archive
+    auto* archive = compio_open_archive(filename.c_str(), "w", &config);
+    ASSERT_NE(archive, nullptr);
+    compio_close_archive(archive);
+
+    // Try open with different block_size
+    config.block_size = 1024;
+    archive = compio_open_archive(filename.c_str(), "r", &config);
+    
+    // Expect failure due to mismatch
+    EXPECT_EQ(archive, nullptr);
+    if (archive) compio_close_archive(archive);
+}
+
+TEST_F(HeaderValidationTest, ValidateBTreeDegreeMismatch) {
+    compio_config config;
+    compio_build_default_config(&config);
+    config.b_tree_degree = 16;
+    
+    // Create archive
+    auto* archive = compio_open_archive(filename.c_str(), "w", &config);
+    ASSERT_NE(archive, nullptr);
+    compio_close_archive(archive);
+
+    // Try open with different degree
+    config.b_tree_degree = 8;
+    archive = compio_open_archive(filename.c_str(), "r", &config);
+    
+    // Expect failure due to mismatch
+    EXPECT_EQ(archive, nullptr);
+    if (archive) compio_close_archive(archive);
+}

--- a/tests/src/test_max_files.cpp
+++ b/tests/src/test_max_files.cpp
@@ -26,7 +26,7 @@ TEST_F(MaxFilesTest, DiskSizeReflectsMaxFiles) {
     ASSERT_NE(ar, nullptr);
 
     const uint64_t expected =
-        4 + 8 + 8 + 8 + 8 + 4 + 4 + 8 +
+        4 + 8 + 8 + 8 + 8 + 4 + 4 + 4 + 4 + 8 +
         static_cast<uint64_t>(128) * (COMPIO_FNAME_MAX_SIZE + 8);
     EXPECT_EQ(ar->header->disk_size(), expected);
     EXPECT_EQ(ar->header->ftable.max_files, 128u);
@@ -57,6 +57,7 @@ TEST_F(MaxFilesTest, MaxFilesPersistsAcrossReopen) {
     {
         compio_config cfg;
         compio_build_default_config(&cfg);
+        cfg.max_files = 0; // Use smart open to detect max_files
 
         compio_archive *ar = compio_open_archive(fn, "r", &cfg);
         ASSERT_NE(ar, nullptr);
@@ -65,7 +66,7 @@ TEST_F(MaxFilesTest, MaxFilesPersistsAcrossReopen) {
             << "max_files should be read back from disk unchanged";
 
         const uint64_t expected =
-            4 + 8 + 8 + 8 + 8 + 4 + 4 + 8 +
+            4 + 8 + 8 + 8 + 8 + 4 + 4 + 4 + 4 + 8 +
             static_cast<uint64_t>(custom_max) * (COMPIO_FNAME_MAX_SIZE + 8);
         EXPECT_EQ(ar->header->disk_size(), expected);
 

--- a/tests/src/test_max_files_scalability.cpp
+++ b/tests/src/test_max_files_scalability.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <cstdio>
+#include <cstdint>
 #include "compio/compio_file.hpp"
 
 // We need to define Test class
@@ -40,8 +41,8 @@ TEST_F(ScalabilityTest, HandleLargeFileCount) {
         ASSERT_NE(file, nullptr) << "Failed to open inner file " << name;
         
         std::string content = "Content of " + name;
-        ssize_t written = compio_write(content.c_str(), content.size(), file);
-        EXPECT_EQ(written, content.size());
+        int64_t written = compio_write(content.c_str(), content.size(), file);
+        EXPECT_EQ(written, static_cast<int64_t>(content.size()));
         
         compio_close_file(file);
         filenames.push_back(name);
@@ -66,7 +67,7 @@ TEST_F(ScalabilityTest, HandleLargeFileCount) {
         ASSERT_NE(file, nullptr) << "Failed to open inner file " << name;
         
         char buffer[100];
-        ssize_t bytes_read = compio_read(buffer, sizeof(buffer), file);
+        int64_t bytes_read = compio_read(buffer, sizeof(buffer), file);
         if (bytes_read >= 0) {
             buffer[bytes_read] = '\0';
             std::string expected = "Content of " + name;

--- a/tests/src/test_max_files_scalability.cpp
+++ b/tests/src/test_max_files_scalability.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+#include "compio.h"
+#include <string>
+#include <vector>
+#include <cstdio>
+#include "compio/compio_file.hpp"
+
+// We need to define Test class
+class ScalabilityTest : public ::testing::Test {
+protected:
+    std::string filename = "scalability_test_large.compio";
+
+    void SetUp() override {
+        remove(filename.c_str());
+    }
+
+    void TearDown() override {
+        remove(filename.c_str());
+    }
+};
+
+TEST_F(ScalabilityTest, HandleLargeFileCount) {
+    const int NUM_FILES = 500; // Demonstrating significantly more than 64. 500 is enough to prove scalability without taking too long.
+    
+    compio_config config;
+    compio_build_default_config(&config);
+    config.max_files = NUM_FILES + 10; 
+    config.block_size = 4096;
+    config.b_tree_degree = 8;
+    
+    // Create archive
+    auto* archive = compio_open_archive(filename.c_str(), "w", &config);
+    ASSERT_NE(archive, nullptr) << "Failed to create archive with max_files=" << config.max_files;
+
+    std::vector<std::string> filenames;
+    for (int i = 0; i < NUM_FILES; ++i) {
+        std::string name = "file_" + std::to_string(i) + ".txt";
+        
+        auto* file = compio_open_file(name.c_str(), archive);
+        ASSERT_NE(file, nullptr) << "Failed to open inner file " << name;
+        
+        std::string content = "Content of " + name;
+        ssize_t written = compio_write(content.c_str(), content.size(), file);
+        EXPECT_EQ(written, content.size());
+        
+        compio_close_file(file);
+        filenames.push_back(name);
+    }
+    compio_close_archive(archive);
+
+    // Reopen using Smart Open (auto-detect max_files=0)
+    config.max_files = 0; 
+    archive = compio_open_archive(filename.c_str(), "r", &config);
+    ASSERT_NE(archive, nullptr) << "Failed to reopen archive with Smart Open";
+    
+    // Verify auto-detected value
+    EXPECT_EQ(archive->config.max_files, NUM_FILES + 10);
+
+    // Verify content of a few files to be sure
+    // Check first, middle, last
+    std::vector<int> check_indices = {0, NUM_FILES/2, NUM_FILES-1};
+    
+    for (int idx : check_indices) {
+        std::string name = filenames[idx];
+        auto* file = compio_open_file(name.c_str(), archive);
+        ASSERT_NE(file, nullptr) << "Failed to open inner file " << name;
+        
+        char buffer[100];
+        ssize_t bytes_read = compio_read(buffer, sizeof(buffer), file);
+        if (bytes_read >= 0) {
+            buffer[bytes_read] = '\0';
+            std::string expected = "Content of " + name;
+            EXPECT_EQ(std::string(buffer), expected);
+        } else {
+            ADD_FAILURE() << "Read failed for " << name;
+        }
+        
+        compio_close_file(file);
+    }
+    
+    compio_close_archive(archive);
+}


### PR DESCRIPTION
- Persist block_size and b_tree_degree in archive header
- Implement strict parameter validation on open (prevents corruption)
- Add "Smart Open" (auto-detect parameters if config has 0)
- Add validation and scalability tests