### PR TITLE
docs: add branch structure documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # compio
+
+## Development Branches
+
+- **`main`** — Stable releases. Updated from `develop` via pull requests.
+- **`develop`** — Active development. All feature branches merge here.
+- **`gh-pages`** — Auto-generated Doxygen documentation (GitHub Pages). Updated by CI workflow.
+
+Feature branches (e.g., `docs/*`, `feat/*`, `fix/*`) are merged into `develop` via pull requests.
+
+---


### PR DESCRIPTION
- Document main as stable branch
- Document develop as active development branch
- Document gh-pages for auto-generated Doxygen
- Explain feature branch workflow