### PR TITLE
ci: simplify Doxygen deploy to gh-pages branch

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -5,19 +5,17 @@ on:
     branches:
       - main
       - develop
-  pull_request:
-    branches:
-      - main
-      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,12 +29,13 @@ jobs:
         run: |
           doxygen Doxyfile
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs/public/html
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+      - name: Deploy to GitHub Pages (gh-pages branch)
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        run: |
+          cd docs/public/html
+          git init
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "docs: update Doxygen documentation"
+          git push -f https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:gh-pages


### PR DESCRIPTION
- Push generated documentation directly to gh-pages branch
- More reliable than upload-pages-artifact for Doxygen
- Support manual trigger via workflow_dispatch
- Documentation will auto-update on push to main/develop