### PR TITLE
chore: rename and improve utility tools

### DIFF
--- a/compio.h
+++ b/compio.h
@@ -180,9 +180,9 @@ typedef struct {
     bool fill_holes_with_zeros;      /**< Zero-fill freed blocks for sparse file optimization */
     uint8_t fragmentation_threshold; /**< Trigger defragmentation when fragmentation exceeds this
                                         percentage (1-100) */
-    int max_files; /**< Maximum number of files in a single archive (default: COMPIO_MAX_FILES).
-360.                         Set to 0 to use the default limit (COMPIO_MAX_FILES) when creating a new archive,
-361.                         or to read the limit from the archive header when opening an existing one. */
+    int max_files; /**< Initial capacity for the files table (default: COMPIO_MAX_FILES).
+                        The table grows dynamically, so this is not a hard limit.
+                        Set to 0 to use the default capacity. */
     uint64_t wal_max_size_bytes; /**< Maximum size of WAL file in bytes before forcing a checkpoint. 0 = unlimited. */
     compio_checksum_type checksum_type; /**< Checksum algorithm for data blocks */
     compio_wal_sync_mode wal_sync_mode; /**< WAL synchronization mode */

--- a/compio.h
+++ b/compio.h
@@ -182,7 +182,10 @@ typedef struct {
                                         percentage (1-100) */
     int max_files; /**< Initial capacity for the files table (default: COMPIO_MAX_FILES).
                         The table grows dynamically, so this is not a hard limit.
-                        Set to 0 to use the default capacity. */
+                        For archives using the v5 dynamic files table, this capacity may grow
+                        beyond the initial value (subject to the hard upper bound COMPIO_MAX_FILES_LIMIT).
+                        For legacy/fixed-table formats, the on-disk files table size is fixed, so this
+                        may act as an effective limit. Set to 0 to use the default capacity. */
     uint64_t wal_max_size_bytes; /**< Maximum size of WAL file in bytes before forcing a checkpoint. 0 = unlimited. */
     compio_checksum_type checksum_type; /**< Checksum algorithm for data blocks */
     compio_wal_sync_mode wal_sync_mode; /**< WAL synchronization mode */

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -80,6 +80,9 @@ config.cache_size__blocks = 8192;                   // Storage block cache
 config.allocation_strategy = COMPIO_ALLOC_FIRST_FIT; // Allocation strategy
 config.fragmentation_threshold = 30;                // Defrag threshold (%)
 config.fill_holes_with_zeros = false;               // Zero-fill freed blocks
+config.wal_sync_mode = COMPIO_WAL_SYNC_ALWAYS;      // WAL synchronization mode (ALWAYS, NORMAL, OFF)
+config.wal_max_size_bytes = 64 * 1024 * 1024;       // Max WAL size before checkpoint
+config.max_files = 4096;                            // Initial file table capacity (grows dynamically)
 ```
 
 ### Allocation Strategies
@@ -89,3 +92,38 @@ config.fill_holes_with_zeros = false;               // Zero-fill freed blocks
 - `COMPIO_ALLOC_WORST_FIT` - Use largest suitable free block
 - `COMPIO_ALLOC_NEXT_FIT` - Continue from last allocation position
 
+### Thread Safety
+
+The library is thread-safe for concurrent operations on the same archive:
+- **Concurrent Reads**: Multiple threads can read from different files (or same file) concurrently.
+- **Concurrent Writes**: Multiple threads can write to different files concurrently.
+- **Concurrent Read/Write**: Readers and writers can operate concurrently.
+- **Defragmentation**: Can run concurrently with other operations (locks only necessary regions).
+
+Note: `compio_config` setup is not thread-safe; initialize it before opening archive.
+
+### Tools
+
+#### compio_repair
+
+A CLI tool to recover data from corrupted archives.
+
+```bash
+# Basic usage
+./compio_repair input_archive.cmp output_directory/
+
+# It attempts to recover files even if the header or index is corrupted.
+```
+
+#### compio_unpack
+
+A CLI tool to extract all files from a valid archive.
+
+```bash
+# Basic usage
+./compio_unpack input_archive.cmp output_directory_prefix/
+
+# Extracts all files from the archive to the specified location.
+# Note: output_directory_prefix is a prefix, so if you want a directory, end it with /
+# Example: ./compio_unpack archive.cmp extracted/
+```

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -94,13 +94,12 @@ config.max_files = 4096;                            // Initial file table capaci
 
 ### Thread Safety
 
-The library is thread-safe for concurrent operations on the same archive:
-- **Concurrent Reads**: Multiple threads can read from different files (or same file) concurrently.
-- **Concurrent Writes**: Multiple threads can write to different files concurrently.
-- **Concurrent Read/Write**: Readers and writers can operate concurrently.
-- **Defragmentation**: Can run concurrently with other operations (locks only necessary regions).
+The library is thread-safe for multi-threaded use on the same archive, with the following guarantees:
+- **Concurrent Reads**: Multiple threads can read from different files (or the same file) in the same archive concurrently.
+- **Writes Are Exclusive**: Write operations (`compio_write` and related APIs) take an exclusive lock on the archive. While a write is in progress, other reads and writes on that archive are blocked.
+- **Defragmentation Is Exclusive**: `compio_defragment` also takes an exclusive lock on the archive. It cannot run concurrently with reads or writes on that archive.
 
-Note: `compio_config` setup is not thread-safe; initialize it before opening archive.
+Note: `compio_config` setup is not thread-safe; initialize it before opening an archive.
 
 ### Tools
 

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -71,6 +71,8 @@ compio_close_archive(archive);
 
 ```c
 compio_config config;
+compio_build_default_config(&config);       // Initialize with defaults first!
+
 config.b_tree_degree = 16;                          // B-Tree degree
 config.block_size = 4096;                           // Block size in bytes
 config.block_size__minimum = 512;                   // Minumum block size in bytes

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,7 +19,7 @@ set_target_properties(cpp_wrapper_example PROPERTIES
     CXX_STANDARD_REQUIRED ON
 )
 
-# Recovery tool
-add_executable(compio_repair compio_repair.cpp)
-target_link_libraries(compio_repair PRIVATE compio)
-target_include_directories(compio_repair PRIVATE ${CMAKE_SOURCE_DIR})
+# Recovery tool example
+add_executable(repair_example compio_repair.cpp)
+target_link_libraries(repair_example PRIVATE compio)
+target_include_directories(repair_example PRIVATE ${CMAKE_SOURCE_DIR})

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_executable(unpack unpack.cpp)
-target_link_libraries(unpack PRIVATE compio)
+add_executable(compio_unpack unpack.cpp)
+target_link_libraries(compio_unpack PRIVATE compio)
 
-add_executable(repair repair.cpp)
-target_link_libraries(repair PRIVATE compio)
+add_executable(compio_repair repair.cpp)
+target_link_libraries(compio_repair PRIVATE compio)

--- a/util/unpack.cpp
+++ b/util/unpack.cpp
@@ -1,14 +1,31 @@
 #include <stdexcept>
+#include <algorithm>
+#include <memory>
+#include <cstdio>
+#include <string>
+#include <filesystem>
 
 #include "compio/compio_file.hpp"
 #include "compio.h"
 
+namespace fs = std::filesystem;
+
 int main(int argc, char **argv) {
     if (argc != 3) {
-        throw std::runtime_error("usage: ./unpack <file> <output_prefix>");
+        throw std::runtime_error("usage: ./compio_unpack <file> <output_prefix>");
     }
 
     const std::string out_prefix = argv[2];
+
+    // Ensure parent directory exists if prefix contains a path
+    fs::path prefix_path(out_prefix);
+    if (prefix_path.has_parent_path()) {
+        std::error_code ec;
+        fs::create_directories(prefix_path.parent_path(), ec);
+        if (ec) {
+             throw std::runtime_error("failed to create directory " + prefix_path.parent_path().string());
+        }
+    }
 
     compio_config config;
     compio_build_default_config(&config);
@@ -34,18 +51,34 @@ int main(int argc, char **argv) {
 
         printf("size = %lu\n", f.size);
 
-        auto buffer = std::make_unique<uint8_t[]>(f.size);
-        std::size_t read_bytes = compio_read(buffer.get(), f.size, file);
-        if (read_bytes != f.size) {
-            throw std::runtime_error("failed to read file " + std::string(f.name));
+        std::string out_fp = out_prefix + f.name;
+        FILE *out_file = fopen(out_fp.c_str(), "wb");
+        if (!out_file) {
+            compio_close_file(file);
+            throw std::runtime_error("failed to open output file " + out_fp);
         }
 
-        std::string out_fp = out_prefix + f.name;
-        FILE *out_file = fopen(out_fp.c_str(), "w+");
-
-        std::size_t written_bytes = fwrite(buffer.get(), 1, f.size, out_file);
-        if (written_bytes != f.size) {
-            throw std::runtime_error("failed to write data to file " + out_fp);
+        // Use 1MB buffer to avoid huge allocations
+        constexpr size_t buffer_size = 1024 * 1024;
+        auto buffer = std::make_unique<uint8_t[]>(buffer_size);
+        
+        uint64_t remaining = f.size;
+        while (remaining > 0) {
+            size_t to_read = std::min(static_cast<uint64_t>(buffer_size), remaining);
+            size_t read_bytes = compio_read(buffer.get(), to_read, file);
+            
+            if (read_bytes != to_read) {
+                fclose(out_file);
+                compio_close_file(file);
+                throw std::runtime_error("failed to read file " + std::string(f.name));
+            }
+            
+            if (fwrite(buffer.get(), 1, read_bytes, out_file) != read_bytes) {
+                fclose(out_file);
+                compio_close_file(file);
+                throw std::runtime_error("failed to write data to file " + out_fp);
+            }
+            remaining -= read_bytes;
         }
 
         fclose(out_file);

--- a/util/unpack.cpp
+++ b/util/unpack.cpp
@@ -4,26 +4,63 @@
 #include <cstdio>
 #include <string>
 #include <filesystem>
+#include <cinttypes>
 
 #include "compio/compio_file.hpp"
 #include "compio.h"
 
 namespace fs = std::filesystem;
 
+// Helper to sanitize and join paths, preventing traversal attacks
+fs::path safe_join(const fs::path& base, const std::string& part) {
+    fs::path target = base / part;
+    // Normalize path
+    target = target.lexically_normal();
+    
+    // Check if target is within base
+    // Note: lexically_normal() handles ".." resolution. 
+    // We convert both to absolute paths to be sure, or just check the string prefix if base is absolute.
+    // However, if base is relative, we need to be careful.
+    // A simple check: ensure the resulting path starts with the base path.
+    // But lexically_normal might produce "base/../other" -> "other", which is outside.
+    // So we check if the relative path from base to target starts with "..".
+    
+    // Ensure base is absolute for robust checking
+    fs::path abs_base = fs::absolute(base);
+    fs::path abs_target = fs::absolute(target);
+    
+    auto rel = fs::relative(abs_target, abs_base);
+    if (!rel.empty() && rel.string().rfind("..", 0) == 0) {
+        throw std::runtime_error("security error: path traversal detected: " + part);
+    }
+    
+    return target;
+}
+
 int main(int argc, char **argv) {
     if (argc != 3) {
         throw std::runtime_error("usage: ./compio_unpack <file> <output_prefix>");
     }
 
-    const std::string out_prefix = argv[2];
+    const std::string out_prefix_str = argv[2];
+    fs::path out_prefix(out_prefix_str);
 
-    // Ensure parent directory exists if prefix contains a path
-    fs::path prefix_path(out_prefix);
-    if (prefix_path.has_parent_path()) {
+    // If prefix ends with separator, treat it as a directory
+    bool is_directory_mode = !out_prefix_str.empty() && 
+                             (out_prefix_str.back() == fs::path::preferred_separator || 
+                              out_prefix_str.back() == '/'); // support both slash types
+
+    if (is_directory_mode) {
         std::error_code ec;
-        fs::create_directories(prefix_path.parent_path(), ec);
+        fs::create_directories(out_prefix, ec);
         if (ec) {
-             throw std::runtime_error("failed to create directory " + prefix_path.parent_path().string());
+             throw std::runtime_error("failed to create directory " + out_prefix.string());
+        }
+    } else if (out_prefix.has_parent_path()) {
+        std::error_code ec;
+        fs::create_directories(out_prefix.parent_path(), ec);
+        if (ec) {
+             throw std::runtime_error("failed to create directory " + out_prefix.parent_path().string());
         }
     }
 
@@ -49,13 +86,48 @@ int main(int argc, char **argv) {
             throw std::runtime_error("failed to open file " + std::string(f.name));
         }
 
-        printf("size = %lu\n", f.size);
+        printf("size = %" PRIu64 "\n", f.size);
 
-        std::string out_fp = out_prefix + f.name;
-        FILE *out_file = fopen(out_fp.c_str(), "wb");
+        // Sanitize output path
+        fs::path out_fp;
+        if (is_directory_mode) {
+            out_fp = safe_join(out_prefix, f.name);
+        } else {
+             // If out_prefix is just a prefix string (e.g. "out_"), we just concat.
+             // But we still need to check for traversal in f.name itself.
+             // This is tricky because "out_" + "../foo" -> "out_../foo".
+             // Safer to only support directory mode or simple prefix.
+             // But to preserve backward compatibility (if any), let's assume simple concat is allowed
+             // providing f.name doesn't traverse up.
+             
+             // Construct the full path first
+             std::string full_path_str = out_prefix_str + f.name;
+             fs::path full_path(full_path_str);
+             
+             // Check if full_path is safe relative to CWD? 
+             // Or relative to the parent of out_prefix?
+             // Let's enforce that f.name does not contain ".."
+             fs::path name_path(f.name);
+             if (name_path.is_absolute() || name_path.string().find("..") != std::string::npos) {
+                 throw std::runtime_error("security error: invalid filename " + std::string(f.name));
+             }
+             out_fp = full_path;
+        }
+
+        // Ensure parent directory of the output file exists
+        if (out_fp.has_parent_path()) {
+            std::error_code ec;
+            fs::create_directories(out_fp.parent_path(), ec);
+            if (ec) {
+                compio_close_file(file);
+                throw std::runtime_error("failed to create directory " + out_fp.parent_path().string());
+            }
+        }
+
+        FILE *out_file = fopen(out_fp.string().c_str(), "wb");
         if (!out_file) {
             compio_close_file(file);
-            throw std::runtime_error("failed to open output file " + out_fp);
+            throw std::runtime_error("failed to open output file " + out_fp.string());
         }
 
         // Use 1MB buffer to avoid huge allocations
@@ -76,7 +148,7 @@ int main(int argc, char **argv) {
             if (fwrite(buffer.get(), 1, read_bytes, out_file) != read_bytes) {
                 fclose(out_file);
                 compio_close_file(file);
-                throw std::runtime_error("failed to write data to file " + out_fp);
+                throw std::runtime_error("failed to write data to file " + out_fp.string());
             }
             remaining -= read_bytes;
         }


### PR DESCRIPTION
- Rename `unpack` target to `compio_unpack` and `repair` to `compio_repair` in `util/CMakeLists.txt` to avoid conflicts and match installed binary naming conventions.
- Rename `compio_repair` example target to `repair_example` in `examples/CMakeLists.txt`.
- Improve `compio_unpack` implementation:
  - Use chunked I/O (1MB buffer) instead of loading entire file into memory, preventing OOM on large files.
  - Automatically create parent directories for output files if `output_prefix` contains path separators.
  - Add missing standard includes.
- Update `docs/api_usage.md` to document both `compio_repair` and `compio_unpack` tools.