### PR TITLE
feat: harden WAL with checkpointing and close safety

### DIFF
--- a/include/compio/wal.hpp
+++ b/include/compio/wal.hpp
@@ -64,6 +64,11 @@ public:
     // Clear the WAL (truncate) after a successful checkpoint
     bool clear();
 
+    // Checkpoint the WAL (sync main archive, then truncate WAL)
+    // Only works if transaction depth is 0.
+    // returns true on success, false if busy or error.
+    bool checkpoint();
+
     // Recover from WAL (replay records to the main archive file)
     // Returns true if recovery was successful or unnecessary (empty WAL)
     bool recover(FILE* archive_file);

--- a/include/compio/wal.hpp
+++ b/include/compio/wal.hpp
@@ -66,6 +66,8 @@ public:
 
     // Checkpoint the WAL (sync main archive, then truncate WAL)
     // Only works if transaction depth is 0.
+    // NOTE: The caller MUST ensure the main archive file is fully synced (fsync/flush)
+    // BEFORE calling this method. This method only truncates the WAL.
     // returns true on success, false if busy or error.
     bool checkpoint();
 
@@ -78,6 +80,43 @@ public:
 
 private:
     uint32_t calculate_checksum(const void* data, uint64_t size);
+};
+
+// RAII Guard for WAL Transactions
+class TransactionGuard {
+    WalManager* wal_;
+    bool committed_;
+
+public:
+    explicit TransactionGuard(WalManager* wal) : wal_(wal), committed_(false) {
+        if (wal_) {
+            wal_->begin_transaction();
+        }
+    }
+
+    ~TransactionGuard() {
+        if (wal_ && !committed_) {
+            wal_->rollback_transaction();
+        }
+    }
+
+    // Disable copy/move to keep it simple
+    TransactionGuard(const TransactionGuard&) = delete;
+    TransactionGuard& operator=(const TransactionGuard&) = delete;
+
+    bool commit() {
+        if (!wal_) return false;
+        if (committed_) return true; // Already committed/attempted
+        
+        // Mark as committed before calling, or assume commit_transaction 
+        // handles its own state. 
+        // Current implementation of commit_transaction decrements depth unconditionally.
+        // So we must mark as committed regardless of result to avoid double decrement 
+        // (one in commit_transaction, one in ~TransactionGuard via rollback).
+        bool result = wal_->commit_transaction();
+        committed_ = true;
+        return result;
+    }
 };
 
 } // namespace compio

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -553,14 +553,14 @@ bool free_blocks_manager::save_to_file(compio_archive *archive) {
         return false;
     }
 
+    compio::TransactionGuard txn(archive->wal.get());
     if (archive->wal) {
-        archive->wal->begin_transaction();
         if (!archive->wal->log_write(WalRecordType::ALLOCATOR, pos, buffer.data(), size)) {
             WARNING_PRINT("warning: WAL log_write failed in allocator.save_state\n");
-            archive->wal->rollback_transaction();
+            // txn destructor will rollback automatically
             return false;
         }
-        if (!archive->wal->commit_transaction()) {
+        if (!txn.commit()) {
             WARNING_PRINT("warning: WAL commit failed in allocator.save_state\n");
             return false;
         }

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -8,6 +8,12 @@
 #include <memory>
 #include <utility>
 
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
 #include "compio/allocator.hpp"
 #include "compio/compio_file.hpp"
 #include "compio/debug_print.hpp"
@@ -659,6 +665,21 @@ int compio_close_archive(compio_archive *archive) {
     // If we crash during this write, the previous valid header (in the other slot) is preserved.
     flush_header_double_buffered(archive);
 
+    // Ensure all data is physically on disk before clearing WAL.
+    // This prevents data loss if power fails between WAL clear and fclose.
+    if (fflush(archive->file) != 0) {
+        WARNING_PRINT("warning: fflush failed in compio_close_archive\n");
+    }
+#ifdef _WIN32
+    if (_commit(_fileno(archive->file)) != 0) {
+        WARNING_PRINT("warning: _commit failed in compio_close_archive\n");
+    }
+#else
+    if (fsync(fileno(archive->file)) != 0) {
+        WARNING_PRINT("warning: fsync failed in compio_close_archive\n");
+    }
+#endif
+
     // If WAL is enabled and we are closing cleanly, we should clear the WAL.
     // At this point, all data is synced to the archive file (via flush and header update).
     // The WAL is redundant now.
@@ -1254,5 +1275,28 @@ void compio_flush(compio_archive *archive) {
 
     if (fflush(archive->file)) {
         WARNING_PRINT("warning: fflush failed\n");
+    }
+    
+    // Now that everything is flushed to the OS buffer for the main file,
+    // and the WAL transaction is committed and synced (via commit_transaction),
+    // we can safely checkpoint.
+    //
+    // Checkpointing means:
+    // 1. fsync the main archive file (ensure data is durable).
+    // 2. Truncate the WAL (it is no longer needed since main file is up to date).
+    
+    if (wal_active && archive->wal) {
+#ifdef _WIN32
+        if (_commit(_fileno(archive->file)) != 0) {
+            WARNING_PRINT("warning: _commit failed in compio_flush checkpoint\n");
+        }
+#else
+        if (fsync(fileno(archive->file)) != 0) {
+            WARNING_PRINT("warning: fsync failed in compio_flush checkpoint\n");
+        }
+#endif
+        if (!archive->wal->checkpoint()) {
+             WARNING_PRINT("warning: WAL checkpoint failed\n");
+        }
     }
 }

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -1254,6 +1254,9 @@ void compio_flush(compio_archive *archive) {
         wal_active = true;
     }
 
+    // Track whether all durability operations succeed; used to decide if we can safely checkpoint.
+    bool durable = true;
+
     if (archive->block_reader) archive->block_reader->clear_cache();
     if (archive->block_reader) archive->block_reader->invalidate_temporary_index();
     if (archive->index) archive->index->clear_cache();
@@ -1270,33 +1273,46 @@ void compio_flush(compio_archive *archive) {
     if (wal_active && archive->wal) {
         if (!archive->wal->commit_transaction()) {
             WARNING_PRINT("warning: WAL commit failed in compio_flush\n");
+            durable = false;
         }
     }
 
     if (fflush(archive->file)) {
         WARNING_PRINT("warning: fflush failed\n");
+        durable = false;
     }
     
     // Now that everything is flushed to the OS buffer for the main file,
     // and the WAL transaction is committed and synced (via commit_transaction),
-    // we can safely checkpoint.
+    // we can safely checkpoint, but only if all durability steps have succeeded.
     //
     // Checkpointing means:
     // 1. fsync the main archive file (ensure data is durable).
     // 2. Truncate the WAL (it is no longer needed since main file is up to date).
     
-    if (wal_active && archive->wal) {
+    if (wal_active && archive->wal && durable) {
+        bool main_file_synced = true;
 #ifdef _WIN32
         if (_commit(_fileno(archive->file)) != 0) {
             WARNING_PRINT("warning: _commit failed in compio_flush checkpoint\n");
+            main_file_synced = false;
         }
 #else
         if (fsync(fileno(archive->file)) != 0) {
             WARNING_PRINT("warning: fsync failed in compio_flush checkpoint\n");
+            main_file_synced = false;
         }
 #endif
-        if (!archive->wal->checkpoint()) {
-             WARNING_PRINT("warning: WAL checkpoint failed\n");
+        if (!main_file_synced) {
+            WARNING_PRINT("warning: skipping WAL checkpoint due to main file sync failure\n");
+        } else {
+            if (!archive->wal->checkpoint()) {
+                 WARNING_PRINT("warning: WAL checkpoint failed\n");
+            }
         }
+    } else if (wal_active && archive->wal && !durable) {
+        // We had a durability failure earlier (e.g., WAL commit or fflush);
+        // do not truncate the WAL so that recovery remains possible.
+        WARNING_PRINT("warning: skipping WAL checkpoint due to earlier durability failure\n");
     }
 }

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -1247,12 +1247,18 @@ void compio_flush(compio_archive *archive) {
     if (!archive) return;
     std::unique_lock<std::shared_mutex> lock(archive->mutex);
     
-    // Start atomic transaction for the entire flush operation
-    bool wal_active = false;
-    if (archive->wal && !(archive->mode_b & mode_bit::r)) {
-        archive->wal->begin_transaction();
-        wal_active = true;
-    }
+    // Check if we have write permission (w, a, or + modes)
+    // mode_bit::r is set for 'r' and 'r+'. 'w'/'a' don't set 'r'.
+    // So we need explicit check for write capability.
+    bool can_write = (archive->mode_b & mode_bit::w) || 
+                     (archive->mode_b & mode_bit::a) || 
+                     (archive->mode_b & mode_bit::plus);
+
+    // Start atomic transaction for the entire flush operation using RAII guard
+    // Pass nullptr if we shouldn't use WAL, so guard becomes no-op
+    compio::WalManager* wal_ptr = (archive->wal && can_write) ? archive->wal.get() : nullptr;
+    compio::TransactionGuard txn(wal_ptr);
+    bool wal_active = (wal_ptr != nullptr);
 
     // Track whether all durability operations succeed; used to decide if we can safely checkpoint.
     bool durable = true;
@@ -1262,7 +1268,7 @@ void compio_flush(compio_archive *archive) {
     if (archive->index) archive->index->clear_cache();
 
     // Save allocator state (updates header fields)
-    if (archive->allocator && !(archive->mode_b & mode_bit::r)) {
+    if (archive->allocator && can_write) {
          archive->allocator->save_state(archive);
     }
     
@@ -1270,8 +1276,8 @@ void compio_flush(compio_archive *archive) {
     flush_header_double_buffered(archive);
     
     // Commit transaction (this performs a single fsync on the WAL)
-    if (wal_active && archive->wal) {
-        if (!archive->wal->commit_transaction()) {
+    if (wal_active) {
+        if (!txn.commit()) {
             WARNING_PRINT("warning: WAL commit failed in compio_flush\n");
             durable = false;
         }
@@ -1290,7 +1296,7 @@ void compio_flush(compio_archive *archive) {
     // 1. fsync the main archive file (ensure data is durable).
     // 2. Truncate the WAL (it is no longer needed since main file is up to date).
     
-    if (wal_active && archive->wal && durable) {
+    if (wal_active && durable) {
         bool main_file_synced = true;
 #ifdef _WIN32
         if (_commit(_fileno(archive->file)) != 0) {

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #endif
 
 // Use existing utils if possible, but FNV-1a is simple enough to include here
@@ -81,8 +82,15 @@ bool WalManager::log_write(WalRecordType type, uint64_t addr, const void* data, 
 }
 
 void WalManager::begin_transaction() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (!wal_file_) return;
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!wal_file_) {
+        // We allow begin_transaction on unopened WAL to support read-only archives 
+        // that might call it via guards but never write.
+        // But if we intend to write, log_write will fail.
+        // We should track depth anyway to balance with commit/rollback.
+        transaction_depth_++;
+        return;
+    }
 
     if (transaction_depth_ == 0) {
         current_transaction_id_++;
@@ -91,12 +99,16 @@ void WalManager::begin_transaction() {
 }
 
 bool WalManager::commit_transaction() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (!wal_file_) return false;
+    std::unique_lock<std::mutex> lock(mutex_);
+    
+    if (transaction_depth_ > 0) {
+        transaction_depth_--;
+    } else {
+        return false;
+    }
 
-    if (transaction_depth_ == 0) return false;
+    if (!wal_file_) return true; // No-op success for read-only scenario
 
-    transaction_depth_--;
     if (transaction_depth_ > 0) return true; // Nested commit, defer actual commit
 
     // Write COMMIT record
@@ -161,20 +173,28 @@ bool WalManager::checkpoint() {
     // Can only checkpoint if no active transaction
     if (transaction_depth_ > 0) return false;
     
-    if (wal_file_) {
-        fclose(wal_file_);
-        wal_file_ = nullptr;
-    }
+    if (!wal_file_) return true; // Nothing to truncate
+
+    if (fflush(wal_file_) != 0) return false;
+
+#ifdef _WIN32
+    int fd = _fileno(wal_file_);
+    if (_chsize_s(fd, 0) != 0) return false;
+    // Seek to beginning for subsequent writes
+    if (_lseek(fd, 0, SEEK_SET) == -1) return false;
+    if (_commit(fd) != 0) return false;
+#else
+    int fd = fileno(wal_file_);
+    if (ftruncate(fd, 0) != 0) return false;
+    // Seek to beginning for subsequent writes
+    if (lseek(fd, 0, SEEK_SET) < 0) return false;
+    if (fsync(fd) != 0) return false;
+#endif
+
+    // Update stdio buffer position as well
+    rewind(wal_file_);
     
-    // Truncate file
-    wal_file_ = fopen(wal_path_.c_str(), "wb"); // 'w' truncates
-    if (!wal_file_) return false;
-    fclose(wal_file_);
-    wal_file_ = nullptr;
-    
-    // Reopen in append mode
-    lock.unlock();
-    return open();
+    return true;
 }
 
 bool WalManager::clear() {
@@ -241,7 +261,13 @@ bool WalManager::recover(FILE* archive_file) {
         // Sanity check for data size to prevent OOM on corrupt WAL
         // 1GB limit seems reasonable for a single record? Or even smaller.
         // Block size is usually 4KB-64KB. Header is small.
-        if (data_size > 1024 * 1024 * 1024) { // 1GB
+        int64_t current_pos = ftell64(wal_in);
+        int64_t remaining = size - current_pos;
+        if (data_size > static_cast<uint64_t>(remaining)) {
+            // Record claims to be larger than remaining file size -> corrupt
+            break;
+        }
+        if (data_size > 64 * 1024 * 1024) { // 64MB hard limit for sanity
              break;
         }
 
@@ -261,6 +287,9 @@ bool WalManager::recover(FILE* archive_file) {
         
         if (type_u8 == static_cast<uint8_t>(WalRecordType::COMMIT)) {
             // Validate COMMIT record structure: addr=0, size=0, checksum=valid
+            // And ensure we have seen valid records leading up to this commit.
+            // Since we don't track transaction boundaries in Pass 1, we just check
+            // that the COMMIT record itself is structurally valid.
             uint32_t valid_checksum = calculate_checksum(nullptr, 0);
             if (addr == 0 && data_size == 0 && expected_checksum == valid_checksum) {
                 valid_limit = ftell64(wal_in);

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -155,6 +155,28 @@ bool WalManager::sync() {
     return true;
 }
 
+bool WalManager::checkpoint() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    
+    // Can only checkpoint if no active transaction
+    if (transaction_depth_ > 0) return false;
+    
+    if (wal_file_) {
+        fclose(wal_file_);
+        wal_file_ = nullptr;
+    }
+    
+    // Truncate file
+    wal_file_ = fopen(wal_path_.c_str(), "wb"); // 'w' truncates
+    if (!wal_file_) return false;
+    fclose(wal_file_);
+    wal_file_ = nullptr;
+    
+    // Reopen in append mode
+    lock.unlock();
+    return open();
+}
+
 bool WalManager::clear() {
     std::unique_lock<std::mutex> lock(mutex_);
     if (wal_file_) {

--- a/tests/src/test_wal_recovery.cpp
+++ b/tests/src/test_wal_recovery.cpp
@@ -226,3 +226,45 @@ TEST_F(WalRecoveryTest, NestedTransactionsAreAtomic) {
     file.read(buf, 5);
     ASSERT_NE(std::string(buf), "INNER"); 
 }
+
+TEST_F(WalRecoveryTest, CompioFlushTruncatesWal) {
+    // 1. Create archive
+    compio_config config;
+    compio_build_default_config(&config);
+    config.block_size = 1024; // Small blocks
+    config.cache_size__blocks = 2; // Small cache to force evictions if we write many
+    
+    compio_archive* archive = compio_open_archive(filename, "w", &config);
+    ASSERT_NE(archive, nullptr);
+    
+    // 2. Write enough data to trigger WAL activity
+    // Writing multiple blocks should cause cache evictions (writes to WAL)
+    // or at least put them in cache.
+    // compio_write itself doesn't guarantee WAL write until eviction or flush.
+    // But flush guarantees everything.
+    
+    compio_file* f = compio_open_file("test_file", archive);
+    ASSERT_NE(f, nullptr);
+    
+    std::vector<uint8_t> data(config.block_size * 5, 'D');
+    ASSERT_EQ(compio_write(data.data(), data.size(), f), data.size());
+    
+    // At this point, WAL might be empty or not, depending on cache eviction.
+    // But we want to test that flush truncates it.
+    
+    // Force a flush. This writes everything to WAL, syncs, then checkpoints (truncates).
+    compio_flush(archive);
+    
+    // Verify WAL is empty
+    ASSERT_TRUE(fs::exists(wal_filename));
+    ASSERT_EQ(fs::file_size(wal_filename), 0);
+    
+    // Verify data is still readable
+    std::vector<uint8_t> read_buf(data.size());
+    compio_seek(f, 0, COMPIO_SEEK_SET);
+    ASSERT_EQ(compio_read(read_buf.data(), read_buf.size(), f), data.size());
+    ASSERT_EQ(read_buf, data);
+    
+    compio_close_file(f);
+    compio_close_archive(archive);
+}


### PR DESCRIPTION
- Add `checkpoint()` method to `WalManager` to safely truncate the log when the archive is synced.
- Integrate checkpointing into `compio_flush`:
  - Truncates WAL after successful fsync of the main archive.
  - Ensures WAL doesn't grow indefinitely during long running processes.
- Improve `compio_close_archive` safety:
  - Add explicit `fsync` (or `_commit` on Windows) of the archive file *before* clearing the WAL.
  - This prevents data loss if power fails between WAL truncation and file closure.
- Add necessary system headers for file operations in `compio.cpp`.