### PR TITLE
perf(core): optimize file removal to O(1)

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -630,15 +630,30 @@ int files_table::remove(const char *name) {
     
     uint32_t i = it->second;
     
-    // Move memory
-    if (i < n_files - 1) {
-        memmove(&files[i], &files[i + 1], (--n_files - i) * sizeof(files_table::file));
-    } else {
-        --n_files;
+    // Move memory: Swap with the last element to avoid O(N) shift
+    // This changes the order of files in the table, but that is permitted.
+    // The B-Tree index relies on name hashes, not file table position.
+    
+    if (i != n_files - 1) {
+        // We are removing an element from the middle.
+        // Move the last element to this position.
+        uint32_t last_idx = n_files - 1;
+        
+        // Ensure string copy happens before overwrite
+        std::string last_name(files[last_idx].name);
+        
+        // Overwrite the removed element
+        files[i] = files[last_idx];
+        
+        // Update index for the moved file
+        index_map_[last_name] = i;
     }
     
-    // Rebuild index because indices shifted
-    rebuild_index();
+    // Decrease count
+    --n_files;
+    
+    // Remove the deleted file from the index
+    index_map_.erase(key);
     
     return 0;
 }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -645,15 +645,28 @@ int files_table::remove(const char *name) {
         // Overwrite the removed element
         files[i] = files[last_idx];
         
-        // Update index for the moved file
-        index_map_[last_name] = i;
+        // Update index for the moved file ONLY if it currently points to the old position
+        // This preserves correctness if duplicates exist (though duplicates are generally discouraged)
+        auto last_it = index_map_.find(last_name);
+        if (last_it != index_map_.end() && last_it->second == last_idx) {
+            index_map_[last_name] = i;
+        }
     }
     
     // Decrease count
     --n_files;
     
     // Remove the deleted file from the index
-    index_map_.erase(key);
+    // Only erase if the index actually points to the deleted slot
+    // AND we didn't just replace it with a file of the same name (e.g. swap with last)
+    auto key_it = index_map_.find(key);
+    if (key_it != index_map_.end() && key_it->second == i) {
+        // Check if the slot 'i' now holds a file with the same name (duplicate moved from end)
+        bool slot_has_same_name = (i < n_files && std::string(files[i].name) == key);
+        if (!slot_has_same_name) {
+            index_map_.erase(key_it);
+        }
+    }
     
     return 0;
 }

--- a/tests/src/test_file_removal.cpp
+++ b/tests/src/test_file_removal.cpp
@@ -147,6 +147,13 @@ TEST_F(FileRemovalTest, RemoveMiddleFilePreservesOthers) {
     // Remove middle file
     EXPECT_EQ(compio_remove_file(archive, "file2.txt"), 0);
     
+    // Verify file2 is gone or recreated empty
+    compio_file* f2 = compio_open_file("file2.txt", archive);
+    if (f2 != nullptr) {
+        EXPECT_EQ(f2->size, 0);
+        compio_close_file(f2);
+    }
+    
     // Check file1 is still there and has data
     compio_file* f1 = compio_open_file("file1.txt", archive);
     ASSERT_NE(f1, nullptr);

--- a/tests/src/test_file_removal.cpp
+++ b/tests/src/test_file_removal.cpp
@@ -149,9 +149,12 @@ TEST_F(FileRemovalTest, RemoveMiddleFilePreservesOthers) {
     
     // Verify file2 is gone or recreated empty
     compio_file* f2 = compio_open_file("file2.txt", archive);
+    // Depending on semantics, it might return nullptr or a new empty file
     if (f2 != nullptr) {
         EXPECT_EQ(f2->size, 0);
         compio_close_file(f2);
+    } else {
+        SUCCEED();
     }
     
     // Check file1 is still there and has data

--- a/tests/src/test_file_removal.cpp
+++ b/tests/src/test_file_removal.cpp
@@ -46,7 +46,7 @@ TEST_F(FileRemovalTest, RemoveFileFreesBlocks) {
     // Flush to ensure blocks are allocated
     compio_flush(archive);
 
-    // Remove the file - this should deallocate all blocks
+    // Remove the file - should deallocate all blocks
     int result = compio_remove_file(archive, "test.txt");
     EXPECT_EQ(result, 0);
 
@@ -129,3 +129,35 @@ TEST_F(FileRemovalTest, RemoveLargeFile) {
     compio_close_archive(archive);
 }
 
+TEST_F(FileRemovalTest, RemoveMiddleFilePreservesOthers) {
+    compio_archive* archive = compio_open_archive(archive_path, "w+", &config);
+    ASSERT_NE(archive, nullptr);
+
+    // Create 3 files
+    const char* names[] = {"file1.txt", "file2.txt", "file3.txt"};
+    for (const char* name : names) {
+        compio_file* f = compio_open_file(name, archive);
+        ASSERT_NE(f, nullptr);
+        // Write something so size > 0
+        compio_write("data", 4, f);
+        compio_close_file(f);
+    }
+    compio_flush(archive);
+    
+    // Remove middle file
+    EXPECT_EQ(compio_remove_file(archive, "file2.txt"), 0);
+    
+    // Check file1 is still there and has data
+    compio_file* f1 = compio_open_file("file1.txt", archive);
+    ASSERT_NE(f1, nullptr);
+    EXPECT_EQ(f1->size, 4);
+    compio_close_file(f1);
+    
+    // Check file3 is still there (moved index) and has data
+    compio_file* f3 = compio_open_file("file3.txt", archive);
+    ASSERT_NE(f3, nullptr);
+    EXPECT_EQ(f3->size, 4);
+    compio_close_file(f3);
+    
+    compio_close_archive(archive);
+}


### PR DESCRIPTION
- Optimize `compio_remove_file` to O(1) using swap-remove strategy (swapping with the last element), avoiding O(N) `memmove` and expensive index rebuilding.
- Verify removal correctness with `RemoveMiddleFilePreservesOthers` test.