### PR TITLE
fix: cleanup WAL files after benchmark runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ vcpkg/*
 # Benchmark results
 fragmentation_results.csv
 fragmentation_results_report.txt
+# Benchmark temporary files
+bench_*.tmp
+bench_*.tmp.wal

--- a/benchmarks/src/allocator_benchmark.cpp
+++ b/benchmarks/src/allocator_benchmark.cpp
@@ -51,6 +51,7 @@ static void BM_FragmentationOverhead(benchmark::State& state) {
 
     for ([[maybe_unused]] auto _ : state) {
         remove(filename.c_str());
+        remove((filename + ".wal").c_str());
 
         compio_config config = {};
         compio_build_default_config(&config);
@@ -133,6 +134,7 @@ static void BM_FragmentationOverhead(benchmark::State& state) {
 
         compio_close_archive(archive);
         remove(filename.c_str());
+        remove((filename + ".wal").c_str());
     }
 
     state.counters["WastedSpace_KB"] = static_cast<double>(total_wasted_space) / 1024.0;
@@ -164,6 +166,7 @@ static void BM_SpaceReuseEfficiency(benchmark::State& state) {
 
     for ([[maybe_unused]] auto _ : state) {
         remove(filename.c_str());
+        remove((filename + ".wal").c_str());
 
         compio_config config = {};
         compio_build_default_config(&config);
@@ -220,6 +223,7 @@ static void BM_SpaceReuseEfficiency(benchmark::State& state) {
 
         compio_close_archive(archive);
         remove(filename.c_str());
+        remove((filename + ".wal").c_str());
     }
 
     double space_growth_pct = 100.0 * (static_cast<double>(space_after - space_before)) / space_before;


### PR DESCRIPTION
- Add WAL file removal in allocator benchmarks after closing archives.
- Cleanup both before starting iteration and after closing.
- Add bench_\*.tmp and bench_\*.tmp.wal patterns to .gitignore.
- Prevents leftover WAL files from appearing in git status.