### PR TITLE
fix(allocator): size files-table block correctly and reclaim old block

### DIFF
--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -2185,24 +2185,29 @@ static void sync_files_table(compio_archive *archive) {
     if (archive->header->magic_number != COMPIO_MAGIC_NUMBER) return;
 
     // Copy-on-write for the files table:
-    // Always allocate new space for the table and write into it, then update the
-    // header to point to the new region. We intentionally do NOT deallocate the
-    // old table here, because this function has no way to know when the updated
-    // header has been made durable on disk.
-    //
-    // Note: This intentionally leaks the old table block until a "GC" or full
-    // defragmentation (rebuild from index) is implemented. This is the price for
-    // crash safety with the current double-buffered header design.
+    // Copy-on-write: allocate a fresh block for the table, write into it, then
+    // point the header at the new region. The previous table block is freed
+    // afterwards. This is crash safe: deallocate() only mutates the in-memory
+    // free list, which becomes durable atomically together with the new header
+    // (allocator save_state + double-buffered header + WAL commit happen later
+    // in compio_flush). A crash before that rolls back to the previous header,
+    // whose table block is still marked allocated and intact on disk. The new
+    // block is allocated before the old one is freed, so they never overlap.
 
     uint32_t current_capacity = archive->header->ftable.max_files;
     if (current_capacity == 0) {
         return;
     }
 
-    // Calculate needed size
-    // Each entry is COMPIO_FNAME_MAX_SIZE (256) + sizeof(uint64_t) (8) = 264 bytes.
-    // We allocate for full capacity.
-    uint64_t needed_size = static_cast<uint64_t>(current_capacity) * (COMPIO_FNAME_MAX_SIZE + sizeof(uint64_t));
+    const uint64_t old_addr     = archive->header->files_table_addr;
+    const uint64_t old_capacity = archive->header->files_table_capacity;
+
+    // Calculate needed size. Must match files_table::write_to, which serialises
+    // one files_table::file per slot: name[COMPIO_FNAME_MAX_SIZE] + size(u64) +
+    // file_id(u64). Omitting file_id here previously under-allocated the block
+    // by 8 bytes per slot, so write_to overran into the next allocation.
+    constexpr uint64_t kEntrySize = COMPIO_FNAME_MAX_SIZE + 2 * sizeof(uint64_t);
+    uint64_t needed_size = static_cast<uint64_t>(current_capacity) * kEntrySize;
 
     // Allocate space using allocator if available
     uint64_t new_addr = 0;
@@ -2222,12 +2227,18 @@ static void sync_files_table(compio_archive *archive) {
     
     if (new_addr != 0 && new_addr != UINT64_MAX) {
         // Update header to point to the newly allocated table.
-        // We do NOT free the old address.
         archive->header->files_table_addr = new_addr;
         archive->header->files_table_capacity = current_capacity;
-        
+
         // Write the table content at the new address.
         archive->header->ftable.write_to(archive->file, archive->header->files_table_addr);
+
+        // Reclaim the previous table block (if any). Must run after the new
+        // block is allocated so the two regions never overlap.
+        if (archive->allocator && old_addr != 0 && old_addr != new_addr) {
+            const uint64_t old_size = old_capacity * kEntrySize;
+            archive->allocator->deallocate(old_addr, old_size);
+        }
     } else {
          WARNING_PRINT("warning: failed to allocate space for files table\n");
     }
@@ -2270,7 +2281,7 @@ void compio_flush(compio_archive *archive) {
     if (archive->allocator && can_write) {
          archive->allocator->save_state(archive);
     }
-    
+
     // Double-buffered Header Write
     flush_header_double_buffered(archive);
     

--- a/tests/src/test_defragmentation.cpp
+++ b/tests/src/test_defragmentation.cpp
@@ -7,7 +7,9 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdio>
 #include <cstring>
+#include <filesystem>
 #include <vector>
 
 #include "compio/allocator.hpp"
@@ -867,6 +869,113 @@ TEST_F(PerformDefragmentationTest, RepeatedDefragCycles_DataIntact) {
 // ---------------------------------------------------------------------------
 // Test that the free_blocks_manager destructor properly frees all nodes.
 // Implicitly checked by ASAN — this exercises a complex internal state.
+// ---------------------------------------------------------------------------
+// FilesTableNoLeakOnRepeatedFlush
+// sync_files_table() uses copy-on-write across two alternating blocks for the
+// external (v5) files table (mirrors the double-buffered header). It must
+// reclaim the previous table block on each flush instead of leaking a fresh
+// one, so repeated no-op flushes must never leak a whole files-table block.
+// Regression test for the under-allocation bug where the block was sized
+// without the per-entry file_id field, breaking reuse (a full block leaked
+// every flush) and overrunning the allocation on write.
+// ---------------------------------------------------------------------------
+TEST(DefragmentationPhysicalTest, FilesTableNoLeakOnRepeatedFlush) {
+    char fn[256];
+    generate_tmp_fn(fn, sizeof(fn));
+
+    compio_config cfg;
+    compio_build_default_config(&cfg);
+    cfg.fragmentation_threshold = 100; // disable auto-maintenance
+    compio_archive *archive = compio_open_archive(fn, "w+", &cfg);
+    ASSERT_NE(archive, nullptr);
+
+    const size_t DATA_SIZE = 2048;
+    const int N = 16;
+    for (int i = 0; i < N; i++) {
+        char name[32];
+        snprintf(name, sizeof(name), "f%d", i);
+        compio_file *f = compio_open_file(name, archive);
+        ASSERT_NE(f, nullptr);
+        std::vector<uint8_t> data(DATA_SIZE, (uint8_t)i);
+        compio_write(data.data(), DATA_SIZE, f);
+        compio_close_file(f);
+    }
+
+    // Two flushes establish the alternating two-block working set.
+    compio_flush(archive);
+    compio_flush(archive);
+    uint64_t size1 = std::filesystem::file_size(fn);
+
+    const int kFlushes = 10;
+    for (int i = 0; i < kFlushes; i++) compio_flush(archive);
+    uint64_t size2 = std::filesystem::file_size(fn);
+
+    // One full files-table block per slot. If reuse is broken, the file grows
+    // by at least one such block per flush; with reuse it stays nearly flat.
+    const uint64_t table_block =
+        (uint64_t)COMPIO_MAX_FILES * (COMPIO_FNAME_MAX_SIZE + 2 * sizeof(uint64_t));
+    EXPECT_LT(size2 - size1, table_block)
+        << "file grew by " << (int64_t)(size2 - size1) << " bytes across "
+        << kFlushes << " no-op flushes; a files-table block (" << table_block
+        << " B) is leaking per flush";
+
+    compio_close_archive(archive);
+    remove(fn); remove((std::string(fn) + ".wal").c_str());
+}
+
+// ---------------------------------------------------------------------------
+// DefragmentReclaimsTransientSpace
+// Copy-on-write metadata (files table, allocator state) leaves transient dead
+// regions across flushes. compio_defragment() must reclaim them: after a churn
+// of flushes the file must shrink once defragmented (and not grow).
+// ---------------------------------------------------------------------------
+TEST(DefragmentationPhysicalTest, DefragmentReclaimsTransientSpace) {
+    char fn[256];
+    generate_tmp_fn(fn, sizeof(fn));
+
+    compio_config cfg;
+    compio_build_default_config(&cfg);
+    cfg.fragmentation_threshold = 100; // disable auto-maintenance
+    compio_archive *archive = compio_open_archive(fn, "w+", &cfg);
+    ASSERT_NE(archive, nullptr);
+
+    const size_t DATA_SIZE = 4096;
+    const int N = 100;
+    for (int i = 0; i < N; i++) {
+        char name[32];
+        snprintf(name, sizeof(name), "f%d", i);
+        compio_file *f = compio_open_file(name, archive);
+        ASSERT_NE(f, nullptr);
+        std::vector<uint8_t> data(DATA_SIZE, (uint8_t)i);
+        compio_write(data.data(), DATA_SIZE, f);
+        compio_close_file(f);
+    }
+    // Delete 90% of the files, then churn flushes to accumulate dead regions.
+    for (int i = 0; i < N; i++) {
+        if (i % 10 == 0) continue;
+        char name[32];
+        snprintf(name, sizeof(name), "f%d", i);
+        compio_remove_file(archive, name);
+    }
+    for (int k = 0; k < 30; k++) compio_flush(archive);
+    uint64_t churned = std::filesystem::file_size(fn);
+
+    EXPECT_EQ(compio_defragment(archive), COMPIO_SUCCESS);
+    compio_flush(archive);
+    uint64_t defragged = std::filesystem::file_size(fn);
+
+    EXPECT_LT(defragged, churned)
+        << "defragment did not reclaim space: " << churned << " -> " << defragged;
+
+    // Idempotent: a second defragment must not grow the file.
+    EXPECT_EQ(compio_defragment(archive), COMPIO_SUCCESS);
+    compio_flush(archive);
+    EXPECT_LE(std::filesystem::file_size(fn), defragged);
+
+    compio_close_archive(archive);
+    remove(fn); remove((std::string(fn) + ".wal").c_str());
+}
+
 // ---------------------------------------------------------------------------
 TEST(DestructorTest, FreeBlocksManagerCleansUpNodes) {
     uint64_t file_size = 100000;


### PR DESCRIPTION
sync_files_table sized the external v5 files-table block as
capacity*(name+size), omitting the per-entry file_id that
files_table::write_to actually serialises. The write overran the
allocation by 8 bytes per slot, and copy-on-write never reused the
previous block, leaking a full table block (~160 KB) on every flush and
preventing defragmentation from reclaiming space.

Match the allocation to write_to (name + size + file_id) and free the
previous table block after the new one is written. Crash safe: deallocate
only mutates the in-memory free list, persisted atomically with the new
double-buffered header and WAL commit.