### PR TITLE
fix(wal): optimize writes and fix test cleanup

### DIFF
--- a/benchmarks/custom/random_usage.cpp
+++ b/benchmarks/custom/random_usage.cpp
@@ -74,7 +74,7 @@ int main() {
         compio_close_archive(archive);
     }
 
-    remove(fn.c_str());
+    remove(fn.c_str()); remove((fn + ".wal").c_str());
 
     return 0;
 }

--- a/benchmarks/src/consecutive_read.cpp
+++ b/benchmarks/src/consecutive_read.cpp
@@ -83,7 +83,7 @@ static void BM_stdio_ConsecutiveRead(benchmark::State &state) {
         benchmark::Counter(0, benchmark::Counter::kDefaults, benchmark::Counter::kIs1024);
 #endif
 
-    remove(fn.c_str());
+    remove(fn.c_str()); remove((fn + ".wal").c_str());
 }
 
 static void BM_compio_ConsecutiveRead(benchmark::State &state) {
@@ -188,7 +188,7 @@ static void BM_compio_ConsecutiveRead(benchmark::State &state) {
 
     state.SetBytesProcessed(state.iterations() * n_blocks * block_size);
 
-    remove(fn.c_str());
+    remove(fn.c_str()); remove((fn + ".wal").c_str());
 }
 
 const std::vector<std::vector<int64_t>> params_grid = {

--- a/benchmarks/src/consecutive_write.cpp
+++ b/benchmarks/src/consecutive_write.cpp
@@ -54,6 +54,7 @@ static void BM_stdio_ConsecutiveWrite(benchmark::State &state) {
 #endif
 
     remove(fn.c_str());
+    remove((fn + ".wal").c_str());
 }
 
 static void BM_compio_ConsecutiveWrite(benchmark::State &state) {
@@ -120,6 +121,7 @@ static void BM_compio_ConsecutiveWrite(benchmark::State &state) {
         get_file_size(fn.c_str()), benchmark::Counter::kDefaults, benchmark::Counter::kIs1024);
 
     remove(fn.c_str());
+    remove((fn + ".wal").c_str());
 }
 
 const std::vector<std::vector<int64_t>> params_grid = {

--- a/benchmarks/src/optimal_usage.cpp
+++ b/benchmarks/src/optimal_usage.cpp
@@ -173,7 +173,7 @@ static void BM_stdio_OptimalUsage(benchmark::State &state) {
     state.counters["file_size"] = get_file_size(fn.c_str());
     state.counters[is_write ? "n_bytes_written" : "n_bytes_read"] =
         static_cast<double>(total_bytes_processed) / state.iterations();
-    remove(fn.c_str());
+    remove(fn.c_str()); remove((fn + ".wal").c_str());
 }
 
 static void BM_compio_OptimalUsage(benchmark::State &state) {
@@ -321,7 +321,7 @@ static void BM_compio_OptimalUsage(benchmark::State &state) {
         static_cast<double>(get_n_read_bytes() - n_bytes_read) / state.iterations();
 #endif
 
-    remove(fn.c_str());
+    remove(fn.c_str()); remove((fn + ".wal").c_str());
 }
 
 const std::vector<std::vector<int64_t>> params_grid = {

--- a/benchmarks/src/random_read.cpp
+++ b/benchmarks/src/random_read.cpp
@@ -99,7 +99,7 @@ static void BM_stdio_RandomRead(benchmark::State &state) {
 #endif
 
     delete[] buffer;
-    remove(fn.c_str());
+    remove(fn.c_str()); remove((fn + ".wal").c_str());
 }
 
 static void BM_compio_RandomRead(benchmark::State &state) {
@@ -220,7 +220,7 @@ static void BM_compio_RandomRead(benchmark::State &state) {
     state.SetBytesProcessed(state.iterations() * n_blocks * block_size);
 
     delete[] buffer;
-    remove(fn.c_str());
+    remove(fn.c_str()); remove((fn + ".wal").c_str());
 }
 
 const std::vector<std::vector<int64_t>> params_grid = {

--- a/benchmarks/src/random_write.cpp
+++ b/benchmarks/src/random_write.cpp
@@ -61,7 +61,7 @@ static void BM_stdio_RandomWrite(benchmark::State &state) {
         benchmark::Counter(block_size, benchmark::Counter::kDefaults, benchmark::Counter::kIs1024);
 #endif
 
-    remove(fn.c_str());
+    remove(fn.c_str()); remove((fn + ".wal").c_str());
 }
 
 static void BM_compio_RandomWrite(benchmark::State &state) {
@@ -142,7 +142,7 @@ static void BM_compio_RandomWrite(benchmark::State &state) {
     state.counters["file_size"] = benchmark::Counter(
         get_file_size(fn.c_str()), benchmark::Counter::kDefaults, benchmark::Counter::kIs1024);
 
-    remove(fn.c_str());
+    remove(fn.c_str()); remove((fn + ".wal").c_str());
 }
 
 const std::vector<std::vector<int64_t>> params_grid = {

--- a/include/compio/utils.hpp
+++ b/include/compio/utils.hpp
@@ -48,6 +48,15 @@ uint64_t fnv1a(const uint8_t *data, size_t size);
 uint32_t fnv1a_32(const uint8_t *data, size_t size);
 
 /**
+ * @brief Continues calculating 32-bit fnv1a hash
+ * @param hash Initial hash value
+ * @param data Pointer to binary data
+ * @param size Size of data in bytes
+ * @return resulting hash
+ */
+uint32_t fnv1a_32_continue(uint32_t hash, const uint8_t *data, size_t size);
+
+/**
  * @brief Portable 64-bit file seek
  *
  * Uses _fseeki64 on Windows (where long is 32-bit) and fseeko on POSIX

--- a/include/compio/wal.hpp
+++ b/include/compio/wal.hpp
@@ -50,6 +50,13 @@ public:
     // Write a record to the WAL
     bool log_write(WalRecordType type, uint64_t addr, const void* data, uint64_t size);
 
+    struct iovec_buf {
+        const void* data;
+        uint64_t size;
+    };
+    // Write a vectored record to the WAL (prevents allocation for combining buffers)
+    bool log_write_vectored(WalRecordType type, uint64_t addr, const std::vector<iovec_buf>& buffers);
+
     // Begin a new transaction
     void begin_transaction();
 
@@ -66,7 +73,7 @@ public:
     // Clear the WAL (truncate) after a successful checkpoint
     bool clear();
 
-    // Checkpoint the WAL (sync main archive, then truncate WAL)
+    // Checkpoint the WAL (truncate WAL after archive sync)
     // Only works if transaction depth is 0.
     // NOTE: The caller MUST ensure the main archive file is fully synced (fsync/flush)
     // BEFORE calling this method. This method only truncates the WAL.

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -417,15 +417,16 @@ void storage_block::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_
     // Calculate checksum before writing (non-const, so we cast)
     const_cast<storage_block*>(this)->calculate_checksum();
 
-    std::vector<uint8_t> buffer;
-    buffer.reserve(STORAGE_BLOCK_METASIZE + size);
+    // Prepare metadata buffer
+    uint8_t meta_buffer[STORAGE_BLOCK_METASIZE];
+    size_t meta_idx = 0;
 
-    auto push_u8 = [&](uint8_t v) { buffer.push_back(v); };
+    auto push_u8 = [&](uint8_t v) { meta_buffer[meta_idx++] = v; };
     auto push_u32 = [&](uint32_t v) { 
-        for(int i=0; i<4; ++i) buffer.push_back(static_cast<uint8_t>(v >> (i*8))); 
+        for(int i=0; i<4; ++i) meta_buffer[meta_idx++] = static_cast<uint8_t>(v >> (i*8)); 
     };
     auto push_u64 = [&](uint64_t v) { 
-        for(int i=0; i<8; ++i) buffer.push_back(static_cast<uint8_t>(v >> (i*8))); 
+        for(int i=0; i<8; ++i) meta_buffer[meta_idx++] = static_cast<uint8_t>(v >> (i*8)); 
     };
 
     push_u8(storage_block_signature);
@@ -434,14 +435,18 @@ void storage_block::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_
     push_u64(original_size);
     push_u32(checksum);
     
-    if (size > 0 && data) {
-        const uint8_t* ptr = data.get();
-        buffer.insert(buffer.end(), ptr, ptr + size);
-    }
+    assert(meta_idx == STORAGE_BLOCK_METASIZE);
 
     if (wal_manager) {
         wal_manager->begin_transaction();
-        if (!wal_manager->log_write(WalRecordType::BLOCK, addr, buffer.data(), buffer.size())) {
+        
+        std::vector<compio::WalManager::iovec_buf> buffers;
+        buffers.push_back({meta_buffer, STORAGE_BLOCK_METASIZE});
+        if (size > 0 && data) {
+            buffers.push_back({data.get(), size});
+        }
+        
+        if (!wal_manager->log_write_vectored(WalRecordType::BLOCK, addr, buffers)) {
             WARNING_PRINT("error: WAL log_write failed for storage_block at addr=%" PRIu64 "\n", addr);
         }
         if (!wal_manager->commit_transaction()) {
@@ -452,8 +457,13 @@ void storage_block::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_
     if (fseek64(file, addr, SEEK_SET))
         DEBUG_PRINT("warning: fseek failed\n");
         
-    if (fwrite(buffer.data(), 1, buffer.size(), file) != buffer.size()) {
-        DEBUG_PRINT("warning: fwrite failed\n");
+    if (fwrite(meta_buffer, 1, STORAGE_BLOCK_METASIZE, file) != STORAGE_BLOCK_METASIZE) {
+        DEBUG_PRINT("warning: fwrite failed for metadata\n");
+    }
+    if (size > 0 && data) {
+        if (fwrite(data.get(), 1, size, file) != size) {
+            DEBUG_PRINT("warning: fwrite failed for dataBody\n");
+        }
     }
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -63,6 +63,13 @@ uint32_t fnv1a_32(const uint8_t *data, size_t size) {
     return hash;
 }
 
+uint32_t fnv1a_32_continue(uint32_t hash, const uint8_t *data, size_t size) {
+    for (size_t i = 0; i < size; ++i) {
+        hash = (hash ^ data[i]) * 0x01000193;
+    }
+    return hash;
+}
+
 bool is_file_empty(FILE *file) {
     fseek64(file, 0, SEEK_END);
     int64_t fsize = ftell64(file);

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -102,6 +102,45 @@ bool WalManager::log_write(WalRecordType type, uint64_t addr, const void* data, 
     return true;
 }
 
+bool WalManager::log_write_vectored(WalRecordType type, uint64_t addr, const std::vector<iovec_buf>& buffers) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!wal_file_) return false;
+
+    uint64_t total_size = 0;
+    for (const auto& buf : buffers) {
+        total_size += buf.size;
+    }
+
+    // Checksum
+    uint32_t checksum = 0;
+    if (!(total_size == 0 && type == WalRecordType::COMMIT)) {
+        checksum = 0x811c9dc5; // FNV-1a 32-bit offset basis
+        for (const auto& buf : buffers) {
+            checksum = fnv1a_32_continue(checksum, static_cast<const uint8_t*>(buf.data), buf.size);
+        }
+    }
+
+    // Prepare Header
+    uint8_t type_u8 = static_cast<uint8_t>(type);
+    
+    if (fwrite(&type_u8, sizeof(uint8_t), 1, wal_file_) != 1) return false;
+    if (fwrite(&addr, sizeof(uint64_t), 1, wal_file_) != 1) return false;
+    if (fwrite(&total_size, sizeof(uint64_t), 1, wal_file_) != 1) return false;
+    if (fwrite(&checksum, sizeof(uint32_t), 1, wal_file_) != 1) return false;
+    
+    // Write Data
+    for (const auto& buf : buffers) {
+        if (buf.size > 0) {
+            if (fwrite(buf.data, 1, buf.size, wal_file_) != buf.size) return false;
+        }
+    }
+    
+    // Update size tracker
+    current_wal_size_ += (1 + 8 + 8 + 4 + total_size);
+
+    return true;
+}
+
 void WalManager::begin_transaction() {
     std::unique_lock<std::mutex> lock(mutex_);
     if (!wal_file_) {

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -70,8 +70,8 @@ bool WalManager::log_write(WalRecordType type, uint64_t addr, const void* data, 
     std::lock_guard<std::mutex> lock(mutex_);
     if (!wal_file_) return false;
 
-    // Checksum
-    uint32_t checksum = (size == 0 && type == WalRecordType::COMMIT) ? 0 : calculate_checksum(data, size);
+    // Checksum: always use the same convention as recovery/commit logic
+    uint32_t checksum = calculate_checksum(data, size);
 
     // Prepare Header
     // We serialize type as uint8_t
@@ -111,12 +111,15 @@ bool WalManager::log_write_vectored(WalRecordType type, uint64_t addr, const std
         total_size += buf.size;
     }
 
-    // Checksum
-    uint32_t checksum = 0;
-    if (!(total_size == 0 && type == WalRecordType::COMMIT)) {
-        checksum = 0x811c9dc5; // FNV-1a 32-bit offset basis
-        for (const auto& buf : buffers) {
-            checksum = fnv1a_32_continue(checksum, static_cast<const uint8_t*>(buf.data), buf.size);
+    // Checksum: initialize using the same zero-length convention as calculate_checksum(nullptr, 0)
+    uint32_t checksum = calculate_checksum(nullptr, 0);
+    for (const auto& buf : buffers) {
+        if (buf.size > 0) {
+            checksum = fnv1a_32_continue(
+                checksum,
+                static_cast<const uint8_t*>(buf.data),
+                buf.size
+            );
         }
     }
 

--- a/tests/src/test_allocator.cpp
+++ b/tests/src/test_allocator.cpp
@@ -31,6 +31,7 @@ protected:
     void TearDown() override {
         compio_close_archive(archive);
         remove(fn);
+        remove((std::string(fn) + ".wal").c_str());
     }
 
     // Helper to verify block allocation

--- a/tests/src/test_allocator_advanced.cpp
+++ b/tests/src/test_allocator_advanced.cpp
@@ -37,6 +37,7 @@ protected:
         delete allocator2;
         compio_close_archive(archive);
         remove(fn);
+        remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -254,6 +255,7 @@ protected:
     void TearDown() override {
         delete_archive_and_allocator();
         remove(fn);
+        remove((std::string(fn) + ".wal").c_str());
     }
 };
 

--- a/tests/src/test_allocator_comprehensive.cpp
+++ b/tests/src/test_allocator_comprehensive.cpp
@@ -34,6 +34,7 @@ protected:
     void TearDown() override {
         compio_close_archive(archive);
         remove(fn);
+        remove((std::string(fn) + ".wal").c_str());
     }
 
     // Helper to create allocator with specific strategy

--- a/tests/src/test_allocator_edge_cases.cpp
+++ b/tests/src/test_allocator_edge_cases.cpp
@@ -33,7 +33,7 @@ protected:
 
     void TearDown() override {
         compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -119,7 +119,7 @@ protected:
 
     void TearDown() override {
         compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -224,7 +224,7 @@ protected:
 
     void TearDown() override {
         compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -302,7 +302,7 @@ protected:
 
     void TearDown() override {
         compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -406,7 +406,7 @@ protected:
 
     void TearDown() override {
         compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -492,7 +492,7 @@ protected:
 
     void TearDown() override {
         compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 

--- a/tests/src/test_allocator_serialization.cpp
+++ b/tests/src/test_allocator_serialization.cpp
@@ -21,7 +21,9 @@ protected:
 
     void TearDown() override {
         remove(fn1);
+        remove((std::string(fn1) + ".wal").c_str());
         remove(fn2);
+        remove((std::string(fn2) + ".wal").c_str());
     }
 };
 

--- a/tests/src/test_allocator_strategies.cpp
+++ b/tests/src/test_allocator_strategies.cpp
@@ -75,7 +75,7 @@ protected:
 
     void TearDown() override {
         if (archive) compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -179,7 +179,7 @@ protected:
 
     void TearDown() override {
         if (archive) compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -277,7 +277,7 @@ protected:
 
     void TearDown() override {
         if (archive) compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -353,7 +353,7 @@ protected:
     char fn[256];
 
     void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
-    void TearDown() override { remove(fn); }
+    void TearDown() override { remove(fn); remove((std::string(fn) + ".wal").c_str()); }
 };
 
 TEST_F(MaintenanceAutoTriggerTest, MaintenanceTriggersWhenThresholdExceeded) {
@@ -420,7 +420,7 @@ protected:
     char fn[256];
 
     void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
-    void TearDown() override { remove(fn); }
+    void TearDown() override { remove(fn); remove((std::string(fn) + ".wal").c_str()); }
 };
 
 TEST_F(StatePersistencePerStrategyTest, BestFitStateRoundTrip) {

--- a/tests/src/test_auto_checkpoint.cpp
+++ b/tests/src/test_auto_checkpoint.cpp
@@ -104,3 +104,39 @@ TEST_F(AutoCheckpointTest, CheckpointDisabledWithZeroLimit) {
     compio_close_file(file);
     compio_close_archive(archive);
 }
+
+TEST_F(AutoCheckpointTest, FlushTruncatesWal) {
+    compio_config config;
+    compio_build_default_config(&config);
+    config.wal_max_size_bytes = 1024 * 1024; // Large limit to prevent auto-checkpoint
+    config.block_size = 512;
+    config.cache_size__blocks = 100; // Large cache to hold data until flush
+    
+    compio_archive* archive = compio_open_archive(archive_path, "w+", &config);
+    ASSERT_NE(archive, nullptr);
+    
+    compio_file* file = compio_open_file("data", archive);
+    ASSERT_NE(file, nullptr);
+    
+    // Write data
+    std::vector<uint8_t> data(2000, 'A');
+    uint64_t written = compio_write(data.data(), data.size(), file);
+    ASSERT_EQ(written, data.size());
+    
+    // Force flush
+    compio_flush(archive);
+    
+    // After flush, WAL size should be 0 (truncated).
+    // Note: get_wal_size() returns actual file size. 
+    // If truncated properly, it should be 0.
+    EXPECT_EQ(get_wal_size(), 0);
+    
+    // Verify data is readable
+    compio_seek(file, 0, COMPIO_SEEK_SET);
+    std::vector<uint8_t> read_buf(2000);
+    ASSERT_EQ(compio_read(read_buf.data(), 2000, file), 2000);
+    EXPECT_EQ(std::memcmp(read_buf.data(), data.data(), 2000), 0);
+    
+    compio_close_file(file);
+    compio_close_archive(archive);
+}

--- a/tests/src/test_defragmentation.cpp
+++ b/tests/src/test_defragmentation.cpp
@@ -46,7 +46,7 @@ protected:
 
     void TearDown() override {
         if (archive) compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -131,7 +131,7 @@ protected:
 
     void TearDown() override {
         if (archive) compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -202,7 +202,7 @@ protected:
 
     void TearDown() override {
         if (archive) compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -309,7 +309,7 @@ TEST(DefragmentationApiTest, RejectsDefragWithOpenFiles) {
     EXPECT_EQ(compio_defragment(archive), COMPIO_SUCCESS);
 
     compio_close_archive(archive);
-    remove(fn);
+    remove(fn); remove((std::string(fn) + ".wal").c_str());
 }
 
 // ---------------------------------------------------------------------------
@@ -366,7 +366,7 @@ TEST(DefragmentationPhysicalTest, FileShrinkAfterDefrag) {
     EXPECT_LE(stats_after.total_free_bytes, free_before);
 
     compio_close_archive(archive);
-    remove(fn);
+    remove(fn); remove((std::string(fn) + ".wal").c_str());
 }
 
 // ---------------------------------------------------------------------------
@@ -604,7 +604,7 @@ TEST(DefragmentationCompressionTest, DataIntegrityWithZlibCompression) {
     }
 
     compio_close_archive(archive);
-    remove(fn);
+    remove(fn); remove((std::string(fn) + ".wal").c_str());
 }
 
 // Defrag with dummy (no) compression — ensures the code path that uses
@@ -660,7 +660,7 @@ TEST(DefragmentationCompressionTest, DataIntegrityWithDummyCompression) {
     }
 
     compio_close_archive(archive);
-    remove(fn);
+    remove(fn); remove((std::string(fn) + ".wal").c_str());
 }
 
 // Close archive (which calls maintenance()) should not corrupt data.
@@ -717,7 +717,7 @@ TEST(DefragmentationCloseTest, MaintenanceOnClose_DataIntact) {
     EXPECT_EQ(buf, data_keep) << "data corrupted after maintenance-on-close";
 
     compio_close_archive(archive);
-    remove(fn);
+    remove(fn); remove((std::string(fn) + ".wal").c_str());
 }
 
 // Many small files — stress the defragmentation with many entries.

--- a/tests/src/test_defragmentation_advanced.cpp
+++ b/tests/src/test_defragmentation_advanced.cpp
@@ -73,7 +73,7 @@ protected:
 
     void TearDown() override {
         if (archive) compio_close_archive(archive);
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 
@@ -156,7 +156,7 @@ protected:
     char fn[256];
 
     void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
-    void TearDown() override { remove(fn); }
+    void TearDown() override { remove(fn); remove((std::string(fn) + ".wal").c_str()); }
 };
 
 TEST_F(FileShrinkTest, HeaderFileSizeShrinks) {
@@ -210,7 +210,7 @@ protected:
     char fn[256];
 
     void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
-    void TearDown() override { remove(fn); }
+    void TearDown() override { remove(fn); remove((std::string(fn) + ".wal").c_str()); }
 };
 
 TEST_F(IncompressibleDataTest, RandomDataIntactAfterDefrag) {
@@ -267,7 +267,7 @@ protected:
     char fn[256];
 
     void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
-    void TearDown() override { remove(fn); }
+    void TearDown() override { remove(fn); remove((std::string(fn) + ".wal").c_str()); }
 };
 
 TEST_F(ForceDefragTest, ForcedDefragRunsRegardlessOfThreshold) {
@@ -329,7 +329,7 @@ protected:
     char fn[256];
 
     void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
-    void TearDown() override { remove(fn); }
+    void TearDown() override { remove(fn); remove((std::string(fn) + ".wal").c_str()); }
 };
 
 TEST_F(MultiBlockFileDefragTest, LargeFileIntactAfterDefragWithNeighbours) {
@@ -390,7 +390,7 @@ protected:
     char fn[256];
 
     void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
-    void TearDown() override { remove(fn); }
+    void TearDown() override { remove(fn); remove((std::string(fn) + ".wal").c_str()); }
 };
 
 TEST_F(RepeatedCycleTest, TenCyclesDataIntact) {

--- a/tests/src/test_insert_erase.cpp
+++ b/tests/src/test_insert_erase.cpp
@@ -43,7 +43,7 @@ protected:
             ASSERT_EQ(compio_close_archive(archive), 0);
         }
 
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 
     // Helper function to verify file content
@@ -103,7 +103,7 @@ protected:
             ASSERT_EQ(compio_close_archive(archive), 0);
         }
 
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 
     // Helper function to verify file content
@@ -584,7 +584,7 @@ protected:
             ASSERT_EQ(compio_close_archive(archive), 0);
         }
 
-        remove(fn);
+        remove(fn); remove((std::string(fn) + ".wal").c_str());
     }
 };
 

--- a/tests/src/test_max_files.cpp
+++ b/tests/src/test_max_files.cpp
@@ -14,7 +14,7 @@ protected:
 
     void SetUp() override { generate_tmp_fn(fn, sizeof(fn)); }
 
-    void TearDown() override { remove(fn); }
+    void TearDown() override { remove(fn); remove((std::string(fn) + ".wal").c_str()); }
 };
 
 TEST_F(MaxFilesTest, DiskSizeReflectsMaxFiles) {


### PR DESCRIPTION
- Optimize WAL logging using vectored I/O (`log_write_vectored`) to avoid large buffer allocations.
- Ensure atomicity by logging to WAL *before* modifying the archive file.
- Replace unsafe `defer_commit` with explicit `commit()` in `TransactionGuard`.
- Fix `wal_max_size_bytes` type to `uint64_t` to prevent overflow.
- Add error checking for `fseek64`/`ftell64` in `WalManager::open`.
- Update `wal.hpp` comments to clarify `checkpoint` behavior.
- Add regression test `FlushTruncatesWal` to verify WAL truncation.
- Fix `TearDown` in 20+ tests and benchmarks to properly remove `.wal` files, preventing disk clutter and potential test interference.