### PR TITLE
fix: prevent concurrent defragmentation during file removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ docs/html/**
 tests/compio_gtest
 
 vcpkg/*
+
+# Benchmark results
+fragmentation_results.csv
+fragmentation_results_report.txt

--- a/include/compio/allocator.hpp
+++ b/include/compio/allocator.hpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <atomic>
 
 #include "compio.h"
 
@@ -403,9 +404,16 @@ public:
      * @brief Release storage block
      * @param offset Block start offset
      * @param size Block size
+     */
+    void deallocate(uint64_t offset, uint64_t size);
+
+    /**
+     * @brief Release storage block with maintenance control
+     * @param offset Block start offset
+     * @param size Block size
      * @param perform_maintenance Trigger maintenance (defragmentation) after deallocation?
      */
-    void deallocate(uint64_t offset, uint64_t size, bool perform_maintenance = true);
+    void deallocate(uint64_t offset, uint64_t size, bool perform_maintenance);
 
     /**
      * @brief Perform maintenance operations if needed
@@ -457,7 +465,7 @@ private:
     free_blocks_manager blocks_manager_; /**< Free blocks manager */
     uint8_t last_fragmentation_;         /**< Last measured fragmentation */
     uint64_t deallocate_count_ = 0;      /**< Counter to throttle maintenance checks */
-    int maintenance_suspended_ = 0;      /**< Maintenance suspension counter */
+    std::atomic<int> maintenance_suspended_{0};      /**< Maintenance suspension counter */
 
     /**
      * @brief Check if defragmentation is needed

--- a/include/compio/allocator.hpp
+++ b/include/compio/allocator.hpp
@@ -403,13 +403,27 @@ public:
      * @brief Release storage block
      * @param offset Block start offset
      * @param size Block size
+     * @param perform_maintenance Trigger maintenance (defragmentation) after deallocation?
      */
-    void deallocate(uint64_t offset, uint64_t size);
+    void deallocate(uint64_t offset, uint64_t size, bool perform_maintenance = true);
 
     /**
      * @brief Perform maintenance operations if needed
      */
     void maintenance();
+
+    /**
+     * @brief Suspend automatic maintenance operations (e.g. during file removal)
+     */
+    void suspend_maintenance() { maintenance_suspended_++; }
+
+    /**
+     * @brief Resume automatic maintenance operations
+     */
+    void resume_maintenance() { 
+        if (maintenance_suspended_ > 0) maintenance_suspended_--; 
+        if (maintenance_suspended_ == 0) maintenance();
+    }
 
     /**
      * @brief Force defragmentation unconditionally (ignores fragmentation threshold).
@@ -443,6 +457,7 @@ private:
     free_blocks_manager blocks_manager_; /**< Free blocks manager */
     uint8_t last_fragmentation_;         /**< Last measured fragmentation */
     uint64_t deallocate_count_ = 0;      /**< Counter to throttle maintenance checks */
+    int maintenance_suspended_ = 0;      /**< Maintenance suspension counter */
 
     /**
      * @brief Check if defragmentation is needed

--- a/include/compio/compio_file.hpp
+++ b/include/compio/compio_file.hpp
@@ -20,7 +20,7 @@ struct compio_archive {
     std::shared_mutex mutex;
     std::mutex io_mutex;
     std::mutex header_mutex;
-    std::recursive_mutex allocator_mutex;
+    std::shared_mutex allocator_mutex;
 
     int current_header_slot; // 0 for A (offset 0), 1 for B (offset disk_size)
     FILE *file;

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -817,8 +817,12 @@ void block_allocator::force_defragmentation() {
 }
 
 void block_allocator::maintenance() {
-    if (maintenance_suspended_ > 0) {
-        return;
+    {
+        // Ensure the suspended flag is read under the same mutex used for allocator state
+        std::lock_guard<std::recursive_mutex> alloc_lock(archive_->allocator_mutex);
+        if (maintenance_suspended_ > 0) {
+            return;
+        }
     }
 
     uint8_t current_fragmentation = get_fragmentation();

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -753,7 +753,7 @@ uint64_t block_allocator::allocate(uint64_t size) {
     }
 }
 
-void block_allocator::deallocate(uint64_t offset, uint64_t size) {
+void block_allocator::deallocate(uint64_t offset, uint64_t size, bool perform_maintenance) {
     if (offset == UINT64_MAX || size == 0 || !archive_ || !archive_->header) {
         return;
     }
@@ -800,7 +800,7 @@ void block_allocator::deallocate(uint64_t offset, uint64_t size) {
     }
     
     // Check if defragmentation is needed (throttled to avoid O(N) cost on every dealloc)
-    if (++deallocate_count_ % 64 == 0) {
+    if (perform_maintenance && maintenance_suspended_ == 0 && ++deallocate_count_ % 64 == 0) {
         maintenance();
     }
 }
@@ -817,6 +817,10 @@ void block_allocator::force_defragmentation() {
 }
 
 void block_allocator::maintenance() {
+    if (maintenance_suspended_ > 0) {
+        return;
+    }
+
     uint8_t current_fragmentation = get_fragmentation();
     uint8_t threshold = archive_->config.fragmentation_threshold;
 

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -818,6 +818,15 @@ void block_allocator::deallocate(uint64_t offset, uint64_t size, bool perform_ma
 
 void block_allocator::force_defragmentation() {
     auto index_lock = archive_->index->get_lock();
+
+    // Flush caches before locking allocator to avoid deadlock.
+    // block::~block() calls allocate/deallocate which lock allocator_mutex.
+    if (archive_->file) {
+        archive_->block_reader->set_maintenance_mode(true);
+        archive_->block_reader->clear_cache();
+        archive_->index->_clear_cache();
+    }
+
     std::unique_lock<std::shared_mutex> alloc_lock(archive_->allocator_mutex);
 
     blocks_manager_.defragment();
@@ -825,6 +834,10 @@ void block_allocator::force_defragmentation() {
         perform_defragmentation();
     }
     last_fragmentation_ = blocks_manager_.get_cached_fragmentation();
+
+    if (archive_->file) {
+        archive_->block_reader->set_maintenance_mode(false);
+    }
 }
 
 void block_allocator::maintenance() {
@@ -842,9 +855,21 @@ void block_allocator::maintenance() {
              // This avoids deadlocks when called from within a B-tree operation (which holds the lock).
              return;
         }
+
+        // Flush caches before locking allocator to avoid deadlock.
+        // block::~block() calls allocate/deallocate which lock allocator_mutex.
+        if (archive_->file) {
+            archive_->block_reader->set_maintenance_mode(true);
+            archive_->block_reader->clear_cache();
+            archive_->index->_clear_cache();
+        }
+
         std::unique_lock<std::shared_mutex> alloc_lock(archive_->allocator_mutex);
 
         if (maintenance_suspended_ > 0) {
+            if (archive_->file) {
+                archive_->block_reader->set_maintenance_mode(false);
+            }
             return;
         }
 
@@ -858,6 +883,10 @@ void block_allocator::maintenance() {
             }
         }
         last_fragmentation_ = blocks_manager_.get_cached_fragmentation();
+
+        if (archive_->file) {
+            archive_->block_reader->set_maintenance_mode(false);
+        }
     } else {
         std::unique_lock<std::shared_mutex> lock(archive_->allocator_mutex);
         last_fragmentation_ = blocks_manager_.get_cached_fragmentation();
@@ -916,9 +945,9 @@ bool block_allocator::needs_defragmentation() const {
 void block_allocator::perform_defragmentation() {
     // Flush all cached/dirty blocks to disk first so that every index entry
     // has a real physical address before we start moving data.
-    archive_->block_reader->set_maintenance_mode(true);
-    archive_->block_reader->clear_cache();
-    archive_->index->_clear_cache();
+    // NOTE: This must be done by the caller (maintenance/force_defragmentation)
+    // BEFORE holding allocator_mutex to avoid deadlocks, as clear_cache() triggers
+    // block destructors which call allocate/deallocate.
 
     // Collect B-tree node addresses so we don't overwrite them during compaction.
     // B-tree nodes and storage blocks share the same file address space.
@@ -1159,8 +1188,7 @@ void block_allocator::perform_defragmentation() {
     // addresses; any stale temporary_index entries would cause reads to use
     // wrong offsets.
     archive_->block_reader->invalidate_temporary_index();
-    archive_->block_reader->set_maintenance_mode(false);
-
+    
     DEBUG_PRINT("[AL] perform_defragmentation complete. New file size: %" PRIu64 "\n", write_pos);
 }
 

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -688,13 +688,13 @@ block_allocator::block_allocator(compio_archive *archive, WalManager *wal)
 
 uint8_t block_allocator::get_fragmentation() const {
     if (!archive_) return 0;
-    std::lock_guard<std::recursive_mutex> lock(archive_->allocator_mutex);
+    std::shared_lock<std::shared_mutex> lock(archive_->allocator_mutex);
     return blocks_manager_.get_cached_fragmentation();
 }
 
 free_blocks_manager::fragmentation_stats block_allocator::get_fragmentation_stats() const {
     if (!archive_) return {};
-    std::lock_guard<std::recursive_mutex> lock(archive_->allocator_mutex);
+    std::shared_lock<std::shared_mutex> lock(archive_->allocator_mutex);
     return blocks_manager_.get_fragmentation_stats();
 }
 
@@ -703,7 +703,7 @@ uint64_t block_allocator::allocate(uint64_t size) {
         return UINT64_MAX;
     }
 
-    std::lock_guard<std::recursive_mutex> lock(archive_->allocator_mutex);
+    std::unique_lock<std::shared_mutex> lock(archive_->allocator_mutex);
 
     try {
         // Convert allocation strategy from config to internal enum
@@ -753,14 +753,20 @@ uint64_t block_allocator::allocate(uint64_t size) {
     }
 }
 
+void block_allocator::deallocate(uint64_t offset, uint64_t size) {
+    deallocate(offset, size, true);
+}
+
 void block_allocator::deallocate(uint64_t offset, uint64_t size, bool perform_maintenance) {
     if (offset == UINT64_MAX || size == 0 || !archive_ || !archive_->header) {
         return;
     }
 
-    std::lock_guard<std::recursive_mutex> lock(archive_->allocator_mutex);
-    
-    // Validate bounds using the cached file size pointer to avoid locking header_mutex
+    bool run_maintenance = false;
+    {
+        std::unique_lock<std::shared_mutex> lock(archive_->allocator_mutex);
+
+        // Validate bounds using the cached file size pointer to avoid locking header_mutex
     // (which could cause deadlocks if held by caller).
     const uint64_t *file_size_ptr = blocks_manager_.get_file_size_ptr();
     if (file_size_ptr) {
@@ -801,13 +807,18 @@ void block_allocator::deallocate(uint64_t offset, uint64_t size, bool perform_ma
     
     // Check if defragmentation is needed (throttled to avoid O(N) cost on every dealloc)
     if (perform_maintenance && maintenance_suspended_ == 0 && ++deallocate_count_ % 64 == 0) {
+        run_maintenance = true;
+    }
+    }
+
+    if (run_maintenance) {
         maintenance();
     }
 }
 
 void block_allocator::force_defragmentation() {
     auto index_lock = archive_->index->get_lock();
-    std::lock_guard<std::recursive_mutex> alloc_lock(archive_->allocator_mutex);
+    std::unique_lock<std::shared_mutex> alloc_lock(archive_->allocator_mutex);
 
     blocks_manager_.defragment();
     if (archive_->file && archive_->index) {
@@ -817,12 +828,8 @@ void block_allocator::force_defragmentation() {
 }
 
 void block_allocator::maintenance() {
-    {
-        // Ensure the suspended flag is read under the same mutex used for allocator state
-        std::lock_guard<std::recursive_mutex> alloc_lock(archive_->allocator_mutex);
-        if (maintenance_suspended_ > 0) {
-            return;
-        }
+    if (maintenance_suspended_ > 0) {
+        return;
     }
 
     uint8_t current_fragmentation = get_fragmentation();
@@ -835,7 +842,11 @@ void block_allocator::maintenance() {
              // This avoids deadlocks when called from within a B-tree operation (which holds the lock).
              return;
         }
-        std::lock_guard<std::recursive_mutex> alloc_lock(archive_->allocator_mutex);
+        std::unique_lock<std::shared_mutex> alloc_lock(archive_->allocator_mutex);
+
+        if (maintenance_suspended_ > 0) {
+            return;
+        }
 
         if (blocks_manager_.get_cached_fragmentation() > threshold) {
             blocks_manager_.defragment();
@@ -848,7 +859,7 @@ void block_allocator::maintenance() {
         }
         last_fragmentation_ = blocks_manager_.get_cached_fragmentation();
     } else {
-        std::lock_guard<std::recursive_mutex> lock(archive_->allocator_mutex);
+        std::unique_lock<std::shared_mutex> lock(archive_->allocator_mutex);
         last_fragmentation_ = blocks_manager_.get_cached_fragmentation();
     }
 }
@@ -857,7 +868,7 @@ bool block_allocator::save_state(compio_archive *archive) {
     if (!archive) {
         return false;
     }
-    std::lock_guard<std::recursive_mutex> alloc_lock(archive->allocator_mutex);
+    std::unique_lock<std::shared_mutex> alloc_lock(archive->allocator_mutex);
     std::lock_guard<std::mutex> head_lock(archive->header_mutex);
     std::lock_guard<std::mutex> io_lock(archive->io_mutex);
     
@@ -890,7 +901,7 @@ bool block_allocator::load_state(compio_archive *archive) {
     if (!archive) {
         return false;
     }
-    std::lock_guard<std::recursive_mutex> alloc_lock(archive->allocator_mutex);
+    std::unique_lock<std::shared_mutex> alloc_lock(archive->allocator_mutex);
     std::lock_guard<std::mutex> head_lock(archive->header_mutex);
     std::lock_guard<std::mutex> io_lock(archive->io_mutex);
     return blocks_manager_.load_from_file(archive);

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -527,9 +527,12 @@ int compio_remove_file(compio_archive *archive, const char *name) {
         const auto& all_blocks = *all_blocks_opt;
 
     // Suspend maintenance to avoid re-entry during block removal
-    if (archive->allocator) {
-        archive->allocator->suspend_maintenance();
-    }
+    // Use RAII guard to ensure maintenance is resumed even if an error occurs
+    struct MaintenanceGuard {
+        block_allocator* alloc;
+        MaintenanceGuard(block_allocator* a) : alloc(a) { if(alloc) alloc->suspend_maintenance(); }
+        ~MaintenanceGuard() { if(alloc) alloc->resume_maintenance(); }
+    } maintenance_guard(archive->allocator);
 
     // Iterate over all blocks of the file
     {
@@ -551,7 +554,9 @@ int compio_remove_file(compio_archive *archive, const char *name) {
                     archive->index->remove(key);
 
                     // Deallocate. Maintenance is suspended globally, so this won't trigger defrag.
-                    archive->allocator->deallocate(val.addr, STORAGE_BLOCK_METASIZE + sb.size);
+                    // Use overloaded deallocate with explicit false for perform_maintenance, although
+                    // suspended state also prevents it.
+                    archive->allocator->deallocate(val.addr, STORAGE_BLOCK_METASIZE + sb.size, false);
                 } else {
                     WARNING_PRINT("warning: failed to read block at %" PRIu64 " during removal\n", val.addr);
                     if (saved_pos >= 0) {
@@ -570,11 +575,6 @@ int compio_remove_file(compio_archive *archive, const char *name) {
         if (saved_pos >= 0) {
             fseek64(archive->file, saved_pos, SEEK_SET);
         }
-    }
-
-    // Resume maintenance (this will trigger maintenance if needed)
-    if (archive->allocator) {
-        archive->allocator->resume_maintenance();
     }
     } // End if (file_size > 0)
     

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -526,7 +526,13 @@ int compio_remove_file(compio_archive *archive, const char *name) {
         }
         const auto& all_blocks = *all_blocks_opt;
 
-        // Save current file position
+    // Suspend maintenance to avoid re-entry during block removal
+    if (archive->allocator) {
+        archive->allocator->suspend_maintenance();
+    }
+
+    // Iterate over all blocks of the file
+    {
         int64_t saved_pos = ftell64(archive->file);
 
         // Deallocate all blocks and remove them from index
@@ -541,7 +547,10 @@ int compio_remove_file(compio_archive *archive, const char *name) {
                 // Read storage_block metadata to get compressed size
                 storage_block sb;
                 if (sb.read_from(archive->file, val.addr)) {
-                    // Deallocate: metadata + compressed data size
+                    // Remove block from B-tree index BEFORE deallocating.
+                    archive->index->remove(key);
+
+                    // Deallocate. Maintenance is suspended globally, so this won't trigger defrag.
                     archive->allocator->deallocate(val.addr, STORAGE_BLOCK_METASIZE + sb.size);
                 } else {
                     WARNING_PRINT("warning: failed to read block at %" PRIu64 " during removal\n", val.addr);
@@ -551,10 +560,10 @@ int compio_remove_file(compio_archive *archive, const char *name) {
                     errno = EIO;
                     return -1;
                 }
+            } else {
+                // Remove block from B-tree index (if addr is 0, it's still in index)
+                archive->index->remove(key);
             }
-
-            // Remove block from B-tree index
-            archive->index->remove(key);
         }
 
         // Restore file position
@@ -563,6 +572,12 @@ int compio_remove_file(compio_archive *archive, const char *name) {
         }
     }
 
+    // Resume maintenance (this will trigger maintenance if needed)
+    if (archive->allocator) {
+        archive->allocator->resume_maintenance();
+    }
+    } // End if (file_size > 0)
+    
     // Remove file from file table
     return archive->header->ftable.remove(name);
 }

--- a/tests/src/test_file_removal.cpp
+++ b/tests/src/test_file_removal.cpp
@@ -61,6 +61,31 @@ TEST_F(FileRemovalTest, RemoveFileFreesBlocks) {
     compio_close_archive(archive);
 }
 
+TEST_F(FileRemovalTest, RemoveFileWithManyBlocksTriggersMaintenanceCheck) {
+    compio_archive* archive = compio_open_archive(archive_path, "w+", &config);
+    ASSERT_NE(archive, nullptr);
+
+    // Create a file with > 128 blocks to trigger maintenance checks (threshold 64)
+    compio_file* file = compio_open_file("many_blocks.txt", archive);
+    ASSERT_NE(file, nullptr);
+
+    const int num_blocks = 150;
+    const int block_size = 1024; // Ensure consistent block size
+    std::vector<uint8_t> buffer(block_size, 'A');
+
+    for (int i = 0; i < num_blocks; ++i) {
+         compio_write(buffer.data(), block_size, file);
+    }
+    compio_close_file(file);
+    compio_flush(archive);
+
+    // Remove should succeed without error/crash despite maintenance triggers
+    // The allocator should suspend maintenance, so no actual defrag happens during removal loop
+    EXPECT_EQ(compio_remove_file(archive, "many_blocks.txt"), 0);
+
+    compio_close_archive(archive);
+}
+
 TEST_F(FileRemovalTest, RemoveNonexistentFile) {
     compio_archive* archive = compio_open_archive(archive_path, "w+", &config);
     ASSERT_NE(archive, nullptr);


### PR DESCRIPTION
This PR fixes a race condition where concurrent defragmentation (maintenance) could be triggered during `compio_remove_file`, causing IO errors and data corruption when removing large files.

1. **Maintenance Suspension Mechanism**:
   - Added `suspend_maintenance()` and `resume_maintenance()` to `block_allocator` to allow safe bulk operations.
   - Uses `std::atomic<int>` for thread-safe suspension counting.
2. **Concurrency Improvements**:
   - Replaced `std::recursive_mutex` with `std::shared_mutex` (RW-Lock) for `allocator_mutex`. This allows concurrent fragmentation checks (`get_fragmentation`) while ensuring exclusive access for `allocate`/`deallocate`.
   - Updated `deallocate` to release the allocator lock *before* calling `maintenance()`, preventing deadlocks since `std::shared_mutex` is not recursive.
3. **Safety in File Removal**:
   - Added `MaintenanceGuard` RAII helper in `compio_remove_file`. This ensures maintenance is suspended for the duration of the file removal loop and automatically resumed even if exceptions occur or the function returns early.
4. **Testing**:
   - Added regression test `RemoveFileWithManyBlocksTriggersMaintenanceCheck` in `tests/src/test_file_removal.cpp` to verify that removing a file with enough blocks to trigger maintenance (threshold 64) does so safely.
