### PR TITLE
feat!: enforce strict data integrity validation on read

### DIFF
--- a/include/compio/btree.hpp
+++ b/include/compio/btree.hpp
@@ -159,10 +159,10 @@ struct btree {
      *
      * @param key_min Minimum key (inclusive)
      * @param key_max Maximum key (exclusive)
-     * @return std::vector<std::pair<tree_key, tree_val>> result Vector with resulting key-value
-     * pairs
+     * @return std::optional<std::vector<std::pair<tree_key, tree_val>>> result Vector with resulting key-value
+     * pairs, or nullopt on read failure
      */
-    std::vector<std::pair<tree_key, tree_val>> get_range(const tree_key &key_min,
+    std::optional<std::vector<std::pair<tree_key, tree_val>>> get_range(const tree_key &key_min,
                                                          const tree_key &key_max);
 
     /**
@@ -333,9 +333,9 @@ private:
      * and its associated value in the given subtree.
      *
      * @param node The root of the subtree to search
-     * @return std::pair<tree_key, tree_val> The maximum key-value pair
+     * @return std::optional<std::pair<tree_key, tree_val>> The maximum key-value pair
      */
-    std::pair<tree_key, tree_val> find_max_in_node(shared_node node);
+    std::optional<std::pair<tree_key, tree_val>> find_max_in_node(shared_node node);
 
     /**
      * @brief Find the minimum key-value pair in a subtree
@@ -344,9 +344,9 @@ private:
      * and its associated value in the given subtree.
      *
      * @param node The root of the subtree to search
-     * @return std::pair<tree_key, tree_val> The minimum key-value pair
+     * @return std::optional<std::pair<tree_key, tree_val>> The minimum key-value pair
      */
-    std::pair<tree_key, tree_val> find_min_in_node(shared_node node);
+    std::optional<std::pair<tree_key, tree_val>> find_min_in_node(shared_node node);
 
     /**
      * @brief Helper for removing a key, that exists in current node
@@ -380,8 +380,9 @@ private:
      * @param key_min Minimum key (inclusive)
      * @param key_max Maximum key (exclusive)
      * @param result Vector to store the resulting key-value pairs
+     * @return true on success, false on read failure
      */
-    void _get_range(shared_node &node, const tree_key &key_min, const tree_key &key_max,
+    bool _get_range(shared_node &node, const tree_key &key_min, const tree_key &key_max,
                     std::vector<std::pair<tree_key, tree_val>> &result);
 
     /**

--- a/include/compio/file.hpp
+++ b/include/compio/file.hpp
@@ -87,7 +87,7 @@ struct header : public infile_object {
     header();
     explicit header(uint32_t max_files);
 
-    void read_from(FILE *file, uint64_t addr) override;
+    bool read_from(FILE *file, uint64_t addr) override;
     void write_to(FILE *file, uint64_t addr, compio::WalManager* wal_manager = nullptr) const override;
 
     /** @brief On-disk size of this header (depends on ftable.max_files) */
@@ -149,7 +149,7 @@ struct index_node : public infile_object {
      */
     index_node(int tree_degree);
 
-    void read_from(FILE *file, uint64_t addr) override;
+    bool read_from(FILE *file, uint64_t addr) override;
     void write_to(FILE *file, uint64_t addr, compio::WalManager* wal_manager = nullptr) const override;
     void validate() const;
 };
@@ -190,7 +190,11 @@ struct storage_block : public infile_object {
      */
     storage_block(uint64_t size);
 
-    void read_from(FILE *file, uint64_t addr) override;
+    /** 
+     * @brief Read block from file and validate content
+     * @return true if valid, false if corrupted
+     */
+    bool read_from(FILE *file, uint64_t addr);
     void write_to(FILE *file, uint64_t addr, compio::WalManager* wal_manager = nullptr) const override;
 
     /**

--- a/include/compio/file.hpp
+++ b/include/compio/file.hpp
@@ -194,7 +194,7 @@ struct storage_block : public infile_object {
      * @brief Read block from file and validate content
      * @return true if valid, false if corrupted
      */
-    bool read_from(FILE *file, uint64_t addr);
+    bool read_from(FILE *file, uint64_t addr) override;
     void write_to(FILE *file, uint64_t addr, compio::WalManager* wal_manager = nullptr) const override;
 
     /**

--- a/include/compio/infile_object.hpp
+++ b/include/compio/infile_object.hpp
@@ -85,8 +85,9 @@ public:
      *
      * @param file File stream to read from
      * @param addr File address (offset) where the object data is stored
+     * @return true if read was successful and data is valid, false otherwise
      */
-    virtual void read_from(FILE *file, uint64_t addr) = 0;
+    virtual bool read_from(FILE *file, uint64_t addr) = 0;
 
     /**
      * @brief Write object data to file at specified address
@@ -209,7 +210,15 @@ private:
          */
         storage(FILE *file, uint64_t addr, std::mutex *io_mutex = nullptr, compio::WalManager *wal = nullptr) 
             : storage(file, addr, new T(), io_mutex, true, wal) { // Re-use main constructor
-            read(); // Then read
+            if (!read()) {
+                // How to signal error from constructor?
+                // For now we just log, but the caller should check validity if possible.
+                // Or maybe throw? But we avoid exceptions.
+                // The loaded object might be invalid.
+                // In compio, failure to read usually means corruption.
+                // We rely on read() returning false, but here we can't return.
+                // Ideally, T (the object) should have an isValid state.
+            }
         }
 
         /**
@@ -229,13 +238,14 @@ private:
          * @brief Read object data from file
          *
          * Calls the object's read_from method to load data from file.
+         * @return true if successful, false otherwise
          */
-        void read() {
+        bool read() {
             if (io_mutex) {
                 std::lock_guard<std::mutex> lock(*io_mutex);
-                data->read_from(file, addr);
+                return data->read_from(file, addr);
             } else {
-                data->read_from(file, addr);
+                return data->read_from(file, addr);
             }
         }
 
@@ -482,8 +492,9 @@ public:
      * @brief Read object data from file
      *
      * Reloads the object data from file, discarding any unsaved modifications.
+     * @return true if successful, false otherwise
      */
-    void read() { S->read(); }
+    bool read() { return S->read(); }
 
     /**
      * @brief Write object data to file

--- a/include/compio/infile_object.hpp
+++ b/include/compio/infile_object.hpp
@@ -211,13 +211,18 @@ private:
         storage(FILE *file, uint64_t addr, std::mutex *io_mutex = nullptr, compio::WalManager *wal = nullptr) 
             : storage(file, addr, new T(), io_mutex, true, wal) { // Re-use main constructor
             if (!read()) {
-                // How to signal error from constructor?
-                // For now we just log, but the caller should check validity if possible.
-                // Or maybe throw? But we avoid exceptions.
-                // The loaded object might be invalid.
-                // In compio, failure to read usually means corruption.
-                // We rely on read() returning false, but here we can't return.
-                // Ideally, T (the object) should have an isValid state.
+                // Mark this storage as logically removed and not modified so that
+                // the destructor will not attempt to write back potentially
+                // corrupted or uninitialized data.
+                removed = true;
+                modified = false;
+
+                // Log the failure; callers that can should still perform their own
+                // validity checks, but this at least records the corruption event.
+                std::fprintf(stderr,
+                             "smart_infile_object::storage: failed to read object at address %llu from FILE %p\n",
+                             static_cast<unsigned long long>(addr),
+                             static_cast<void*>(file));
             }
         }
 

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -904,7 +904,12 @@ void block_allocator::perform_defragmentation() {
     key_max.hash = UINT64_MAX;
     key_max.pos  = UINT64_MAX;
 
-    auto used_blocks = archive_->index->get_range(key_min, key_max);
+    auto used_blocks_opt = archive_->index->get_range(key_min, key_max);
+    if (!used_blocks_opt) {
+        WARNING_PRINT("defragmentation aborted: index read failed\n");
+        return;
+    }
+    auto &used_blocks = *used_blocks_opt;
 
     std::sort(used_blocks.begin(), used_blocks.end(),
               [](const auto &a, const auto &b) { return a.second.addr < b.second.addr; });

--- a/src/btree.cpp
+++ b/src/btree.cpp
@@ -139,12 +139,22 @@ void btree::_remove_in_node(shared_node &node, uint64_t idx) {
         auto child = read_child(node, idx);
         auto successor = read_child(node, idx + 1);
         if (RO(child)->num_keys >= degree) {
-            const auto [p_key, p_val] = find_max_in_node(child);
+            auto max_res = find_max_in_node(child);
+            if (!max_res) {
+                WARNING_PRINT("error: failed to find max in node during remove (corruption)\n");
+                return;
+            }
+            const auto [p_key, p_val] = *max_res;
             node->keys[idx] = p_key;
             node->values[idx] = p_val;
             _remove(child, p_key);
         } else if (RO(successor)->num_keys >= degree) {
-            const auto [s_key, s_val] = find_min_in_node(successor);
+            auto min_res = find_min_in_node(successor);
+            if (!min_res) {
+                WARNING_PRINT("error: failed to find min in node during remove (corruption)\n");
+                return;
+            }
+            const auto [s_key, s_val] = *min_res;
             node->keys[idx] = s_key;
             node->values[idx] = s_val;
             _remove(successor, s_key);
@@ -190,10 +200,10 @@ void btree::remove(const tree_key &key) {
     }
 }
 
-void btree::_get_range(shared_node &node, const tree_key &key_min, const tree_key &key_max,
+bool btree::_get_range(shared_node &node, const tree_key &key_min, const tree_key &key_max,
                        std::vector<std::pair<tree_key, tree_val>> &result) {
     if (RO(node)->num_keys == 0)
-        return;
+        return true;
 
     tree_key start{0, 0};
     tree_key end = RO(node)->keys[0];
@@ -201,7 +211,8 @@ void btree::_get_range(shared_node &node, const tree_key &key_min, const tree_ke
     for (std::size_t i = 0; i <= RO(node)->num_keys; ++i) {
         if (!RO(node)->is_leaf && (key_min < end) && (key_max > start)) {
             auto child = read_child(node, i);
-            if (child) _get_range(child, key_min, key_max, result);
+            if (!child) return false;
+            if (!_get_range(child, key_min, key_max, result)) return false;
         }
 
         if (i < RO(node)->num_keys) {
@@ -217,22 +228,27 @@ void btree::_get_range(shared_node &node, const tree_key &key_min, const tree_ke
                                                : tree_key{UINT64_MAX, UINT64_MAX};
         }
     }
+    return true;
 }
 
-std::vector<std::pair<tree_key, tree_val>> btree::get_range(const tree_key &key_min,
+std::optional<std::vector<std::pair<tree_key, tree_val>>> btree::get_range(const tree_key &key_min,
                                                             const tree_key &key_max) {
     if (key_max <= key_min) {
         WARNING_PRINT("warning: btree::get_range received invalid range bounds (key_min={%" PRIu64 ",%" PRIu64 "} "
                       ">= {%" PRIu64 ",%" PRIu64 "}=key_max)\n",
                       key_min.hash, key_min.pos, key_max.hash, key_max.pos);
-        return {};
+        return std::vector<std::pair<tree_key, tree_val>>{};
     }
     std::vector<std::pair<tree_key, tree_val>> result;
     auto root = read_root();
-    if (root) _get_range(root, key_min, key_max, result);
+    if (!root) return std::nullopt;
+    
+    if (!_get_range(root, key_min, key_max, result)) return std::nullopt;
+
     DEBUG_PRINT("[BTREE]: get_range(key_min={...,%" PRIu64 "},key_max={...,%" PRIu64 "}) ->\n", key_min.pos,
                 key_max.pos);
     for (const auto &[key, val] : result) {
+        (void)key; (void)val;
         DEBUG_PRINT("\t{...,%" PRIu64 "} -> {%" PRIu64 ",%" PRIu64 "}\n", key.pos, val.addr, val.size);
     }
     return result;
@@ -302,7 +318,10 @@ std::optional<tree_val> btree::get(const tree_key &key) {
 }
 
 std::optional<std::pair<tree_key, tree_val>> btree::get_block(const tree_key &key) {
-    auto range = get_range(key, key + 1);
+    auto range_opt = get_range(key, key + 1);
+    if (!range_opt) return std::nullopt;
+    const auto& range = *range_opt;
+
     assert(key.pos < UINT64_MAX);
     assert(range.size() < 2);
     if (!range.empty()) {
@@ -575,24 +594,24 @@ shared_node btree::populate_child(shared_node &node, uint64_t idx) {
     }
 }
 
-std::pair<tree_key, tree_val> btree::find_max_in_node(shared_node node) {
-    if (!node) return {};
+std::optional<std::pair<tree_key, tree_val>> btree::find_max_in_node(shared_node node) {
+    if (!node) return std::nullopt;
     while (!RO(node)->is_leaf) {
         auto next = read_child(node, RO(node)->num_keys);
-        if (!next) return {};
+        if (!next) return std::nullopt;
         node = next;
     }
-    return {RO(node)->keys.back(), RO(node)->values.back()};
+    return std::pair{RO(node)->keys.back(), RO(node)->values.back()};
 }
 
-std::pair<tree_key, tree_val> btree::find_min_in_node(shared_node node) {
-    if (!node) return {};
+std::optional<std::pair<tree_key, tree_val>> btree::find_min_in_node(shared_node node) {
+    if (!node) return std::nullopt;
     while (!RO(node)->is_leaf) {
         auto next = read_child(node, 0);
-        if (!next) return {};
+        if (!next) return std::nullopt;
         node = next;
     }
-    return {RO(node)->keys[0], RO(node)->values[0]};
+    return std::pair{RO(node)->keys[0], RO(node)->values[0]};
 }
 
 uint64_t btree::allocate_node() { return allocator->allocate(INDEX_NODE_SIZE(degree)); }

--- a/src/btree.cpp
+++ b/src/btree.cpp
@@ -26,7 +26,12 @@ shared_node node_reader::read_node(uint64_t addr) {
     auto node = cache.get(addr);
     if (!node.has_value()) {
         auto result = shared_node(file, addr, new index_node(tree_degree), io_mutex, true, wal);
-        result.read();     // read from file (because constructor with obj& does not read)
+        if (!result.read()) {
+            WARNING_PRINT("error: failed to read index node at addr %" PRIu64 "\n", addr);
+            // Return an empty/null shared_node to indicate failure.
+            // smart_infile_object default constructor creates a null state.
+            return shared_node();
+        }
         result.unmodify(); // constructor with obj& sets modified=true
         cache.put(addr, result);
         return result;
@@ -82,11 +87,19 @@ void btree::insert_nonfull(shared_node &node, const tree_key &key, const tree_va
         node->validate();
     } else {
         auto child = read_child(node, idx);
+        if (!child) {
+            WARNING_PRINT("error: failed to read child node during insert\n");
+            return;
+        }
         if (RO(child)->num_keys == (2 * degree - 1)) {
             split_child(node, child, idx);
             if (key > node->keys[idx]) {
                 idx++;
                 child = read_child(node, idx);
+                if (!child) {
+                    WARNING_PRINT("error: failed to read child node after split during insert\n");
+                    return;
+                }
             }
         }
         insert_nonfull(child, key, value);
@@ -97,6 +110,10 @@ void btree::insert(const tree_key &key, const tree_val &value) {
     DEBUG_PRINT("[BTREE]: insert(key={...,%" PRIu64 "},value={%" PRIu64 ",%" PRIu64 "})\n", key.pos, value.addr,
                 value.size);
     auto root = read_root();
+    if (!root) {
+        WARNING_PRINT("error: failed to read root node for insert\n");
+        return;
+    }
     if (RO(root)->num_keys == (2 * degree - 1)) {
         auto new_root = create_node();
         new_root->is_leaf = false;
@@ -184,7 +201,7 @@ void btree::_get_range(shared_node &node, const tree_key &key_min, const tree_ke
     for (std::size_t i = 0; i <= RO(node)->num_keys; ++i) {
         if (!RO(node)->is_leaf && (key_min < end) && (key_max > start)) {
             auto child = read_child(node, i);
-            _get_range(child, key_min, key_max, result);
+            if (child) _get_range(child, key_min, key_max, result);
         }
 
         if (i < RO(node)->num_keys) {
@@ -212,7 +229,7 @@ std::vector<std::pair<tree_key, tree_val>> btree::get_range(const tree_key &key_
     }
     std::vector<std::pair<tree_key, tree_val>> result;
     auto root = read_root();
-    _get_range(root, key_min, key_max, result);
+    if (root) _get_range(root, key_min, key_max, result);
     DEBUG_PRINT("[BTREE]: get_range(key_min={...,%" PRIu64 "},key_max={...,%" PRIu64 "}) ->\n", key_min.pos,
                 key_max.pos);
     for (const auto &[key, val] : result) {
@@ -231,6 +248,7 @@ bool btree::_update(shared_node &node, const tree_key &key, const tree_val &new_
             }
             if (!RO(node)->is_leaf) {
                 auto child = read_child(node, i);
+                if (!child) return false;
                 return _update(child, key, new_value);
             } else {
                 return false;
@@ -241,6 +259,7 @@ bool btree::_update(shared_node &node, const tree_key &key, const tree_val &new_
     }
     if (!RO(node)->is_leaf) {
         auto child = read_child(node, RO(node)->num_keys);
+        if (!child) return false;
         return _update(child, key, new_value);
     }
     return false;
@@ -250,6 +269,10 @@ void btree::update(const tree_key &key, const tree_val &new_value) {
     DEBUG_PRINT("[BTREE]: update(key={...,%" PRIu64 "},new_value={%" PRIu64 ",%" PRIu64 "})\n", key.pos, new_value.addr,
                 new_value.size);
     auto root = read_root();
+    if (!root) {
+        WARNING_PRINT("error: failed to read root node for update\n");
+        return;
+    }
     if (!_update(root, key, new_value)) {
         WARNING_PRINT("warning: trying to update non-existing key\n");
     }
@@ -257,6 +280,7 @@ void btree::update(const tree_key &key, const tree_val &new_value) {
 
 std::optional<tree_val> btree::get(const tree_key &key) {
     auto current = read_root();
+    if (!current) return std::nullopt;
 
     while (true) {
         std::size_t idx =
@@ -265,12 +289,13 @@ std::optional<tree_val> btree::get(const tree_key &key) {
 
         if (idx < RO(current)->num_keys && RO(current)->keys[idx] == key) {
             const auto val = RO(current)->values[idx];
-            DEBUG_PRINT("[BTREE]: get(key={...,%" PRIu64 "}) -> {%" PRIu64 ",%" PRIu64 "}\n", key.pos, val.addr, val.size);
+            // DEBUG_PRINT("[BTREE]: get(key={...,%" PRIu64 "}) -> {%" PRIu64 ",%" PRIu64 "}\n", key.pos, val.addr, val.size);
             return val;
         } else if (!RO(current)->is_leaf) {
             current = read_child(current, idx);
+            if (!current) return std::nullopt;
         } else {
-            DEBUG_PRINT("[BTREE]: get(key={...,%" PRIu64 "}) -> nullopt\n", key.pos);
+            // DEBUG_PRINT("[BTREE]: get(key={...,%" PRIu64 "}) -> nullopt\n", key.pos);
             return std::nullopt;
         }
     }
@@ -306,7 +331,7 @@ void btree::_add_to_range(shared_node &node, int64_t addition, const tree_key &k
     if (!RO(node)->is_leaf) {
         // this child is in range
         auto child = read_child(node, idx);
-        _add_to_range(child, addition, key_min, key_max);
+        if (child) _add_to_range(child, addition, key_min, key_max);
     }
 
     // iterate through keys, that are in range
@@ -320,7 +345,7 @@ void btree::_add_to_range(shared_node &node, int64_t addition, const tree_key &k
             } else {
                 // otherwise, child #idx+1 is partially in range
                 auto child = read_child(node, idx + 1);
-                _add_to_range(child, addition, key_min, key_max);
+                if (child) _add_to_range(child, addition, key_min, key_max);
                 break;
             }
         }
@@ -341,10 +366,11 @@ void btree::add_to_range(int64_t addition, const tree_key &key_min, const tree_k
     }
 
     auto root = read_root();
-    _add_to_range(root, addition, key_min, key_max);
+    if (root) _add_to_range(root, addition, key_min, key_max);
 }
 
 void btree::_print(shared_node node, uint64_t depth) {
+    if (!node) return;
     for (std::size_t i = 0; i <= node->num_keys; ++i) {
         if (!node->is_leaf) {
             _print(read_child(node, i), depth + 1);
@@ -526,7 +552,7 @@ shared_node btree::populate_child(shared_node &node, uint64_t idx) {
 
     if (idx > 0) {
         auto predecessor = read_child(node, idx - 1);
-        if (RO(predecessor)->num_keys >= degree) {
+        if (predecessor && RO(predecessor)->num_keys >= degree) {
             borrow_from_prev(node, idx);
             return read_child(node, idx);
         }
@@ -534,7 +560,7 @@ shared_node btree::populate_child(shared_node &node, uint64_t idx) {
 
     if (idx < RO(node)->num_keys) {
         auto successor = read_child(node, idx + 1);
-        if (RO(successor)->num_keys >= degree) {
+        if (successor && RO(successor)->num_keys >= degree) {
             borrow_from_next(node, idx);
             return read_child(node, idx);
         }
@@ -550,15 +576,21 @@ shared_node btree::populate_child(shared_node &node, uint64_t idx) {
 }
 
 std::pair<tree_key, tree_val> btree::find_max_in_node(shared_node node) {
+    if (!node) return {};
     while (!RO(node)->is_leaf) {
-        node = read_child(node, RO(node)->num_keys);
+        auto next = read_child(node, RO(node)->num_keys);
+        if (!next) return {};
+        node = next;
     }
     return {RO(node)->keys.back(), RO(node)->values.back()};
 }
 
 std::pair<tree_key, tree_val> btree::find_min_in_node(shared_node node) {
+    if (!node) return {};
     while (!RO(node)->is_leaf) {
-        node = read_child(node, 0);
+        auto next = read_child(node, 0);
+        if (!next) return {};
+        node = next;
     }
     return {RO(node)->keys[0], RO(node)->values[0]};
 }
@@ -575,6 +607,9 @@ shared_node btree::create_node() { return reader.create_node(allocate_node()); }
 shared_node btree::read_node(uint64_t addr) {
     DEBUG_PRINT("[BTREE][read_node]: addr=%" PRIu64 "\n", addr);
     auto node = reader.read_node(addr);
+    if (!node) {
+        return node;
+    }
     RO(node)->validate();
     return node;
 }
@@ -583,6 +618,9 @@ shared_node btree::read_child(shared_node &node, uint64_t idx) {
     assert(RO(node)->is_leaf == false);
     assert(idx <= RO(node)->num_keys);
     auto child = read_node(RO(node)->children[idx]);
+    if (!child) {
+        return child;
+    }
     const int64_t addition = RO(node)->key_additions[idx];
     if (addition != 0) {
         if (RO(child)->num_keys > 0) {

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -1003,8 +1003,8 @@ uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
                     val.size);
         const std::shared_ptr<const block> b = block_reader->read_block(val.addr, key);
         if (!b) {
-            // failed to decompress
-            WARNING_PRINT("warning: failed to decompress data (compressed block is corrupted)\n");
+            // failed to decompress OR checksum mismatch
+            WARNING_PRINT("warning: failed to read block (corruption or decompression error)\n");
             errno = EIO;
             block_reader->disable_temporary_index();
             return ptr_bytes_read;

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -504,7 +504,12 @@ int compio_remove_file(compio_archive *archive, const char *name) {
     if (file_size > 0) {
         tree_key key_min = {hash, 0};
         tree_key key_max = {hash, UINT64_MAX}; // Get all blocks for this file
-        auto all_blocks = archive->index->get_range(key_min, key_max);
+        auto all_blocks_opt = archive->index->get_range(key_min, key_max);
+        if (!all_blocks_opt) {
+            errno = EIO;
+            return -1;
+        }
+        const auto& all_blocks = *all_blocks_opt;
 
         // Save current file position
         int64_t saved_pos = ftell64(archive->file);
@@ -518,7 +523,12 @@ int compio_remove_file(compio_archive *archive, const char *name) {
                     // Deallocate: metadata + compressed data size
                     archive->allocator->deallocate(val.addr, STORAGE_BLOCK_METASIZE + sb.size);
                 } else {
-                    WARNING_PRINT("warning: failed to read block at %" PRIu64 " during removal (space leaked)\n", val.addr);
+                    WARNING_PRINT("warning: failed to read block at %" PRIu64 " during removal\n", val.addr);
+                    if (saved_pos >= 0) {
+                        fseek64(archive->file, saved_pos, SEEK_SET);
+                    }
+                    errno = EIO;
+                    return -1;
                 }
             }
 
@@ -758,7 +768,10 @@ static void validate_no_gaps_in_range(const std::vector<std::pair<tree_key, tree
 static void validate_tree(btree *index, compio_file *file, bool allow_empty = false) {
 #ifndef NDEBUG
     DEBUG_PRINT("[VALIDATE_TREE]: current btree state for file with hash=%" PRIu64 ":\n", file->hash);
-    auto file_range = index->get_range(tree_key{file->hash, 0}, tree_key{file->hash, UINT64_MAX});
+    auto file_range_opt = index->get_range(tree_key{file->hash, 0}, tree_key{file->hash, UINT64_MAX});
+    if (!file_range_opt) return; // ignore validation on failure
+    const auto& file_range = *file_range_opt;
+
     if (!allow_empty) {
         assert(!file_range.empty());
     }
@@ -831,7 +844,13 @@ static uint64_t compio_write_impl(const void *ptr, uint64_t size, compio_file *f
         // get blocks range from b-tree
         const tree_key key_min = {file->hash, write_start};
         const tree_key key_max = {file->hash, write_end};
-        auto range = archive->index->get_range(key_min, key_max);
+        auto range_opt = archive->index->get_range(key_min, key_max);
+        if (!range_opt) {
+            WARNING_PRINT("error: failed to read index range during write\n");
+            errno = EIO;
+            return 0;
+        }
+        const auto& range = *range_opt;
         assert(!range.empty());
         assert(range.front().first.pos <= write_start);
         assert(range.back().first.pos + range.back().second.size >= write_start);
@@ -986,7 +1005,13 @@ uint64_t compio_read(void *ptr, uint64_t size, compio_file *file) {
 
     const tree_key key_min = {file->hash, read_start};
     const tree_key key_max = {file->hash, read_end};
-    auto range = archive->index->get_range(key_min, key_max);
+    auto range_opt = archive->index->get_range(key_min, key_max);
+    if (!range_opt) {
+        WARNING_PRINT("error: failed to read index range during read\n");
+        errno = EIO;
+        return 0;
+    }
+    const auto& range = *range_opt;
     assert(!range.empty());
 
     for (std::size_t i = 1; i < range.size(); ++i) {
@@ -1204,7 +1229,13 @@ uint64_t compio_erase(uint64_t size, compio_file *file) {
 
     const tree_key key_min = {file->hash, erase_start};
     const tree_key key_max = {file->hash, erase_end};
-    auto range = archive->index->get_range(key_min, key_max);
+    auto range_opt = archive->index->get_range(key_min, key_max);
+    if (!range_opt) {
+        WARNING_PRINT("error: failed to read index range during insert/erase\n");
+        errno = EIO;
+        return 0;
+    }
+    const auto& range = *range_opt;
     assert(!range.empty());
     assert(range.front().first.pos <= erase_start);
     assert(range.back().first.pos + range.back().second.size >= erase_end);

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -514,10 +514,12 @@ int compio_remove_file(compio_archive *archive, const char *name) {
             if (val.addr != 0) {
                 // Read storage_block metadata to get compressed size
                 storage_block sb;
-                sb.read_from(archive->file, val.addr);
-
-                // Deallocate: metadata + compressed data size
-                archive->allocator->deallocate(val.addr, STORAGE_BLOCK_METASIZE + sb.size);
+                if (sb.read_from(archive->file, val.addr)) {
+                    // Deallocate: metadata + compressed data size
+                    archive->allocator->deallocate(val.addr, STORAGE_BLOCK_METASIZE + sb.size);
+                } else {
+                    WARNING_PRINT("warning: failed to read block at %" PRIu64 " during removal (space leaked)\n", val.addr);
+                }
             }
 
             // Remove block from B-tree index

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -243,13 +243,7 @@ bool header::load_and_validate(FILE *file, uint64_t addr) {
 }
 
 bool header::read_from(FILE *file, uint64_t addr) {
-    if (!load_and_validate(file, addr)) {
-        // Assert on failure as per original contract, but now we have validated it explicitly.
-        // In recovery paths, we will use load_and_validate directly.
-        // assert(false);
-        return false;
-    }
-    return true;
+    return load_and_validate(file, addr);
 }
 
 void header::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_manager) const {
@@ -347,6 +341,14 @@ bool index_node::read_from(FILE *file, uint64_t addr) {
     }
     if (lendian_fread_member(is_leaf, file) != 1) return false;
     if (lendian_fread_member(num_keys, file) != 1) return false;
+    
+    // Sanity check num_keys
+    if (num_keys > 2 * (uint32_t)tree_degree - 1) {
+        WARNING_PRINT("error: index_node num_keys %u exceeds max %u (degree=%d)\n", 
+                      num_keys, 2 * tree_degree - 1, tree_degree);
+        return false;
+    }
+
     keys.resize(num_keys);
     values.resize(num_keys);
     if (!is_leaf) {
@@ -491,8 +493,15 @@ bool storage_block::read_from(FILE *file, uint64_t addr) {
         return false;
     }
     if (lendian_fread_member(is_compressed, file) != 1) return false;
+    if (is_compressed > 1) {
+        WARNING_PRINT("error: storage_block is_compressed invalid (%u) at addr=%" PRIu64 "\n", is_compressed, addr);
+        return false;
+    }
     if (lendian_fread_member(size, file) != 1) return false;
-    assert(size != 0);
+    if (size == 0) {
+        WARNING_PRINT("error: storage_block size is 0 at addr=%" PRIu64 "\n", addr);
+        return false;
+    }
 
     // Cap block size to prevent OOM on corrupted files
     static constexpr uint64_t MAX_BLOCK_SIZE = 256ULL * 1024 * 1024; // 256 MB

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -242,12 +242,14 @@ bool header::load_and_validate(FILE *file, uint64_t addr) {
     return true;
 }
 
-void header::read_from(FILE *file, uint64_t addr) {
+bool header::read_from(FILE *file, uint64_t addr) {
     if (!load_and_validate(file, addr)) {
         // Assert on failure as per original contract, but now we have validated it explicitly.
         // In recovery paths, we will use load_and_validate directly.
-        assert(false);
+        // assert(false);
+        return false;
     }
+    return true;
 }
 
 void header::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_manager) const {
@@ -331,18 +333,20 @@ void header::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_manager
     }
 }
 
-void index_node::read_from(FILE *file, uint64_t addr) {
+bool index_node::read_from(FILE *file, uint64_t addr) {
     DEBUG_PRINT("[R][index_node]addr=%" PRIu64 "\n", addr);
-    if (fseek64(file, addr, SEEK_SET))
+    if (fseek64(file, addr, SEEK_SET)) {
         DEBUG_PRINT("warning: fseek failed\n");
+        return false;
+    }
     uint8_t signature;
-    lendian_fread(&signature, sizeof(signature), 1, file);
+    if (lendian_fread(&signature, sizeof(signature), 1, file) != 1) return false;
     if (signature != index_node_signature) {
         WARNING_PRINT("warning: index_node signature does not match\n");
-        assert(false);
+        return false;
     }
-    lendian_fread_member(is_leaf, file);
-    lendian_fread_member(num_keys, file);
+    if (lendian_fread_member(is_leaf, file) != 1) return false;
+    if (lendian_fread_member(num_keys, file) != 1) return false;
     keys.resize(num_keys);
     values.resize(num_keys);
     if (!is_leaf) {
@@ -351,18 +355,19 @@ void index_node::read_from(FILE *file, uint64_t addr) {
     }
 
     for (auto &key : keys) {
-        lendian_fread_member(key.hash, file);
-        lendian_fread_member(key.pos, file);
+        if (lendian_fread_member(key.hash, file) != 1) return false;
+        if (lendian_fread_member(key.pos, file) != 1) return false;
     }
     for (auto &value : values) {
-        lendian_fread_member(value.addr, file);
-        lendian_fread_member(value.size, file);
+        if (lendian_fread_member(value.addr, file) != 1) return false;
+        if (lendian_fread_member(value.size, file) != 1) return false;
     }
     if (!is_leaf) {
-        lendian_fread(children.data(), sizeof(uint64_t), children.size(), file);
-        lendian_fread(key_additions.data(), sizeof(int64_t), key_additions.size(), file);
+        if (lendian_fread(children.data(), sizeof(uint64_t), children.size(), file) != children.size()) return false;
+        if (lendian_fread(key_additions.data(), sizeof(int64_t), key_additions.size(), file) != key_additions.size()) return false;
     }
     validate();
+    return true;
 }
 
 void index_node::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_manager) const {
@@ -470,19 +475,23 @@ void index_node::validate() const {
 #endif
 }
 
-void storage_block::read_from(FILE *file, uint64_t addr) {
+bool storage_block::read_from(FILE *file, uint64_t addr) {
     DEBUG_PRINT("[R][storage_block]addr=%" PRIu64 "\n", addr);
     assert(addr != 0);
-    if (fseek64(file, addr, SEEK_SET))
+    if (fseek64(file, addr, SEEK_SET)) {
         DEBUG_PRINT("warning: fseek failed\n");
+        return false;
+    }
     uint8_t signature;
-    lendian_fread(&signature, sizeof(signature), 1, file);
+    if (lendian_fread(&signature, sizeof(signature), 1, file) != 1) {
+        return false;
+    }
     if (signature != storage_block_signature) {
         WARNING_PRINT("warning: storage_block signature does not match\n");
-        assert(false);
+        return false;
     }
-    lendian_fread_member(is_compressed, file);
-    lendian_fread_member(size, file);
+    if (lendian_fread_member(is_compressed, file) != 1) return false;
+    if (lendian_fread_member(size, file) != 1) return false;
     assert(size != 0);
 
     // Cap block size to prevent OOM on corrupted files
@@ -491,18 +500,22 @@ void storage_block::read_from(FILE *file, uint64_t addr) {
         WARNING_PRINT("warning: storage_block size %llu exceeds limit at addr=%llu\n", 
                       (unsigned long long)size, (unsigned long long)addr);
         size = 0;
-        return;
+        return false;
     }
 
-    lendian_fread_member(original_size, file);
-    lendian_fread_member(checksum, file);
+    if (lendian_fread_member(original_size, file) != 1) return false;
+    if (lendian_fread_member(checksum, file) != 1) return false;
 
     data = std::unique_ptr<uint8_t[]>(new uint8_t[size]);
-    lendian_fread(data.get(), 1, size, file);
+    if (lendian_fread(data.get(), 1, size, file) != size) {
+        return false;
+    }
 
     if (!verify_checksum()) {
         WARNING_PRINT("warning: storage_block checksum verification failed at addr=%llu\n", (unsigned long long)addr);
+        return false;
     }
+    return true;
 }
 
 void storage_block::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_manager) const {

--- a/src/storage_block_reader.cpp
+++ b/src/storage_block_reader.cpp
@@ -36,7 +36,11 @@ block::block(context_t &context, const tree_key &key, uint64_t addr)
         std::unique_lock<std::mutex> lock;
         if (context.io_mutex)
             lock = std::unique_lock<std::mutex>(*context.io_mutex);
-        b.read_from(context.file, addr);
+        if (!b.read_from(context.file, addr)) {
+            WARNING_PRINT("warning: failed to read storage block at addr %" PRIu64 "\n", addr);
+            _is_valid = false;
+            return;
+        }
     }
 
     _c_size = b.size;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(compio_gtest
     src/test_wal_recovery.cpp
     src/test_wal_format.cpp
     src/test_auto_checkpoint.cpp
+    src/test_data_integrity_strict.cpp
 )
 
 target_link_libraries(compio_gtest PRIVATE compio GTest::GTest GTest::Main)

--- a/tests/src/test_btree.cpp
+++ b/tests/src/test_btree.cpp
@@ -76,7 +76,9 @@ protected:
 
     void verify_range(const tree_key &key_min, const tree_key &key_max,
                       const std::vector<std::pair<tree_key, tree_val>> &expected) {
-        auto result = tree->get_range(key_min, key_max);
+        auto result_opt = tree->get_range(key_min, key_max);
+        ASSERT_TRUE(result_opt.has_value());
+        auto result = result_opt.value();
 
         ASSERT_EQ(result.size(), expected.size())
             << "Range query returned " << result.size() << " items, expected " << expected.size();
@@ -96,8 +98,9 @@ protected:
 };
 
 TEST_F(BTreeTest, EmptyTreeOperations) {
-    auto result = tree->get_range(make_key(0, 0), make_key(100, 100));
-    EXPECT_TRUE(result.empty());
+    auto result_opt = tree->get_range(make_key(0, 0), make_key(100, 100));
+    ASSERT_TRUE(result_opt.has_value());
+    EXPECT_TRUE(result_opt.value().empty());
 
     tree->remove(make_key(1, 1));
 
@@ -169,8 +172,9 @@ TEST_F(BTreeTest, RemoveNonExistingKey) {
 
     tree->remove(key);
 
-    auto result = tree->get_range(make_key(0, 0), make_key(UINT64_MAX, UINT64_MAX));
-    EXPECT_TRUE(result.empty());
+    auto result_opt = tree->get_range(make_key(0, 0), make_key(UINT64_MAX, UINT64_MAX));
+    ASSERT_TRUE(result_opt.has_value());
+    EXPECT_TRUE(result_opt.value().empty());
 }
 
 TEST_F(BTreeTest, BasicRangeQuery) {
@@ -218,16 +222,18 @@ TEST_F(BTreeTest, EmptyRangeQuery) {
     tree_key min_key = make_key(1, 350);
     tree_key max_key = make_key(1, 400);
 
-    auto result = tree->get_range(min_key, max_key);
-    EXPECT_TRUE(result.empty());
+    auto result_opt = tree->get_range(min_key, max_key);
+    ASSERT_TRUE(result_opt.has_value());
+    EXPECT_TRUE(result_opt.value().empty());
 }
 
 TEST_F(BTreeTest, InvalidRangeQuery) {
     tree_key min_key = make_key(1, 200);
     tree_key max_key = make_key(1, 100);
 
-    auto result = tree->get_range(min_key, max_key);
-    EXPECT_TRUE(result.empty());
+    auto result_opt = tree->get_range(min_key, max_key);
+    ASSERT_TRUE(result_opt.has_value());
+    EXPECT_TRUE(result_opt.value().empty());
 }
 
 TEST_F(BTreeTest, SortedInsertTriggersSplits) {

--- a/tests/src/test_btree_advanced.cpp
+++ b/tests/src/test_btree_advanced.cpp
@@ -151,8 +151,9 @@ TEST_F(BTreeAdvancedTest, DeleteAllKeys) {
         current_pos += block_size;
     }
 
-    auto result = tree->get_range(make_key(0, 0), make_key(UINT64_MAX, UINT64_MAX));
-    EXPECT_TRUE(result.empty());
+    auto result_opt = tree->get_range(make_key(0, 0), make_key(UINT64_MAX, UINT64_MAX));
+    ASSERT_TRUE(result_opt.has_value());
+    EXPECT_TRUE(result_opt.value().empty());
 }
 
 TEST_F(BTreeAdvancedTest, CacheEviction) {
@@ -204,7 +205,9 @@ TEST_F(BTreeAdvancedTest, ComplexRangeQueries) {
     tree_key min_key = make_key(1, 200);
     tree_key max_key = make_key(3, 200);
 
-    auto result = tree->get_range(min_key, max_key);
+    auto result_opt = tree->get_range(min_key, max_key);
+    ASSERT_TRUE(result_opt.has_value());
+    auto result = result_opt.value();
 
     EXPECT_EQ(result.size(), 5);
 
@@ -244,7 +247,9 @@ TEST_F(BTreeAdvancedTest, RangeQueryWithGaps) {
     tree_key min_key = make_key(1, 100);
     tree_key max_key = make_key(1, 550);
 
-    auto result = tree->get_range(min_key, max_key);
+    auto result_opt = tree->get_range(min_key, max_key);
+    ASSERT_TRUE(result_opt.has_value());
+    auto result = result_opt.value();
 
     EXPECT_EQ(result.size(), 5);
 }
@@ -280,8 +285,9 @@ TEST_F(BTreeAdvancedTest, MixedOperationsStress) {
         case 1: {
             tree_key min_key = make_key(1, 0);
             tree_key max_key = make_key(5, 10000);
-            auto result = tree->get_range(min_key, max_key);
-            EXPECT_GT(result.size(), 0);
+            auto result_opt = tree->get_range(min_key, max_key);
+            ASSERT_TRUE(result_opt.has_value());
+            EXPECT_GT(result_opt.value().size(), 0);
         } break;
         case 2:
             tree->remove(key);
@@ -303,8 +309,9 @@ TEST_F(BTreeAdvancedTest, BoundaryValues) {
     tree->insert(min_key, make_val(1000, 100));
     tree->insert(max_key, make_val(2000, 200));
 
-    auto result = tree->get_range(min_key, make_key(UINT64_MAX, UINT64_MAX));
-    EXPECT_EQ(result.size(), 2);
+    auto result_opt = tree->get_range(min_key, make_key(UINT64_MAX, UINT64_MAX));
+    ASSERT_TRUE(result_opt.has_value());
+    EXPECT_EQ(result_opt.value().size(), 2);
 }
 
 TEST_F(BTreeAdvancedTest, ZeroSizeValues) {

--- a/tests/src/test_btree_edge_cases.cpp
+++ b/tests/src/test_btree_edge_cases.cpp
@@ -77,7 +77,10 @@ TEST_F(BTreeEdgeCasesTest, InsertDuplicateKey) {
     tree->insert(key, val1);
     tree->insert(key, val2);
 
-    auto result = tree->get_range(key, key + 1);
+    auto result_opt = tree->get_range(key, key + 1);
+    ASSERT_TRUE(result_opt.has_value());
+    auto result = result_opt.value();
+
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(result[0].second, val1);
 }
@@ -169,9 +172,9 @@ TEST_F(BTreeEdgeCasesTest, RangeQueryExactMatch) {
 
     tree->insert(key, val);
 
-    auto result = tree->get_range(key, key);
-
-    EXPECT_TRUE(result.empty());
+    auto result_opt = tree->get_range(key, key);
+    ASSERT_TRUE(result_opt.has_value());
+    EXPECT_TRUE(result_opt.value().empty());
 }
 
 TEST_F(BTreeEdgeCasesTest, RangeQuerySingleUnitRange) {
@@ -180,7 +183,9 @@ TEST_F(BTreeEdgeCasesTest, RangeQuerySingleUnitRange) {
 
     tree->insert(key, val);
 
-    auto result = tree->get_range(key, key + 1);
+    auto result_opt = tree->get_range(key, key + 1);
+    ASSERT_TRUE(result_opt.has_value());
+    auto result = result_opt.value();
 
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(result[0].first, key);
@@ -194,9 +199,9 @@ TEST_F(BTreeEdgeCasesTest, RangeQueryMaximumRange) {
     tree_key min_key = {0, 0};
     tree_key max_key = {UINT64_MAX, UINT64_MAX};
 
-    auto result = tree->get_range(min_key, max_key);
-
-    EXPECT_EQ(result.size(), 2);
+    auto result_opt = tree->get_range(min_key, max_key);
+    ASSERT_TRUE(result_opt.has_value());
+    EXPECT_EQ(result_opt.value().size(), 2);
 }
 
 TEST_F(BTreeEdgeCasesTest, RangeQueryEdge) {
@@ -213,7 +218,9 @@ TEST_F(BTreeEdgeCasesTest, RangeQueryEdge) {
     tree_key min_key = k1;
     tree_key max_key = k3;
 
-    auto result = tree->get_range(min_key, max_key);
+    auto result_opt = tree->get_range(min_key, max_key);
+    ASSERT_TRUE(result_opt.has_value());
+    auto result = result_opt.value();
 
     ASSERT_EQ(result.size(), 2);
     EXPECT_EQ(result[0], (std::pair<tree_key, tree_val>{k1, v1}));
@@ -292,9 +299,9 @@ TEST_F(BTreeEdgeCasesTest, RapidInsertDelete) {
         }
     }
 
-    auto result = tree->get_range(make_key(0, 0), make_key(UINT64_MAX, UINT64_MAX));
-
-    EXPECT_EQ(result.size(), 50);
+    auto result_opt = tree->get_range(make_key(0, 0), make_key(UINT64_MAX, UINT64_MAX));
+    ASSERT_TRUE(result_opt.has_value());
+    EXPECT_EQ(result_opt.value().size(), 50);
 }
 
 TEST_F(BTreeEdgeCasesTest, OperationsAfterFailedUpdate) {
@@ -322,8 +329,9 @@ TEST_F(BTreeEdgeCasesTest, RemoveFromEmptyTree) {
         tree->remove(make_key(1, i * 100));
     }
 
-    auto result = tree->get_range(make_key(0, 0), make_key(UINT64_MAX, UINT64_MAX));
-    EXPECT_TRUE(result.empty());
+    auto result_opt = tree->get_range(make_key(0, 0), make_key(UINT64_MAX, UINT64_MAX));
+    ASSERT_TRUE(result_opt.has_value());
+    EXPECT_TRUE(result_opt.value().empty());
 
     tree_key insert_key = make_key(1, 100);
     tree_val insert_val = make_val(1000, 100);

--- a/tests/src/test_btree_range_add.cpp
+++ b/tests/src/test_btree_range_add.cpp
@@ -334,7 +334,9 @@ TEST_F(BTreeRangeAddTest, RangeAddPreservesTreeStructure) {
 
     tree->add_to_range(50, make_key(1, 100), make_key(1, 500));
 
-    auto range_result = tree->get_range(make_key(1, 0), make_key(1, 5000));
+    auto range_result_opt = tree->get_range(make_key(1, 0), make_key(1, 5000));
+    ASSERT_TRUE(range_result_opt.has_value());
+    auto range_result = range_result_opt.value();
     EXPECT_EQ(range_result.size(), original_data.size());
 
     for (const auto &[key, val] : range_result) {

--- a/tests/src/test_data_integrity_strict.cpp
+++ b/tests/src/test_data_integrity_strict.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "compio.h"
+#include "compio/file.hpp"
+#include "test_util.hpp"
+
+class DataIntegrityStrictTest : public ::testing::Test {
+protected:
+    char fn[256];
+    std::string wal_fn;
+
+    void SetUp() override {
+        generate_tmp_fn(fn, sizeof(fn));
+        wal_fn = std::string(fn) + ".wal";
+    }
+
+    void TearDown() override {
+        remove(fn);
+        remove(wal_fn.c_str());
+    }
+
+    void CreateArchiveWithData(const std::string& filename, const std::string& content) {
+        compio_config cfg;
+        compio_build_default_config(&cfg);
+        cfg.max_files = 10;
+        cfg.block_size = 4096;
+
+        compio_archive* ar = compio_open_archive(fn, "w+", &cfg);
+        ASSERT_NE(ar, nullptr);
+
+        compio_file* f = compio_open_file(filename.c_str(), ar);
+        ASSERT_NE(f, nullptr);
+
+        ASSERT_EQ(compio_write(content.data(), content.size(), f), content.size());
+
+        compio_close_file(f);
+        compio_close_archive(ar);
+    }
+};
+
+TEST_F(DataIntegrityStrictTest, ReadFailsOnCorruptedBlock) {
+    const std::string filename = "test.txt";
+    const std::string content = "This is some test data that will be corrupted.";
+    CreateArchiveWithData(filename, content);
+
+    // Corrupt the data on disk
+    FILE* f = fopen(fn, "r+b");
+    ASSERT_NE(f, nullptr);
+
+    // Find the data block. 
+    // Header is at 0. 
+    // We need to parse header to find index root, then parse index to find data block?
+    // Or just scan for the storage block signature (0xAB = 171).
+    // Let's scan for signature.
+    
+    // Header size for max_files=10 is small.
+    // 4 + 32 + 8 + 8 + 8 + 8 + 8 + 4 + 4 + 4 + 4 + 8 + 10*(32+8) = ~500 bytes.
+    // Double buffered -> ~1000 bytes reserved.
+    
+    // We can search for the content string to be sure where the data is.
+    
+    std::vector<uint8_t> file_content;
+    fseek(f, 0, SEEK_END);
+    long fsize = ftell(f);
+    rewind(f);
+    file_content.resize(fsize);
+    fread(file_content.data(), 1, fsize, f);
+
+    // Find content
+    size_t found_pos = std::string(file_content.begin(), file_content.end()).find(content);
+    ASSERT_NE(found_pos, std::string::npos) << "Could not find content in archive file";
+
+    // Corrupt one byte of the content
+    fseek(f, found_pos, SEEK_SET);
+    uint8_t byte;
+    fread(&byte, 1, 1, f);
+    byte ^= 0xFF; // Flip bits
+    fseek(f, found_pos, SEEK_SET);
+    fwrite(&byte, 1, 1, f);
+    fclose(f);
+
+    // Now try to read it back
+    compio_config cfg;
+    compio_build_default_config(&cfg);
+    cfg.max_files = 10; // Match creation config
+    
+    compio_archive* ar = compio_open_archive(fn, "r", &cfg);
+    ASSERT_NE(ar, nullptr);
+
+    compio_file* cf = compio_open_file(filename.c_str(), ar);
+    ASSERT_NE(cf, nullptr);
+
+    char buffer[1024];
+    // This should fail now!
+    // Before changes: it would warn and return corrupted data.
+    // After changes: it should return 0 or partial read (if multiple blocks), and set errno.
+    
+    // Reset errno
+    errno = 0;
+    uint64_t bytes_read = compio_read(buffer, sizeof(buffer), cf);
+    
+    // If our logic works, bytes_read should be 0 because the only block is corrupted.
+    // And errno should be EIO.
+    EXPECT_EQ(bytes_read, 0) << "Should not read corrupted data";
+    EXPECT_EQ(errno, EIO) << "Errno should be set to EIO";
+
+    compio_close_file(cf);
+    compio_close_archive(ar);
+}

--- a/tests/src/test_data_integrity_strict.cpp
+++ b/tests/src/test_data_integrity_strict.cpp
@@ -28,6 +28,10 @@ protected:
         compio_build_default_config(&cfg);
         cfg.max_files = 10;
         cfg.block_size = 4096;
+        
+        // Use dummy compression to ensure data is plaintext on disk
+        // This makes corruption deterministic (we can find the content string)
+        compio_build_dummy_compressor(&cfg.compressor);
 
         compio_archive* ar = compio_open_archive(fn, "w+", &cfg);
         ASSERT_NE(ar, nullptr);
@@ -51,18 +55,6 @@ TEST_F(DataIntegrityStrictTest, ReadFailsOnCorruptedBlock) {
     FILE* f = fopen(fn, "r+b");
     ASSERT_NE(f, nullptr);
 
-    // Find the data block. 
-    // Header is at 0. 
-    // We need to parse header to find index root, then parse index to find data block?
-    // Or just scan for the storage block signature (0xAB = 171).
-    // Let's scan for signature.
-    
-    // Header size for max_files=10 is small.
-    // 4 + 32 + 8 + 8 + 8 + 8 + 8 + 4 + 4 + 4 + 4 + 8 + 10*(32+8) = ~500 bytes.
-    // Double buffered -> ~1000 bytes reserved.
-    
-    // We can search for the content string to be sure where the data is.
-    
     std::vector<uint8_t> file_content;
     fseek(f, 0, SEEK_END);
     long fsize = ftell(f);
@@ -72,7 +64,7 @@ TEST_F(DataIntegrityStrictTest, ReadFailsOnCorruptedBlock) {
 
     // Find content
     size_t found_pos = std::string(file_content.begin(), file_content.end()).find(content);
-    ASSERT_NE(found_pos, std::string::npos) << "Could not find content in archive file";
+    ASSERT_NE(found_pos, std::string::npos) << "Could not find content in archive file (compression might be interfering)";
 
     // Corrupt one byte of the content
     fseek(f, found_pos, SEEK_SET);
@@ -88,6 +80,9 @@ TEST_F(DataIntegrityStrictTest, ReadFailsOnCorruptedBlock) {
     compio_build_default_config(&cfg);
     cfg.max_files = 10; // Match creation config
     
+    // Use dummy compressor for reading too
+    compio_build_dummy_compressor(&cfg.compressor);
+    
     compio_archive* ar = compio_open_archive(fn, "r", &cfg);
     ASSERT_NE(ar, nullptr);
 
@@ -96,15 +91,11 @@ TEST_F(DataIntegrityStrictTest, ReadFailsOnCorruptedBlock) {
 
     char buffer[1024];
     // This should fail now!
-    // Before changes: it would warn and return corrupted data.
-    // After changes: it should return 0 or partial read (if multiple blocks), and set errno.
     
     // Reset errno
     errno = 0;
     uint64_t bytes_read = compio_read(buffer, sizeof(buffer), cf);
     
-    // If our logic works, bytes_read should be 0 because the only block is corrupted.
-    // And errno should be EIO.
     EXPECT_EQ(bytes_read, 0) << "Should not read corrupted data";
     EXPECT_EQ(errno, EIO) << "Errno should be set to EIO";
 


### PR DESCRIPTION
Modified low-level read operations to propagate failures instead of
silently logging warnings. `infile_object::read_from` now returns
`bool` to indicate success/failure. Updated `storage_block`, `header`,
and `index_node` to validate checksums and signatures, returning `false`
on mismatch.

Updated `btree` logic to handle node read failures gracefully, preventing
crashes when encountering corrupt index nodes. Modified `compio_read`
and `compio_write` to abort operation and set `errno = EIO` if a data
block cannot be verified or decompressed.

Added `tests/src/test_data_integrity_strict.cpp` to verify that
manually corrupted data causes read operations to fail as expected.