### PR TITLE
feat: implement WAL transactions and recovery

### DIFF
--- a/include/compio/wal.hpp
+++ b/include/compio/wal.hpp
@@ -55,6 +55,9 @@ public:
     // Commit the current transaction
     bool commit_transaction();
 
+    // Rollback transaction (decrements depth without writing COMMIT record)
+    void rollback_transaction();
+
     // Sync the WAL to disk
     bool sync();
 

--- a/include/compio/wal.hpp
+++ b/include/compio/wal.hpp
@@ -34,6 +34,7 @@ class WalManager {
     FILE* wal_file_;
     std::mutex mutex_;
     uint64_t current_transaction_id_;
+    int transaction_depth_ = 0;
 
 public:
     explicit WalManager(const std::string& archive_path);
@@ -47,6 +48,12 @@ public:
 
     // Write a record to the WAL
     bool log_write(WalRecordType type, uint64_t addr, const void* data, uint64_t size);
+
+    // Begin a new transaction
+    void begin_transaction();
+
+    // Commit the current transaction
+    bool commit_transaction();
 
     // Sync the WAL to disk
     bool sync();

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -557,6 +557,7 @@ bool free_blocks_manager::save_to_file(compio_archive *archive) {
         archive->wal->begin_transaction();
         if (!archive->wal->log_write(WalRecordType::ALLOCATOR, pos, buffer.data(), size)) {
             WARNING_PRINT("warning: WAL log_write failed in allocator.save_state\n");
+            archive->wal->rollback_transaction();
             return false;
         }
         if (!archive->wal->commit_transaction()) {

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -554,12 +554,13 @@ bool free_blocks_manager::save_to_file(compio_archive *archive) {
     }
 
     if (archive->wal) {
+        archive->wal->begin_transaction();
         if (!archive->wal->log_write(WalRecordType::ALLOCATOR, pos, buffer.data(), size)) {
             WARNING_PRINT("warning: WAL log_write failed in allocator.save_state\n");
             return false;
         }
-        if (!archive->wal->sync()) {
-            WARNING_PRINT("warning: WAL sync failed in allocator.save_state\n");
+        if (!archive->wal->commit_transaction()) {
+            WARNING_PRINT("warning: WAL commit failed in allocator.save_state\n");
             return false;
         }
     }

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -1227,8 +1227,12 @@ void compio_flush(compio_archive *archive) {
     std::unique_lock<std::shared_mutex> lock(archive->mutex);
     
     // Start atomic transaction for the entire flush operation
-    if (archive->wal) archive->wal->begin_transaction();
-    
+    bool wal_active = false;
+    if (archive->wal && !(archive->mode_b & mode_bit::r)) {
+        archive->wal->begin_transaction();
+        wal_active = true;
+    }
+
     if (archive->block_reader) archive->block_reader->clear_cache();
     if (archive->block_reader) archive->block_reader->invalidate_temporary_index();
     if (archive->index) archive->index->clear_cache();
@@ -1242,7 +1246,7 @@ void compio_flush(compio_archive *archive) {
     flush_header_double_buffered(archive);
     
     // Commit transaction (this performs a single fsync on the WAL)
-    if (archive->wal) {
+    if (wal_active && archive->wal) {
         if (!archive->wal->commit_transaction()) {
             WARNING_PRINT("warning: WAL commit failed in compio_flush\n");
         }

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -663,6 +663,9 @@ int compio_close_archive(compio_archive *archive) {
     // At this point, all data is synced to the archive file (via flush and header update).
     // The WAL is redundant now.
     if (archive->wal) {
+        // Commit any pending transaction before clearing (though close logic usually implies clean state)
+        // Actually, we don't need commit here, as flush_header_double_buffered creates its own atomic write.
+        // And compio_flush called earlier committed its changes.
         archive->wal->clear();
     }
 
@@ -1222,6 +1225,10 @@ uint64_t compio_erase(uint64_t size, compio_file *file) {
 void compio_flush(compio_archive *archive) {
     if (!archive) return;
     std::unique_lock<std::shared_mutex> lock(archive->mutex);
+    
+    // Start atomic transaction for the entire flush operation
+    if (archive->wal) archive->wal->begin_transaction();
+    
     if (archive->block_reader) archive->block_reader->clear_cache();
     if (archive->block_reader) archive->block_reader->invalidate_temporary_index();
     if (archive->index) archive->index->clear_cache();
@@ -1233,6 +1240,13 @@ void compio_flush(compio_archive *archive) {
     
     // Double-buffered Header Write
     flush_header_double_buffered(archive);
+    
+    // Commit transaction (this performs a single fsync on the WAL)
+    if (archive->wal) {
+        if (!archive->wal->commit_transaction()) {
+            WARNING_PRINT("warning: WAL commit failed in compio_flush\n");
+        }
+    }
 
     if (fflush(archive->file)) {
         WARNING_PRINT("warning: fflush failed\n");

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -148,13 +148,67 @@ void header::read_from(FILE *file, uint64_t addr) {
 }
 
 void header::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_manager) const {
-    UNUSED(wal_manager);
     DEBUG_PRINT("[W][header]addr=%" PRIu64 ";size=%" PRIu64 "\n", addr, disk_size());
     
     // Auto-update checksum before writing
     // We cast away const because we want the on-disk structure to be correct, 
     // and updating the checksum member is logically part of the serialization process.
     const_cast<header*>(this)->compute_checksum(const_cast<uint8_t*>(checksum));
+
+    if (wal_manager) {
+        wal_manager->begin_transaction();
+        // Serialize to buffer for WAL
+        std::vector<uint8_t> buffer;
+        buffer.reserve(4096); 
+        
+        auto push_u32 = [&](uint32_t v) { 
+            for(int i=0; i<4; ++i) buffer.push_back(static_cast<uint8_t>(v >> (i*8))); 
+        };
+        auto push_u64 = [&](uint64_t v) { 
+            for(int i=0; i<8; ++i) buffer.push_back(static_cast<uint8_t>(v >> (i*8))); 
+        };
+        
+        // Serialize header fields
+        // magic(4)
+        for(int i=0; i<4; ++i) buffer.push_back(static_cast<uint8_t>(magic_number >> (i*8)));
+        // checksum(32)
+        buffer.insert(buffer.end(), checksum, checksum + 32);
+        // sequence_id(8)
+        push_u64(sequence_id);
+        // index_root(8)
+        push_u64(index_root);
+        // file_size(8)
+        push_u64(file_size);
+        // allocator_state_offset(8)
+        push_u64(allocator_state_offset);
+        // allocator_state_size(8)
+        push_u64(allocator_state_size);
+        // compression_type(4)
+        push_u32(compression_type);
+        // block_size(4)
+        push_u32(block_size);
+        // b_tree_degree(4)
+        push_u32(b_tree_degree);
+        // max_files(4)
+        push_u32(ftable.max_files);
+        // n_files(8)
+        push_u64(ftable.n_files);
+        
+        for (uint32_t i = 0; i < ftable.max_files; ++i) {
+            // name(32)
+            buffer.insert(buffer.end(), ftable.files[i].name, ftable.files[i].name + COMPIO_FNAME_MAX_SIZE);
+            // size(8)
+            push_u64(ftable.files[i].size);
+        }
+        
+        if (!wal_manager->log_write(WalRecordType::HEADER, addr, buffer.data(), buffer.size())) {
+            WARNING_PRINT("error: WAL log_write failed for header at addr=%" PRIu64 "\n", addr);
+        }
+        
+        if (!wal_manager->commit_transaction()) {
+            WARNING_PRINT("error: WAL commit failed for header at addr=%" PRIu64 "\n", addr);
+        }
+    }
 
     if (fseek64(file, addr, SEEK_SET))
         DEBUG_PRINT("warning: fseek failed\n");
@@ -258,11 +312,12 @@ void index_node::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_man
     }
 
     if (wal_manager) {
+        wal_manager->begin_transaction();
         if (!wal_manager->log_write(WalRecordType::INDEX_NODE, addr, buffer.data(), buffer.size())) {
             WARNING_PRINT("error: WAL log_write failed for index_node at addr=%" PRIu64 "\n", addr);
         }
-        if (!wal_manager->sync()) {
-            WARNING_PRINT("error: WAL sync failed for index_node at addr=%" PRIu64 "\n", addr);
+        if (!wal_manager->commit_transaction()) {
+            WARNING_PRINT("error: WAL commit failed for index_node at addr=%" PRIu64 "\n", addr);
         }
     }
 
@@ -385,11 +440,12 @@ void storage_block::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_
     }
 
     if (wal_manager) {
+        wal_manager->begin_transaction();
         if (!wal_manager->log_write(WalRecordType::BLOCK, addr, buffer.data(), buffer.size())) {
             WARNING_PRINT("error: WAL log_write failed for storage_block at addr=%" PRIu64 "\n", addr);
         }
-        if (!wal_manager->sync()) {
-             WARNING_PRINT("error: WAL sync failed for storage_block at addr=%" PRIu64 "\n", addr);
+        if (!wal_manager->commit_transaction()) {
+            WARNING_PRINT("error: WAL commit failed for storage_block at addr=%" PRIu64 "\n", addr);
         }
     }
 

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -80,9 +80,54 @@ bool WalManager::log_write(WalRecordType type, uint64_t addr, const void* data, 
     return true;
 }
 
+void WalManager::begin_transaction() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (transaction_depth_ == 0) {
+        current_transaction_id_++;
+    }
+    transaction_depth_++;
+}
+
+bool WalManager::commit_transaction() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (transaction_depth_ == 0) return false;
+
+    transaction_depth_--;
+    if (transaction_depth_ > 0) return true; // Nested commit, defer actual commit
+
+    // Write COMMIT record
+    // Type=255, Addr=0, Size=0, Checksum=0
+    uint8_t type = static_cast<uint8_t>(WalRecordType::COMMIT);
+    uint64_t zero = 0;
+    uint32_t zero32 = 0;
+    
+    if (fwrite(&type, sizeof(uint8_t), 1, wal_file_) != 1) return false;
+    if (fwrite(&zero, sizeof(uint64_t), 1, wal_file_) != 1) return false; // Addr
+    if (fwrite(&zero, sizeof(uint64_t), 1, wal_file_) != 1) return false; // Size
+    if (fwrite(&zero32, sizeof(uint32_t), 1, wal_file_) != 1) return false; // Checksum
+    
+    if (fflush(wal_file_) != 0) return false;
+
+    // Force sync for durability
+#ifdef _WIN32
+    int fd = _fileno(wal_file_);
+    if (_commit(fd) != 0) return false;
+#else
+    int fd = fileno(wal_file_);
+    if (fsync(fd) != 0) return false;
+#endif
+
+    return true;
+}
+
 bool WalManager::sync() {
     std::lock_guard<std::mutex> lock(mutex_);
     if (!wal_file_) return false;
+    
+    if (transaction_depth_ > 0) {
+        // Defer sync until outermost commit
+        return true;
+    }
     
     if (fflush(wal_file_) != 0) return false;
     
@@ -144,46 +189,70 @@ bool WalManager::recover(FILE* archive_file) {
         return true;
     }
 
-    bool success = true;
+    // Pass 1: Scan for valid transactions
+    uint64_t valid_limit = 0;
+    uint64_t current_pos = 0;
     while (true) {
+        current_pos = ftell64(wal_in);
+        
         uint8_t type_u8;
-        if (fread(&type_u8, sizeof(uint8_t), 1, wal_in) != 1) {
-            if (feof(wal_in)) break; // Clean EOF
-            success = false;
-            break; // Read error
-        }
+        if (fread(&type_u8, sizeof(uint8_t), 1, wal_in) != 1) break;
         
         uint64_t addr;
-        if (fread(&addr, sizeof(uint64_t), 1, wal_in) != 1) {
-            success = false;
-            break; // Partial record
-        }
+        if (fread(&addr, sizeof(uint64_t), 1, wal_in) != 1) break;
         
         uint64_t data_size;
-        if (fread(&data_size, sizeof(uint64_t), 1, wal_in) != 1) {
-            success = false;
-            break;
-        }
+        if (fread(&data_size, sizeof(uint64_t), 1, wal_in) != 1) break;
         
         uint32_t expected_checksum;
-        if (fread(&expected_checksum, sizeof(uint32_t), 1, wal_in) != 1) {
-            success = false;
-            break;
+        if (fread(&expected_checksum, sizeof(uint32_t), 1, wal_in) != 1) break;
+        
+        if (data_size > 0) {
+            if (fseek64(wal_in, data_size, SEEK_CUR) != 0) break;
         }
+        
+        // Note: In Pass 1 we strictly rely on COMMIT record to mark valid boundary.
+        // But for backward compatibility (allocator records without COMMIT), we might need to be smarter.
+        // However, we just updated allocator to use COMMIT.
+        // What if we have old WALs? They will be ignored!
+        // This is a risk. But typically WAL is empty on upgrade.
+        // Let's assume we require COMMIT for durability.
+        
+        if (type_u8 == static_cast<uint8_t>(WalRecordType::COMMIT)) {
+            valid_limit = ftell64(wal_in);
+        }
+    }
+    
+    // Pass 2: Replay up to valid_limit
+    rewind(wal_in);
+    bool success = true;
+    
+    while (ftell64(wal_in) < valid_limit) {
+        uint8_t type_u8;
+        if (fread(&type_u8, sizeof(uint8_t), 1, wal_in) != 1) { success = false; break; }
+        
+        uint64_t addr;
+        if (fread(&addr, sizeof(uint64_t), 1, wal_in) != 1) { success = false; break; }
+        
+        uint64_t data_size;
+        if (fread(&data_size, sizeof(uint64_t), 1, wal_in) != 1) { success = false; break; }
+        
+        uint32_t expected_checksum;
+        if (fread(&expected_checksum, sizeof(uint32_t), 1, wal_in) != 1) { success = false; break; }
         
         std::vector<uint8_t> buffer(data_size);
         if (data_size > 0) {
-            if (fread(buffer.data(), 1, data_size, wal_in) != data_size) {
-                success = false;
-                break;
-            }
+            if (fread(buffer.data(), 1, data_size, wal_in) != data_size) { success = false; break; }
         }
+        
+        // Skip COMMIT records during replay
+        if (type_u8 == static_cast<uint8_t>(WalRecordType::COMMIT)) continue;
         
         // Verify checksum
         if (calculate_checksum(buffer.data(), data_size) != expected_checksum) {
             fprintf(stderr, "[WAL] Corrupt record at addr %" PRIu64 ". Stopping recovery.\n", addr);
             success = false;
-            break; // Stop or fail? Stop prevents writing bad data.
+            break;
         }
         
         // Apply to archive

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -227,6 +227,10 @@ bool WalManager::recover(FILE* archive_file) {
     rewind(wal_in);
     bool success = true;
     
+    // Buffer of pending records for the current transaction. These are only
+    // applied to the archive when a COMMIT record is encountered.
+    std::vector<std::pair<uint64_t, std::vector<uint8_t>>> pending_records;
+
     while (ftell64(wal_in) < valid_limit) {
         uint8_t type_u8;
         if (fread(&type_u8, sizeof(uint8_t), 1, wal_in) != 1) { success = false; break; }
@@ -245,23 +249,40 @@ bool WalManager::recover(FILE* archive_file) {
             if (fread(buffer.data(), 1, data_size, wal_in) != data_size) { success = false; break; }
         }
         
-        // Skip COMMIT records during replay
-        if (type_u8 == static_cast<uint8_t>(WalRecordType::COMMIT)) continue;
-        
-        // Verify checksum
+        // Verify checksum before doing anything with the record
         if (calculate_checksum(buffer.data(), data_size) != expected_checksum) {
             fprintf(stderr, "[WAL] Corrupt record at addr %" PRIu64 ". Stopping recovery.\n", addr);
             success = false;
             break;
         }
-        
-        // Apply to archive
-        fseek64(archive_file, addr, SEEK_SET);
-        if (fwrite(buffer.data(), 1, data_size, archive_file) != data_size) {
-            fprintf(stderr, "[WAL] Failed to write recovered data to archive.\n");
-            success = false;
-            break;
+
+        // On COMMIT, apply all buffered records atomically to the archive.
+        if (type_u8 == static_cast<uint8_t>(WalRecordType::COMMIT)) {
+            for (const auto &rec : pending_records) {
+                uint64_t rec_addr = rec.first;
+                const std::vector<uint8_t> &rec_data = rec.second;
+                if (fseek64(archive_file, rec_addr, SEEK_SET) != 0) {
+                    fprintf(stderr, "[WAL] Failed to seek during recovery.\n");
+                    success = false;
+                    break;
+                }
+                if (!rec_data.empty() &&
+                    fwrite(rec_data.data(), 1, rec_data.size(), archive_file) != rec_data.size()) {
+                    fprintf(stderr, "[WAL] Failed to write recovered data to archive.\n");
+                    success = false;
+                    break;
+                }
+            }
+            if (!success) {
+                break;
+            }
+            // Successfully applied this transaction; clear buffer for next one.
+            pending_records.clear();
+            continue;
         }
+        
+        // Non-COMMIT records are buffered until we see a COMMIT.
+        pending_records.emplace_back(addr, std::move(buffer));
     }
     
     fclose(wal_in);

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -82,6 +82,8 @@ bool WalManager::log_write(WalRecordType type, uint64_t addr, const void* data, 
 
 void WalManager::begin_transaction() {
     std::lock_guard<std::mutex> lock(mutex_);
+    if (!wal_file_) return;
+
     if (transaction_depth_ == 0) {
         current_transaction_id_++;
     }
@@ -90,6 +92,8 @@ void WalManager::begin_transaction() {
 
 bool WalManager::commit_transaction() {
     std::lock_guard<std::mutex> lock(mutex_);
+    if (!wal_file_) return false;
+
     if (transaction_depth_ == 0) return false;
 
     transaction_depth_--;
@@ -118,6 +122,13 @@ bool WalManager::commit_transaction() {
 #endif
 
     return true;
+}
+
+void WalManager::rollback_transaction() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (transaction_depth_ > 0) {
+        transaction_depth_--;
+    }
 }
 
 bool WalManager::sync() {
@@ -191,9 +202,8 @@ bool WalManager::recover(FILE* archive_file) {
 
     // Pass 1: Scan for valid transactions
     uint64_t valid_limit = 0;
-    uint64_t current_pos = 0;
     while (true) {
-        current_pos = ftell64(wal_in);
+        // current_pos was unused
         
         uint8_t type_u8;
         if (fread(&type_u8, sizeof(uint8_t), 1, wal_in) != 1) break;
@@ -204,6 +214,13 @@ bool WalManager::recover(FILE* archive_file) {
         uint64_t data_size;
         if (fread(&data_size, sizeof(uint64_t), 1, wal_in) != 1) break;
         
+        // Sanity check for data size to prevent OOM on corrupt WAL
+        // 1GB limit seems reasonable for a single record? Or even smaller.
+        // Block size is usually 4KB-64KB. Header is small.
+        if (data_size > 1024 * 1024 * 1024) { // 1GB
+             break;
+        }
+
         uint32_t expected_checksum;
         if (fread(&expected_checksum, sizeof(uint32_t), 1, wal_in) != 1) break;
         
@@ -219,7 +236,10 @@ bool WalManager::recover(FILE* archive_file) {
         // Let's assume we require COMMIT for durability.
         
         if (type_u8 == static_cast<uint8_t>(WalRecordType::COMMIT)) {
-            valid_limit = ftell64(wal_in);
+            // Validate COMMIT record structure: addr=0, size=0, checksum=0
+            if (addr == 0 && data_size == 0 && expected_checksum == 0) {
+                valid_limit = ftell64(wal_in);
+            }
         }
     }
     

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -100,15 +100,17 @@ bool WalManager::commit_transaction() {
     if (transaction_depth_ > 0) return true; // Nested commit, defer actual commit
 
     // Write COMMIT record
-    // Type=255, Addr=0, Size=0, Checksum=0
+    // Type=255, Addr=0, Size=0, Checksum=FNV1a(empty)
     uint8_t type = static_cast<uint8_t>(WalRecordType::COMMIT);
     uint64_t zero = 0;
-    uint32_t zero32 = 0;
+    
+    // Compute checksum of empty data for consistency
+    uint32_t checksum = calculate_checksum(nullptr, 0);
     
     if (fwrite(&type, sizeof(uint8_t), 1, wal_file_) != 1) return false;
     if (fwrite(&zero, sizeof(uint64_t), 1, wal_file_) != 1) return false; // Addr
     if (fwrite(&zero, sizeof(uint64_t), 1, wal_file_) != 1) return false; // Size
-    if (fwrite(&zero32, sizeof(uint32_t), 1, wal_file_) != 1) return false; // Checksum
+    if (fwrite(&checksum, sizeof(uint32_t), 1, wal_file_) != 1) return false; // Checksum
     
     if (fflush(wal_file_) != 0) return false;
 
@@ -236,8 +238,9 @@ bool WalManager::recover(FILE* archive_file) {
         // Let's assume we require COMMIT for durability.
         
         if (type_u8 == static_cast<uint8_t>(WalRecordType::COMMIT)) {
-            // Validate COMMIT record structure: addr=0, size=0, checksum=0
-            if (addr == 0 && data_size == 0 && expected_checksum == 0) {
+            // Validate COMMIT record structure: addr=0, size=0, checksum=valid
+            uint32_t valid_checksum = calculate_checksum(nullptr, 0);
+            if (addr == 0 && data_size == 0 && expected_checksum == valid_checksum) {
                 valid_limit = ftell64(wal_in);
             }
         }
@@ -270,10 +273,7 @@ bool WalManager::recover(FILE* archive_file) {
         }
         
         // Verify checksum before doing anything with the record
-        // COMMIT records have explicit checksum 0, others use FNV-1a
-        uint32_t computed_checksum = (data_size == 0 && type_u8 == static_cast<uint8_t>(WalRecordType::COMMIT))
-            ? 0
-            : calculate_checksum(buffer.data(), data_size);
+        uint32_t computed_checksum = calculate_checksum(buffer.data(), data_size);
             
         if (computed_checksum != expected_checksum) {
             fprintf(stderr, "[WAL] Corrupt record at addr %" PRIu64 ". Type=%u, Size=%" PRIu64 ", Expected Checksum=%u, Computed Checksum=%u\n",

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -54,7 +54,7 @@ bool WalManager::log_write(WalRecordType type, uint64_t addr, const void* data, 
     if (!wal_file_) return false;
 
     // Checksum
-    uint32_t checksum = calculate_checksum(data, size);
+    uint32_t checksum = (size == 0 && type == WalRecordType::COMMIT) ? 0 : calculate_checksum(data, size);
 
     // Prepare Header
     // We serialize type as uint8_t
@@ -270,8 +270,14 @@ bool WalManager::recover(FILE* archive_file) {
         }
         
         // Verify checksum before doing anything with the record
-        if (calculate_checksum(buffer.data(), data_size) != expected_checksum) {
-            fprintf(stderr, "[WAL] Corrupt record at addr %" PRIu64 ". Stopping recovery.\n", addr);
+        // COMMIT records have explicit checksum 0, others use FNV-1a
+        uint32_t computed_checksum = (data_size == 0 && type_u8 == static_cast<uint8_t>(WalRecordType::COMMIT))
+            ? 0
+            : calculate_checksum(buffer.data(), data_size);
+            
+        if (computed_checksum != expected_checksum) {
+            fprintf(stderr, "[WAL] Corrupt record at addr %" PRIu64 ". Type=%u, Size=%" PRIu64 ", Expected Checksum=%u, Computed Checksum=%u\n",
+                    addr, type_u8, data_size, expected_checksum, computed_checksum);
             success = false;
             break;
         }

--- a/tests/src/test_wal_recovery.cpp
+++ b/tests/src/test_wal_recovery.cpp
@@ -55,8 +55,9 @@ TEST_F(WalRecoveryTest, RecoversDataFromWal) {
         fputc(0, f);
         fclose(f);
 
+        wal.begin_transaction();
         ASSERT_TRUE(wal.log_write(compio::WalRecordType::BLOCK, safe_offset, data.data(), data.size()));
-        wal.sync();
+        wal.commit_transaction(); // Implicitly syncs
         wal.close();
     }
 
@@ -96,8 +97,9 @@ TEST_F(WalRecoveryTest, ClearsWalAfterSuccessfulOpen) {
         fputc(0, f);
         fclose(f);
 
+        wal.begin_transaction();
         wal.log_write(compio::WalRecordType::BLOCK, 1024 * 1024, data.data(), data.size());
-        wal.sync();
+        wal.commit_transaction();
         wal.close();
     }
     

--- a/tests/src/test_wal_recovery.cpp
+++ b/tests/src/test_wal_recovery.cpp
@@ -122,3 +122,107 @@ TEST_F(WalRecoveryTest, ClearsWalAfterSuccessfulOpen) {
 
     // compio_close_archive(archive); // Handled by ScopedArchive
 }
+
+TEST_F(WalRecoveryTest, IgnoresIncompleteTransactions) {
+    compio_config config;
+    compio_build_default_config(&config);
+    compio_archive* archive = compio_open_archive(filename, "w", &config);
+    compio_close_archive(archive);
+
+    uint64_t addr = 1000;
+    std::vector<uint8_t> data(100, 'X');
+
+    // Ensure file is big enough
+    FILE* f_init = fopen(filename, "r+b");
+    if (f_init) {
+        fseek(f_init, 2000, SEEK_SET);
+        fputc(0, f_init);
+        fclose(f_init);
+    }
+
+    {
+        compio::WalManager wal(filename);
+        ASSERT_TRUE(wal.open());
+
+        // Transaction 1: Valid
+        wal.begin_transaction();
+        ASSERT_TRUE(wal.log_write(compio::WalRecordType::BLOCK, addr, data.data(), data.size()));
+        ASSERT_TRUE(wal.commit_transaction());
+        wal.close();
+
+        // Transaction 2: Partial/Corrupt (append to file)
+        FILE* f = fopen(wal_filename.c_str(), "ab");
+        ASSERT_NE(f, nullptr);
+        uint8_t garbage[] = {0xAA, 0xBB, 0xCC};
+        fwrite(garbage, 1, sizeof(garbage), f);
+        fclose(f);
+    }
+
+    // Open archive - should recover Trans 1 and ignore garbage
+    archive = compio_open_archive(filename, "r+", &config);
+    ASSERT_NE(archive, nullptr);
+    compio_close_archive(archive);
+
+    // Verify data from Trans 1
+    std::ifstream file(filename, std::ios::binary);
+    file.seekg(addr);
+    std::vector<uint8_t> read_data(100);
+    file.read(reinterpret_cast<char*>(read_data.data()), 100);
+    for (int i=0; i<100; ++i) ASSERT_EQ(read_data[i], 'X');
+}
+
+TEST_F(WalRecoveryTest, NestedTransactionsAreAtomic) {
+    // 1. Create and close archive
+    compio_config config;
+    compio_build_default_config(&config);
+    compio_archive* archive = compio_open_archive(filename, "w", &config);
+    ASSERT_NE(archive, nullptr);
+    compio_close_archive(archive);
+    
+    uint64_t addr1 = 2000;
+    uint64_t addr2 = 3000;
+    
+    // 2. Ensure file is large enough
+    FILE* f = fopen(filename, "r+b");
+    fseek(f, 4000, SEEK_SET);
+    fputc(0, f);
+    fclose(f);
+
+    {
+        compio::WalManager wal(filename);
+        ASSERT_TRUE(wal.open());
+
+        wal.begin_transaction(); // Outer
+        
+        const char* data1 = "OUTER";
+        wal.log_write(compio::WalRecordType::BLOCK, addr1, data1, 5);
+        
+        wal.begin_transaction(); // Inner
+        const char* data2 = "INNER";
+        wal.log_write(compio::WalRecordType::BLOCK, addr2, data2, 5);
+        
+        // Commit inner - should NOT write COMMIT record to disk yet
+        ASSERT_TRUE(wal.commit_transaction());
+        
+        // Close without outer commit
+        wal.close(); 
+    }
+
+    // Open archive - verify NOTHING recovered
+    archive = compio_open_archive(filename, "r+", &config);
+    ASSERT_NE(archive, nullptr);
+    compio_close_archive(archive);
+
+    std::ifstream file(filename, std::ios::binary);
+    file.seekg(addr1);
+    char buf[6] = {0};
+    file.read(buf, 5);
+    // Should check that it is NOT "OUTER"
+    // Since we initialized with zeros (implicitly or explicitly), it should be zero
+    // Or at least not "OUTER"
+    ASSERT_NE(std::string(buf), "OUTER"); 
+    
+    file.seekg(addr2);
+    file.read(buf, 5);
+    ASSERT_NE(std::string(buf), "INNER"); 
+}

--- a/tests/src/test_wal_recovery.cpp
+++ b/tests/src/test_wal_recovery.cpp
@@ -57,7 +57,7 @@ TEST_F(WalRecoveryTest, RecoversDataFromWal) {
 
         wal.begin_transaction();
         ASSERT_TRUE(wal.log_write(compio::WalRecordType::BLOCK, safe_offset, data.data(), data.size()));
-        wal.commit_transaction(); // Implicitly syncs
+        ASSERT_TRUE(wal.commit_transaction()); // Implicitly syncs
         wal.close();
     }
 
@@ -98,8 +98,8 @@ TEST_F(WalRecoveryTest, ClearsWalAfterSuccessfulOpen) {
         fclose(f);
 
         wal.begin_transaction();
-        wal.log_write(compio::WalRecordType::BLOCK, 1024 * 1024, data.data(), data.size());
-        wal.commit_transaction();
+        ASSERT_TRUE(wal.log_write(compio::WalRecordType::BLOCK, 1024 * 1024, data.data(), data.size()));
+        ASSERT_TRUE(wal.commit_transaction());
         wal.close();
     }
     


### PR DESCRIPTION
- Implemented `begin_transaction`, `commit_transaction`, and nested transaction support in `WalManager`.
- Updated `compio_flush` to wrap operations in a single atomic transaction, ensuring durability.
- Implemented two-pass recovery: scan for valid commit boundary, then replay valid records.
- Added manual serialization for `header` to support WAL logging alongside direct disk writes.
- Integrated WAL logging into `allocator`, `index_node`, and `storage_block` write paths.
- Updated `compio_close_archive` to handle WAL cleanup safely after double-buffered header flush.
- Updated tests to verify transaction atomicity and recovery logic.