### PR TITLE
fix: resolve allocator fragmentation

### DIFF
--- a/benchmarks/src/defragmentation_benchmark.cpp
+++ b/benchmarks/src/defragmentation_benchmark.cpp
@@ -101,6 +101,7 @@ static void BM_DefragThroughput(benchmark::State& state) {
 
         compio_close_archive(ar);
         remove(path.c_str());
+        remove((path + ".wal").c_str());
         ++iterations;
     }
 
@@ -152,6 +153,7 @@ static void BM_DefragSpaceRecovery(benchmark::State& state) {
 
         compio_close_archive(ar);
         remove(path.c_str());
+        remove((path + ".wal").c_str());
     }
 
     state.SetBytesProcessed(
@@ -185,6 +187,7 @@ static void BM_FragmentationMetric(benchmark::State& state) {
     state.counters["fragmentation"] = ar->allocator->get_fragmentation();
     compio_close_archive(ar);
     remove(path.c_str());
+    remove((path + ".wal").c_str());
 }
 
 // ----------------------------------------------------------------------------
@@ -254,6 +257,7 @@ static void BM_DefragCycle(benchmark::State& state) {
 
         compio_close_archive(ar);
         remove(path.c_str());
+        remove((path + ".wal").c_str());
     }
 
     state.SetBytesProcessed(state.iterations() * total_data);

--- a/benchmarks/src/optimal_usage.cpp
+++ b/benchmarks/src/optimal_usage.cpp
@@ -124,7 +124,7 @@ static void BM_stdio_OptimalUsage(benchmark::State &state) {
 
     UsageStrategy strategy(0, html_data, sizeof(html_data), file_size, gamma_shape, gamma_scale,
                            region_size, n_switch);
-    std::unique_ptr<char> buffer(new char[file_size]);
+    std::unique_ptr<char[]> buffer(new char[file_size]);
     std::size_t total_bytes_processed = 0;
 
     for (auto _ : state) {
@@ -230,7 +230,7 @@ static void BM_compio_OptimalUsage(benchmark::State &state) {
 
     UsageStrategy strategy(0, html_data, sizeof(html_data), file_size, gamma_shape, gamma_scale,
                            region_size, n_switch);
-    std::unique_ptr<char> buffer(new char[file_size]);
+    std::unique_ptr<char[]> buffer(new char[file_size]);
     std::size_t total_bytes_processed = 0;
     double total_node_cache_hit_probability = 0.;
     double total_block_cache_hit_probability = 0.;

--- a/include/third_party/lrucache.hpp
+++ b/include/third_party/lrucache.hpp
@@ -43,6 +43,7 @@
 #include <list>
 #include <map>
 #include <mutex>
+#include <vector>
 #include <optional>
 #include <stdexcept>
 

--- a/include/third_party/lrucache.hpp
+++ b/include/third_party/lrucache.hpp
@@ -114,6 +114,18 @@ public:
         return _cache_items_map.size() >= _max_size; 
     }
 
+    std::vector<value_t> extract_all() {
+        std::lock_guard<std::mutex> lock(_mutex);
+        std::vector<value_t> result;
+        result.reserve(_cache_items_list.size());
+        for (const auto& item : _cache_items_list) {
+            result.push_back(item.second);
+        }
+        _cache_items_map.clear();
+        _cache_items_list.clear();
+        return result;
+    }
+
     value_t pop_back() {
         std::lock_guard<std::mutex> lock(_mutex);
         if (_cache_items_map.size() == 0) {

--- a/src/storage_block_reader.cpp
+++ b/src/storage_block_reader.cpp
@@ -396,7 +396,9 @@ void storage_block_reader::remove_block(std::shared_ptr<block> b) {
         }
     }
     context.index->remove(key);
-    context.allocator->deallocate(b->addr(), b->c_size() + STORAGE_BLOCK_METASIZE);
+    if (b->addr() != 0) {
+        context.allocator->deallocate(b->addr(), b->c_size() + STORAGE_BLOCK_METASIZE);
+    }
 #ifdef COMPIO_BENCHMARK_BLOCKS_COUNTER
     --bm_n_blocks;
 #endif

--- a/src/storage_block_reader.cpp
+++ b/src/storage_block_reader.cpp
@@ -6,6 +6,8 @@
 #include <cassert>
 #include <mutex>
 #include <cinttypes>
+#include <algorithm>
+#include <vector>
 
 #include "compio/debug_print.hpp"
 
@@ -114,7 +116,7 @@ block::~block() {
             // }
 
             // though it would be better to pass this logic to allocator, and allocate memory again
-            context.allocator->deallocate(_addr, _c_size);
+            context.allocator->deallocate(_addr, _c_size + STORAGE_BLOCK_METASIZE);
         }
 
         uint64_t new_addr = context.allocator->allocate(STORAGE_BLOCK_METASIZE + b.size);
@@ -284,7 +286,37 @@ std::shared_ptr<block> storage_block_reader::create_block(uint64_t size, tree_ke
 
 void storage_block_reader::clear_cache() {
     DEBUG_PRINT("[SBR][clear_cache]\n");
-    cache.clear();
+    auto blocks = cache.extract_all();
+
+    // Sort blocks by address to optimize reallocation during flush.
+    // When we destroy blocks (triggering write-back), they free their old space
+    // and allocate new space. By destroying them in address order, we maximize
+    // the chance that adjacent freed blocks merge, creating larger holes for reuse.
+    // This is critical for sequential update workloads to prevent fragmentation drift.
+    std::sort(blocks.begin(), blocks.end(), [](const std::shared_ptr<block> &a, const std::shared_ptr<block> &b) {
+        // If one block is new (addr=0), it should be processed after existing blocks?
+        // No, new blocks just allocate, they don't free.
+        // Existing blocks free then allocate.
+        // We want to free as much as possible first?
+        // If we process addr=0 first, they take space.
+        // If we process addr!=0 first, they free space.
+        // So we prefer processing blocks that free space first.
+        // addr=0 blocks sort to the beginning (0 < non-zero).
+        // So they are processed first. This consumes space before freeing old blocks.
+        // This is slightly suboptimal for overall usage, but consistent.
+        // Wait, if we have addr=0, we can't sort by old address effectively.
+        // But for "drift" scenario, all blocks have addresses.
+        return a->addr() < b->addr();
+    });
+
+    // Explicitly release blocks in sorted order.
+    // std::vector::clear() typically destroys elements in reverse order (back to front),
+    // which would defeat our sorting. By manually resetting shared_ptrs, we ensure
+    // destructors run in the exact order we want (ascending address).
+    for (auto& b : blocks) {
+        b.reset();
+    }
+    blocks.clear();
 }
 
 void storage_block_reader::set_maintenance_mode(bool enabled) {
@@ -364,7 +396,7 @@ void storage_block_reader::remove_block(std::shared_ptr<block> b) {
         }
     }
     context.index->remove(key);
-    context.allocator->deallocate(b->addr(), b->c_size());
+    context.allocator->deallocate(b->addr(), b->c_size() + STORAGE_BLOCK_METASIZE);
 #ifdef COMPIO_BENCHMARK_BLOCKS_COUNTER
     --bm_n_blocks;
 #endif

--- a/src/storage_block_reader.cpp
+++ b/src/storage_block_reader.cpp
@@ -289,30 +289,23 @@ void storage_block_reader::clear_cache() {
     auto blocks = cache.extract_all();
 
     // Sort blocks by address to optimize reallocation during flush.
-    // When we destroy blocks (triggering write-back), they free their old space
-    // and allocate new space. By destroying them in address order, we maximize
-    // the chance that adjacent freed blocks merge, creating larger holes for reuse.
-    // This is critical for sequential update workloads to prevent fragmentation drift.
+    // We prioritize existing blocks (addr != 0) over new blocks (addr == 0).
+    // Existing blocks free their old space first, creating holes.
+    // New blocks then allocate, potentially filling those holes.
+    // Within existing blocks, we sort by address to maximize merging of adjacent freed blocks.
     std::sort(blocks.begin(), blocks.end(), [](const std::shared_ptr<block> &a, const std::shared_ptr<block> &b) {
-        // If one block is new (addr=0), it should be processed after existing blocks?
-        // No, new blocks just allocate, they don't free.
-        // Existing blocks free then allocate.
-        // We want to free as much as possible first?
-        // If we process addr=0 first, they take space.
-        // If we process addr!=0 first, they free space.
-        // So we prefer processing blocks that free space first.
-        // addr=0 blocks sort to the beginning (0 < non-zero).
-        // So they are processed first. This consumes space before freeing old blocks.
-        // This is slightly suboptimal for overall usage, but consistent.
-        // Wait, if we have addr=0, we can't sort by old address effectively.
-        // But for "drift" scenario, all blocks have addresses.
+        bool a_exists = a->addr() != 0;
+        bool b_exists = b->addr() != 0;
+        if (a_exists != b_exists) {
+            return a_exists; // exists (true) comes before new (false)
+        }
         return a->addr() < b->addr();
     });
 
-    // Explicitly release blocks in sorted order.
-    // std::vector::clear() typically destroys elements in reverse order (back to front),
-    // which would defeat our sorting. By manually resetting shared_ptrs, we ensure
-    // destructors run in the exact order we want (ascending address).
+    // The C++ standard does not guarantee any particular destruction order for
+    // std::vector::clear() / erase(). By manually resetting shared_ptrs in this loop,
+    // we ensure destructors run in the exact order we want (ascending address / existing first),
+    // independent of the container's internal destruction order.
     for (auto& b : blocks) {
         b.reset();
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(compio_gtest
     src/test_allocator_edge_cases.cpp
     src/test_allocator_serialization.cpp
     src/test_allocator_strategies.cpp
+    src/test_allocator_drift.cpp
     src/test_compression_type.cpp
     src/test_compressor.cpp
     src/test_data_integrity.cpp

--- a/tests/src/test_allocator_drift.cpp
+++ b/tests/src/test_allocator_drift.cpp
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include <string>
+
+#include "compio/allocator.hpp"
+#include "compio/compio_file.hpp"
+#include "compio/utils.hpp"
+#include "test_util.hpp"
+
+using namespace compio;
+
+class AllocatorDriftTest : public ::testing::Test {
+protected:
+    char fn[256];
+    compio_archive *archive;
+    block_allocator *allocator;
+    compio_config config;
+
+    void SetUp() override {
+        generate_tmp_fn(fn, sizeof(fn));
+
+        compio_build_default_config(&config);
+        config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT;
+        // High threshold to disable auto-defrag unless we explicitly call it,
+        // so we can test the raw allocation behavior.
+        config.fragmentation_threshold = 100; 
+        config.fill_holes_with_zeros = false;
+
+        archive = compio_open_archive(fn, "w+", &config);
+        allocator = archive->allocator;
+    }
+
+    void TearDown() override {
+        compio_close_archive(archive);
+        remove(fn);
+        remove((std::string(fn) + ".wal").c_str());
+    }
+};
+
+TEST_F(AllocatorDriftTest, SequentialDriftReusesSpace) {
+    // Simulate the drift scenario:
+    // 1. Allocate block A (size S)
+    // 2. Allocate block B (size S)
+    // 3. Free block A
+    // 4. Allocate block A' (size S + small_delta)
+    // Expected: A' should reuse A's space if A's size < A's space + available padding,
+    // OR if A's space can be merged with subsequent free space.
+    // But in a sequential write scenario, B is occupied.
+    
+    const size_t initial_size = 1000;
+    const size_t drift_amount = 100;
+    
+    uint64_t addrA = allocator->allocate(initial_size);
+    uint64_t addrB = allocator->allocate(initial_size);
+    (void)allocator->allocate(initial_size);
+    
+    // Free A and B. They are adjacent.
+    allocator->deallocate(addrA, initial_size);
+    allocator->deallocate(addrB, initial_size);
+    
+    // Now we should have a free block of size 2000 at addrA.
+    // Verify by allocating something larger than 1000 but smaller than 2000.
+    
+    uint64_t addrNew = allocator->allocate(initial_size + drift_amount);
+    
+    EXPECT_EQ(addrNew, addrA) << "Allocator should reuse the merged free space of A and B";
+    
+    // The remaining space should also be reusable.
+    // Remaining: 2000 - 1100 = 900.
+    uint64_t addrRemainder = allocator->allocate(500);
+    // Address of new block = A + size of A' (1100)
+    EXPECT_EQ(addrRemainder, addrA + initial_size + drift_amount) << "Should allocate remainder immediately after A'";
+}
+
+TEST_F(AllocatorDriftTest, SingleBlockGrowFail) {
+    // Scenario: [A][B]
+    // Free A.
+    // Allocate A' > A.
+    // Since B is occupied, A' cannot fit in A. It must go to end.
+    // This is expected behavior (fragmentation), but we want to confirm it works as expected.
+    
+    const size_t size = 1000;
+    uint64_t addrA = allocator->allocate(size);
+    uint64_t addrB = allocator->allocate(size);
+    
+    allocator->deallocate(addrA, size);
+    
+    // Try to allocate slightly larger
+    uint64_t addrA_Prime = allocator->allocate(size + 10);
+    
+    EXPECT_NE(addrA_Prime, addrA) << "Should NOT fit in A because B blocks expansion";
+    // It should be allocated after B (at least B + size)
+    EXPECT_GE(addrA_Prime, addrB + size) << "Should be allocated after B";
+}
+
+TEST_F(AllocatorDriftTest, MergeThreeBlocks) {
+    // Scenario: [A][B][C]
+    // Free A, C, then B.
+    // Should merge into one big block A+B+C.
+    
+    const size_t size = 1000;
+    uint64_t addrA = allocator->allocate(size);
+    uint64_t addrB = allocator->allocate(size);
+    uint64_t addrC = allocator->allocate(size);
+    
+    allocator->deallocate(addrA, size);
+    allocator->deallocate(addrC, size);
+    allocator->deallocate(addrB, size); // Middle block freed last
+    
+    uint64_t addrBig = allocator->allocate(size * 3);
+    EXPECT_EQ(addrBig, addrA) << "Should have merged A, B, C into one contiguous block";
+}

--- a/tests/src/test_repair.cpp
+++ b/tests/src/test_repair.cpp
@@ -96,7 +96,7 @@ TEST_F(RepairTest, RecoversWithCorruptedHeader) {
         FILE* f = fopen(archive_path.c_str(), "rb+");
 #endif
         ASSERT_NE(f, nullptr);
-        std::unique_ptr<FILE, decltype(&fclose)> f_guard(f, fclose);
+        std::unique_ptr<FILE, int(*)(FILE*)> f_guard(f, fclose);
         std::vector<uint8_t> zeros(512, 0);
         fwrite(zeros.data(), 1, 512, f);
     }
@@ -121,11 +121,9 @@ TEST_F(RepairTest, RecoversWithCorruptedHeader) {
     
     std::string expected_name = "file_" + std::to_string(hash);
     
-    bool found = false;
     for (const auto& entry : fs::directory_iterator(recover_dir)) {
         if (entry.path().filename().string().find("file_") == 0 || 
             entry.path().filename().string().find("orphan_") == 0) {
-            found = true;
             // Content check
             std::ifstream ifs(entry.path(), std::ios::binary);
             std::vector<uint8_t> content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());


### PR DESCRIPTION
- Fix incorrect deallocation size in storage_block_reader (was missing metadata size).
- Optimize storage_block_reader::clear_cache to flush blocks in address order, enabling effective free space merging.
- Add test_allocator_drift.cpp to verify sequential update scenarios.
- Fix benchmarks/optimal_usage.cpp array deletion bug (mismatched new[]/delete).
- Fix benchmarks cleanup to remove temporary .wal files.
- Fix compiler warnings in tests.