### PR TITLE
fix: enhance file I/O safety and security, enforce little-endian format for WAL

### DIFF
--- a/include/compio/utils.hpp
+++ b/include/compio/utils.hpp
@@ -84,6 +84,43 @@ int64_t ftell64(FILE *file);
 bool is_file_empty(FILE *file);
 
 /**
+ * @brief Check if system is Big Endian
+ * @return true if Big Endian, false if Little Endian
+ */
+inline bool is_big_endian() {
+    uint32_t num = 1;
+    return *(reinterpret_cast<unsigned char *>(&num)) == 0;
+}
+
+/**
+ * @brief Swap 64-bit integer endianness
+ * @param val Pointer to value to swap
+ */
+inline void swap_uint64(uint64_t* val) {
+    uint8_t* p = (uint8_t*)val;
+    uint8_t temp;
+    for(int i=0; i<4; ++i) {
+        temp = p[i];
+        p[i] = p[7-i];
+        p[7-i] = temp;
+    }
+}
+
+/**
+ * @brief Swap 32-bit integer endianness
+ * @param val Pointer to value to swap
+ */
+inline void swap_uint32(uint32_t* val) {
+    uint8_t* p = (uint8_t*)val;
+    uint8_t temp;
+    for(int i=0; i<2; ++i) {
+        temp = p[i];
+        p[i] = p[3-i];
+        p[3-i] = temp;
+    }
+}
+
+/**
  * @brief Calculate checksum of data
  * @param data Pointer to the data
  * @param size Size of the data

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -53,7 +53,10 @@ static bool read_files_batched(FILE* file, files_table& ftable) {
         size_t count = std::min(remaining, BATCH_SIZE);
         size_t bytes_to_read = count * ENTRY_SIZE;
         
-        size_t read_count = fread(buffer.data(), 1, bytes_to_read, file);
+        // Use lendian_fread with size=1 to read bytes directly into buffer
+        // (endian swapping is handled manually below). 
+        // Checks ferror and updates metrics.
+        size_t read_count = lendian_fread(buffer.data(), 1, bytes_to_read, file);
         if (read_count != bytes_to_read) {
             WARNING_PRINT("warning: short read in files table (expected %zu, got %zu)\n", 
                           bytes_to_read, read_count);
@@ -112,7 +115,9 @@ static bool write_files_batched(FILE* file, const files_table& ftable) {
         }
         
         size_t bytes_to_write = count * ENTRY_SIZE;
-        if (fwrite(buffer.data(), 1, bytes_to_write, file) != bytes_to_write) {
+        // Use lendian_fwrite with size=1 to write bytes directly from buffer.
+        // Checks ferror and updates metrics.
+        if (lendian_fwrite(buffer.data(), 1, bytes_to_write, file) != bytes_to_write) {
             WARNING_PRINT("warning: short write in files table\n");
             return false;
         }
@@ -643,9 +648,7 @@ void files_table::rebuild_index() {
     index_map_.clear();
     index_map_.reserve(n_files);
     for (uint32_t i = 0; i < n_files; ++i) {
-        // Only insert if not exists to mimic linear search finding the first one
-        // (though duplicates shouldn't exist)
-        // Construct a bounded string_view pointing to files[i].name
+        // Insert if not exists to preserve "first match" semantics for legacy archives
         size_t len = portable_strnlen(files[i].name, COMPIO_FNAME_MAX_SIZE);
         if (len >= COMPIO_FNAME_MAX_SIZE) {
             len = COMPIO_FNAME_MAX_SIZE - 1;
@@ -711,10 +714,6 @@ files_table::file *files_table::add(const char *name) {
     files[n_files].size = 0;
     
     // Update index
-    // Use string_view to avoid allocation. Points to files[n_files].name.
-    // Map points to this new entry.
-    // Explicitly construct bounded string_view to avoid scanning past safe bounds (though it is null-terminated)
-    // and match the logic used in find/remove.
     std::string_view stored_key(files[n_files].name, key.length());
     index_map_.emplace(stored_key, n_files);
     
@@ -724,8 +723,7 @@ files_table::file *files_table::add(const char *name) {
 int files_table::remove(const char *name) {
     if (!name) return -1;
     
-    // Construct lookup key with truncation logic
-    // Use string_view to avoid allocation.
+    // Construct lookup key
     size_t len = portable_strnlen(name, COMPIO_FNAME_MAX_SIZE);
     std::string_view key;
     if (len >= COMPIO_FNAME_MAX_SIZE) {
@@ -776,6 +774,10 @@ int files_table::remove(const char *name) {
     
     // Decrease count
     --n_files;
+    
+    // Zero out the slot that is now unused to avoid leaking deleted data
+    // and ensure deterministic content for checksums (though existing archives may have garbage).
+    memset(&files[n_files], 0, sizeof(files_table::file));
     
     return 0;
 }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -23,16 +23,6 @@ static size_t portable_strnlen(const char *s, size_t maxlen) {
 static const uint8_t index_node_signature = 67;
 static const uint8_t storage_block_signature = 171;
 
-static inline bool is_big_endian() {
-    uint32_t num = 1;
-    return *(reinterpret_cast<unsigned char *>(&num)) == 0;
-}
-
-static void swap_uint64(uint64_t* val) {
-    uint8_t* p = (uint8_t*)val;
-    for(int i=0; i<4; ++i) std::swap(p[i], p[7-i]);
-}
-
 // Helper to batch read files table
 static bool read_files_batched(FILE* file, files_table& ftable) {
     const size_t BATCH_SIZE = 4096; // 4096 files * 40 bytes = ~160KB buffer

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -432,7 +432,16 @@ bool WalManager::recover(FILE* archive_file) {
     // applied to the archive when a COMMIT record is encountered.
     std::vector<std::pair<uint64_t, std::vector<uint8_t>>> pending_records;
 
-    while (static_cast<uint64_t>(ftell64(wal_in)) < valid_limit) {
+    while (true) {
+        int64_t pos = ftell64(wal_in);
+        if (pos < 0) {
+            fprintf(stderr, "[WAL] ftell64 failed during recovery.\n");
+            success = false;
+            break;
+        }
+        if (static_cast<uint64_t>(pos) >= valid_limit) {
+            break;
+        }
         uint8_t type_u8;
         if (fread(&type_u8, sizeof(uint8_t), 1, wal_in) != 1) { success = false; break; }
         

--- a/src/wal.cpp
+++ b/src/wal.cpp
@@ -20,6 +20,29 @@
 
 namespace compio {
 
+// Helper for Little-Endian I/O
+static bool write_u64_le(FILE* f, uint64_t v) {
+    if (is_big_endian()) swap_uint64(&v);
+    return fwrite(&v, sizeof(v), 1, f) == 1;
+}
+
+static bool write_u32_le(FILE* f, uint32_t v) {
+    if (is_big_endian()) swap_uint32(&v);
+    return fwrite(&v, sizeof(v), 1, f) == 1;
+}
+
+static bool read_u64_le(FILE* f, uint64_t* v) {
+    if (fread(v, sizeof(*v), 1, f) != 1) return false;
+    if (is_big_endian()) swap_uint64(v);
+    return true;
+}
+
+static bool read_u32_le(FILE* f, uint32_t* v) {
+    if (fread(v, sizeof(*v), 1, f) != 1) return false;
+    if (is_big_endian()) swap_uint32(v);
+    return true;
+}
+
 WalManager::WalManager(const std::string& archive_path)
     : wal_path_(archive_path + ".wal"),
       wal_file_(nullptr),
@@ -82,9 +105,9 @@ bool WalManager::log_write(WalRecordType type, uint64_t addr, const void* data, 
     // Transaction ID? Maybe skip for now, just simple log.
     
     if (fwrite(&type_u8, sizeof(uint8_t), 1, wal_file_) != 1) return false;
-    if (fwrite(&addr, sizeof(uint64_t), 1, wal_file_) != 1) return false;
-    if (fwrite(&size, sizeof(uint64_t), 1, wal_file_) != 1) return false;
-    if (fwrite(&checksum, sizeof(uint32_t), 1, wal_file_) != 1) return false;
+    if (!write_u64_le(wal_file_, addr)) return false;
+    if (!write_u64_le(wal_file_, size)) return false;
+    if (!write_u32_le(wal_file_, checksum)) return false;
     
     // Write Data
     if (size > 0) {
@@ -127,9 +150,9 @@ bool WalManager::log_write_vectored(WalRecordType type, uint64_t addr, const std
     uint8_t type_u8 = static_cast<uint8_t>(type);
     
     if (fwrite(&type_u8, sizeof(uint8_t), 1, wal_file_) != 1) return false;
-    if (fwrite(&addr, sizeof(uint64_t), 1, wal_file_) != 1) return false;
-    if (fwrite(&total_size, sizeof(uint64_t), 1, wal_file_) != 1) return false;
-    if (fwrite(&checksum, sizeof(uint32_t), 1, wal_file_) != 1) return false;
+    if (!write_u64_le(wal_file_, addr)) return false;
+    if (!write_u64_le(wal_file_, total_size)) return false;
+    if (!write_u32_le(wal_file_, checksum)) return false;
     
     // Write Data
     for (const auto& buf : buffers) {
@@ -183,9 +206,9 @@ bool WalManager::commit_transaction(FILE* archive_file, uint64_t max_wal_size) {
     uint32_t checksum = calculate_checksum(nullptr, 0);
     
     if (fwrite(&type, sizeof(uint8_t), 1, wal_file_) != 1) return false;
-    if (fwrite(&zero, sizeof(uint64_t), 1, wal_file_) != 1) return false; // Addr
-    if (fwrite(&zero, sizeof(uint64_t), 1, wal_file_) != 1) return false; // Size
-    if (fwrite(&checksum, sizeof(uint32_t), 1, wal_file_) != 1) return false; // Checksum
+    if (!write_u64_le(wal_file_, zero)) return false; // Addr
+    if (!write_u64_le(wal_file_, zero)) return false; // Size
+    if (!write_u32_le(wal_file_, checksum)) return false; // Checksum
     
     // Update size for COMMIT record (1+8+8+4 = 21 bytes)
     current_wal_size_ += 21;
@@ -357,10 +380,10 @@ bool WalManager::recover(FILE* archive_file) {
         if (fread(&type_u8, sizeof(uint8_t), 1, wal_in) != 1) break;
         
         uint64_t addr;
-        if (fread(&addr, sizeof(uint64_t), 1, wal_in) != 1) break;
+        if (!read_u64_le(wal_in, &addr)) break;
         
         uint64_t data_size;
-        if (fread(&data_size, sizeof(uint64_t), 1, wal_in) != 1) break;
+        if (!read_u64_le(wal_in, &data_size)) break;
         
         // Sanity check for data size to prevent OOM on corrupt WAL
         // 1GB limit seems reasonable for a single record? Or even smaller.
@@ -376,7 +399,7 @@ bool WalManager::recover(FILE* archive_file) {
         }
 
         uint32_t expected_checksum;
-        if (fread(&expected_checksum, sizeof(uint32_t), 1, wal_in) != 1) break;
+        if (!read_u32_le(wal_in, &expected_checksum)) break;
         
         if (data_size > 0) {
             if (fseek64(wal_in, data_size, SEEK_CUR) != 0) break;
@@ -409,18 +432,18 @@ bool WalManager::recover(FILE* archive_file) {
     // applied to the archive when a COMMIT record is encountered.
     std::vector<std::pair<uint64_t, std::vector<uint8_t>>> pending_records;
 
-    while (ftell64(wal_in) < valid_limit) {
+    while (static_cast<uint64_t>(ftell64(wal_in)) < valid_limit) {
         uint8_t type_u8;
         if (fread(&type_u8, sizeof(uint8_t), 1, wal_in) != 1) { success = false; break; }
         
         uint64_t addr;
-        if (fread(&addr, sizeof(uint64_t), 1, wal_in) != 1) { success = false; break; }
+        if (!read_u64_le(wal_in, &addr)) { success = false; break; }
         
         uint64_t data_size;
-        if (fread(&data_size, sizeof(uint64_t), 1, wal_in) != 1) { success = false; break; }
+        if (!read_u64_le(wal_in, &data_size)) { success = false; break; }
         
         uint32_t expected_checksum;
-        if (fread(&expected_checksum, sizeof(uint32_t), 1, wal_in) != 1) { success = false; break; }
+        if (!read_u32_le(wal_in, &expected_checksum)) { success = false; break; }
         
         std::vector<uint8_t> buffer(data_size);
         if (data_size > 0) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(compio_gtest
     src/test_max_files_scalability.cpp
     src/test_crash_protection.cpp
     src/test_wal_recovery.cpp
+    src/test_wal_format.cpp
     src/test_auto_checkpoint.cpp
 )
 

--- a/tests/src/test_wal_format.cpp
+++ b/tests/src/test_wal_format.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+#include "compio/wal.hpp"
+#include "test_util.hpp"
+
+namespace fs = std::filesystem;
+
+class WalFormatTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        generate_tmp_fn(filename, sizeof(filename));
+        wal_filename = std::string(filename) + ".wal";
+    }
+
+    void TearDown() override {
+        if (fs::exists(filename)) fs::remove(filename);
+        if (fs::exists(wal_filename)) fs::remove(wal_filename);
+    }
+
+    char filename[256];
+    std::string wal_filename;
+};
+
+TEST_F(WalFormatTest, EnforcesLittleEndianOnDisk) {
+    compio::WalManager wal(filename);
+    ASSERT_TRUE(wal.open());
+
+    // Use a pattern that is distinct in LE vs BE
+    // 0x1234567890ABCDEF
+    // LE: EF CD AB 90 78 56 34 12
+    // BE: 12 34 56 78 90 AB CD EF
+    uint64_t addr = 0x1234567890ABCDEF;
+    std::vector<uint8_t> data = {0xCC}; 
+
+    wal.begin_transaction();
+    ASSERT_TRUE(wal.log_write(compio::WalRecordType::BLOCK, addr, data.data(), data.size()));
+    ASSERT_TRUE(wal.commit_transaction());
+    wal.close();
+
+    std::ifstream f(wal_filename, std::ios::binary);
+    ASSERT_TRUE(f.is_open());
+
+    // Record structure:
+    // [Type(1)][Addr(8)][Size(8)][Checksum(4)]
+    // ... data ...
+    
+    // Read Type
+    char type;
+    f.read(&type, 1);
+    ASSERT_EQ(static_cast<uint8_t>(type), static_cast<uint8_t>(compio::WalRecordType::BLOCK));
+
+    // Read Addr (8 bytes)
+    uint8_t addr_bytes[8];
+    f.read(reinterpret_cast<char*>(addr_bytes), 8);
+    
+    // Verify Little Endian
+    ASSERT_EQ(addr_bytes[0], 0xEF);
+    ASSERT_EQ(addr_bytes[1], 0xCD);
+    ASSERT_EQ(addr_bytes[2], 0xAB);
+    ASSERT_EQ(addr_bytes[3], 0x90);
+    ASSERT_EQ(addr_bytes[4], 0x78);
+    ASSERT_EQ(addr_bytes[5], 0x56);
+    ASSERT_EQ(addr_bytes[6], 0x34);
+    ASSERT_EQ(addr_bytes[7], 0x12);
+
+    // Read Size (8 bytes)
+    uint8_t size_bytes[8];
+    f.read(reinterpret_cast<char*>(size_bytes), 8);
+    
+    // Verify Little Endian for size=1
+    // 0x0000000000000001 -> 01 00 00 00 00 00 00 00
+    ASSERT_EQ(size_bytes[0], 0x01);
+    ASSERT_EQ(size_bytes[1], 0x00);
+    ASSERT_EQ(size_bytes[7], 0x00);
+
+    // Checksum (4 bytes) - skip verification as algorithm is complex
+    f.seekg(4, std::ios::cur);
+
+    // Data (1 byte)
+    char data_byte;
+    f.read(&data_byte, 1);
+    ASSERT_EQ(static_cast<uint8_t>(data_byte), 0xCC);
+}


### PR DESCRIPTION
- Replace `fwrite`/`fread` with `lendian_fwrite`/`lendian_fread` in
`read_files_batched` and `write_files_batched` to ensure proper error checking
(`ferror`) and update benchmark counters.
- Zero out the memory of removed entries in `files_table::remove` to prevent
leaking deleted filenames and ensure deterministic content for unused slots.
- Clean up redundant comments in `src/file.cpp`.
- Moved endianness helper functions (`is_big_endian`, `swap_uint64`) from `src/file.cpp` to `include/compio/utils.hpp`.
- Added `swap_uint32` helper.
- Updated `src/wal.cpp` to use explicit Little-Endian I/O for `addr`, `size`, and `checksum` fields, ensuring portability.
- Fixed a signed/unsigned comparison warning in `WalManager::recover`.