### PR TITLE
docs: various documentation improvements and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Compio is a lightweight library designed for transparent data compression, enabl
 
    ```cmd
    git clone https://github.com/lovyagin/compio.git
-   cd C:\Users\Admin\compio
+   cd compio
    ```
 
 2. **Set Up vcpkg**:
@@ -78,7 +78,7 @@ Compio is a lightweight library designed for transparent data compression, enabl
       ```cmd
       vcpkg install
       ```
-    - **Optional**: Add the vcpkg directory (e.g., `C:\Users\Admin\compio\vcpkg`) to your system's `PATH` environment variable for easier access to `vcpkg.exe`.
+    - **Optional**: Add the vcpkg directory (e.g., `C:\path\to\compio\vcpkg`) to your system's `PATH` environment variable for easier access to `vcpkg.exe`.
 
 3. **Build the Project**:
 
@@ -91,7 +91,7 @@ Compio is a lightweight library designed for transparent data compression, enabl
     - Configure the project with CMake, specifying the vcpkg toolchain file:
 
       ```cmd
-      cmake .. -DCMAKE_TOOLCHAIN_FILE=C:/Users/Admin/compio/vcpkg/scripts/buildsystems/vcpkg.cmake
+      cmake .. -DCMAKE_TOOLCHAIN_FILE=C:/path/to/compio/vcpkg/scripts/buildsystems/vcpkg.cmake
       ```
     - Build the project:
 
@@ -101,7 +101,7 @@ Compio is a lightweight library designed for transparent data compression, enabl
     - **Using an IDE (e.g., CLion)**: If you are using an IDE like CLion, open the project and add the following to your CMake options:
 
       ```
-      -DCMAKE_TOOLCHAIN_FILE=C:/Users/Admin/compio/vcpkg/scripts/buildsystems/vcpkg.cmake
+      -DCMAKE_TOOLCHAIN_FILE=C:/path/to/compio/vcpkg/scripts/buildsystems/vcpkg.cmake
       ```
 
       Then, use the IDE's build tools to compile the project.
@@ -137,7 +137,7 @@ See [`docs/cpp_wrapper.md`](docs/cpp_wrapper.md) for full API reference and [`ex
 
 ## Notes
 
-- Ensure the path `C:/Users/Admin/compio/vcpkg/scripts/buildsystems/vcpkg.cmake` is adjusted to match your actual directory structure on Windows.
+- Ensure the path `C:/path/to/compio/vcpkg/scripts/buildsystems/vcpkg.cmake` is adjusted to match your actual directory structure on Windows.
 - If you encounter issues with dependencies, verify that vcpkg has installed all required packages by running `vcpkg install` in the vcpkg directory.
 - For additional support or to report issues, visit the Compio GitHub repository.
 

--- a/compio.h
+++ b/compio.h
@@ -130,14 +130,14 @@ typedef struct compio_compressor {
 /**
  * @brief Test compressor, keeps data exactly the same
  *
- * @param result
+ * @param result Pointer to compressor structure to initialize
  */
 void compio_build_dummy_compressor(compio_compressor *result);
 
 /**
  * @brief ZLIB compressor
  *
- * @param result
+ * @param result Pointer to compressor structure to initialize
  */
 void compio_build_zlib_compressor(compio_compressor *result);
 
@@ -153,7 +153,7 @@ void compio_build_zlib_compressor_with_level(compio_compressor *result, int leve
 /**
  * @brief LZ4 compressor - very fast compression/decompression
  *
- * @param result
+ * @param result Pointer to compressor structure to initialize
  */
 void compio_build_lz4_compressor(compio_compressor *result);
 
@@ -169,7 +169,7 @@ void compio_build_lz4_compressor_with_level(compio_compressor *result, int level
 /**
  * @brief Zstandard (zstd) compressor - modern efficient compression
  *
- * @param result
+ * @param result Pointer to compressor structure to initialize
  */
 void compio_build_zstd_compressor(compio_compressor *result);
 
@@ -184,7 +184,7 @@ void compio_build_zstd_compressor_with_level(compio_compressor *result, int leve
 /**
  * @brief Brotli compressor - high compression ratio
  *
- * @param result
+ * @param result Pointer to compressor structure to initialize
  */
 void compio_build_brotli_compressor(compio_compressor *result);
 
@@ -263,16 +263,16 @@ typedef struct {
 /**
  * @brief Default configuration
  *
- * @param result
+ * @param result Pointer to config structure to initialize with defaults
  */
 void compio_build_default_config(compio_config *result);
 
 /**
  * @brief Get compression type from header of existing archive
  *
- * @param fp path to archive file
- * @param t pointer t compression_type object
- * @return int
+ * @param fp Path to archive file
+ * @param t Pointer to compression_type to receive the result
+ * @return COMPIO_SUCCESS on success, COMPIO_ERROR on failure
  */
 int compio_get_compression_type(const char *fp, compio_compression_type *t);
 

--- a/compio.h
+++ b/compio.h
@@ -142,9 +142,11 @@ void compio_build_dummy_compressor(compio_compressor *result);
 void compio_build_zlib_compressor(compio_compressor *result);
 
 /**
- * @brief ZLIB compressor
+ * @brief ZLIB compressor with explicit compression level
  *
- * @param result
+ * @param result Pointer to compressor structure to initialize
+ * @param level Compression level (0 = no compression, 1 = fastest, 9 = best compression,
+ *              Z_DEFAULT_COMPRESSION = default balance)
  */
 void compio_build_zlib_compressor_with_level(compio_compressor *result, int level);
 
@@ -156,9 +158,11 @@ void compio_build_zlib_compressor_with_level(compio_compressor *result, int leve
 void compio_build_lz4_compressor(compio_compressor *result);
 
 /**
- * @brief LZ4 compressor - very fast compression/decompression
+ * @brief LZ4 compressor with explicit acceleration level
  *
- * @param result
+ * @param result Pointer to compressor structure to initialize
+ * @param level Acceleration factor (1 = default speed/ratio balance, higher = faster but lower
+ *              compression ratio)
  */
 void compio_build_lz4_compressor_with_level(compio_compressor *result, int level);
 
@@ -170,9 +174,10 @@ void compio_build_lz4_compressor_with_level(compio_compressor *result, int level
 void compio_build_zstd_compressor(compio_compressor *result);
 
 /**
- * @brief Zstandard (zstd) compressor - modern efficient compression
+ * @brief Zstandard (zstd) compressor with explicit compression level
  *
- * @param result
+ * @param result Pointer to compressor structure to initialize
+ * @param level Compression level (1 = fastest, 22 = best compression, default = 5)
  */
 void compio_build_zstd_compressor_with_level(compio_compressor *result, int level);
 
@@ -184,9 +189,10 @@ void compio_build_zstd_compressor_with_level(compio_compressor *result, int leve
 void compio_build_brotli_compressor(compio_compressor *result);
 
 /**
- * @brief Brotli compressor - high compression ratio
+ * @brief Brotli compressor with explicit compression level
  *
- * @param result
+ * @param result Pointer to compressor structure to initialize
+ * @param level Compression level (0 = fastest, 11 = best compression, default = 5)
  */
 void compio_build_brotli_compressor_with_level(compio_compressor *result, int level);
 

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -32,6 +32,24 @@ compio_build_lz4_compressor(&config.compressor);      // LZ4
 compio_archive* archive = compio_open_archive("archive.cmp", "w+", &config);
 ```
 
+### Selecting Compression Level
+
+Each algorithm supports an explicit level via `_with_level` variants:
+
+```c
+// ZLIB: 0 = no compression, 1 = fastest, 9 = best; default = Z_DEFAULT_COMPRESSION
+compio_build_zlib_compressor_with_level(&config.compressor, 9);
+
+// LZ4: acceleration factor — 1 = default balance, higher = faster/lower ratio
+compio_build_lz4_compressor_with_level(&config.compressor, 1);
+
+// Zstandard: 1 = fastest, 22 = best compression; default = 5
+compio_build_zstd_compressor_with_level(&config.compressor, 3);
+
+// Brotli: 0 = fastest, 11 = best compression; default = 5
+compio_build_brotli_compressor_with_level(&config.compressor, 11);
+```
+
 ### Automatic Compression Detection
 
 The compression algorithm is automatically saved in the archive header. When reopening an archive, the correct compressor is automatically selected:
@@ -75,7 +93,7 @@ compio_build_default_config(&config);       // Initialize with defaults first!
 
 config.b_tree_degree = 16;                          // B-Tree degree
 config.block_size = 4096;                           // Block size in bytes
-config.block_size__minimum = 512;                   // Minumum block size in bytes
+config.block_size__minimum = 512;                   // Minimum block size in bytes
 config.block_size__maximum = 16384;                 // Maximum block size in bytes
 config.cache_size__nodes = 1024;                    // B-tree node cache
 config.cache_size__blocks = 8192;                   // Storage block cache

--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -103,6 +103,8 @@ config.fill_holes_with_zeros = false;               // Zero-fill freed blocks
 config.wal_sync_mode = COMPIO_WAL_SYNC_ALWAYS;      // WAL synchronization mode (ALWAYS, NORMAL, OFF)
 config.wal_max_size_bytes = 64 * 1024 * 1024;       // Max WAL size before checkpoint
 config.max_files = 4096;                            // Initial file table capacity (grows dynamically)
+config.checksum_type = COMPIO_CHECKSUM_CRC32C;      // Checksum algorithm (FNV1A or CRC32C)
+config.auto_batch_size = 8;                         // Auto-batch sequential ops (0 = disabled)
 ```
 
 ### Allocation Strategies
@@ -115,9 +117,10 @@ config.max_files = 4096;                            // Initial file table capaci
 ### Thread Safety
 
 The library is thread-safe for multi-threaded use on the same archive, with the following guarantees:
-- **Concurrent Reads**: Multiple threads can read from different files (or the same file) in the same archive concurrently.
-- **Writes Are Exclusive**: Write operations (`compio_write` and related APIs) take an exclusive lock on the archive. While a write is in progress, other reads and writes on that archive are blocked.
-- **Defragmentation Is Exclusive**: `compio_defragment` also takes an exclusive lock on the archive. It cannot run concurrently with reads or writes on that archive.
+- **Concurrent reads**: Multiple threads can read from different files (or the same file) concurrently using separate file handles.
+- **Concurrent writes**: Multiple threads can write to **different** files simultaneously, each using its own file handle.
+- **Per-file exclusivity**: A single file handle must not be used by multiple threads concurrently — each thread needs its own handle (via `compio_open_file`).
+- **Defragmentation is exclusive**: `compio_defragment` cannot run concurrently with reads or writes on that archive.
 
 Note: `compio_config` setup is not thread-safe; initialize it before opening an archive.
 

--- a/docs/cpp_wrapper.md
+++ b/docs/cpp_wrapper.md
@@ -31,7 +31,7 @@ config.set_block_size(4096)
       .set_compressor(compio::compressors::lz4());
 ```
 
-**Methods**: `set_block_size()`, `set_btree_degree()`, `set_cache_blocks()`, `set_compressor()`, `set_allocation_strategy()`, `set_fill_holes()`, `set_fragmentation_threshold()`
+**Methods**: `set_block_size()`, `set_btree_degree()`, `set_cache_nodes()`, `set_cache_blocks()`, `set_compressor()`, `set_allocation_strategy()`, `set_fill_holes()`, `set_fragmentation_threshold()`
 
 ### Archive
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,14 @@ This directory contains examples demonstrating compression functionality.
 
 ## Examples
 
+### `example_usage.c`
+Basic end-to-end example: open archive, write data, read it back, close.
+
+**Usage:**
+```bash
+./example_usage
+```
+
 ### `compressor_example.c`
 Demonstrates all available compression algorithms and their compression ratios on sample data.
 
@@ -29,6 +37,14 @@ Demonstrates that compression type is automatically saved and restored when reop
 - Verifies data integrity and correct decompression
 
 This example proves that you don't need to specify the compression algorithm when opening an existing archive - it's automatically detected from the header.
+
+### `cpp_wrapper_example.cpp`
+Demonstrates the C++ wrapper API: RAII archive/file management, stream operators, and error handling.
+
+**Usage:**
+```bash
+./cpp_wrapper_example
+```
 
 ## Available Compression Algorithms
 


### PR DESCRIPTION
This PR consolidates several minor updates to improve the accuracy and completeness of the documentation:

*   **Fixes:** Corrected typos, copy-paste errors in Doxygen, and replaced a hardcoded Windows path in the README.
*   **Additions:** Added missing methods (`set_cache_nodes`), config fields, and example files to the documentation.
*   **Improvements:** Clarified thread-safety descriptions and improved Doxygen parameter details in the public API (`compio.h`).