### PR TITLE
feat: self-describing blocks for index recovery

### DIFF
--- a/include/compio/file.hpp
+++ b/include/compio/file.hpp
@@ -185,16 +185,28 @@ struct index_node : public infile_object {
  *
  */
 struct storage_block : public infile_object {
-    static constexpr uint8_t signature = 171; // FNV-1a
-    static constexpr uint8_t signature_crc32c = 172; // CRC32C
+    static constexpr uint8_t signature = 171; // FNV-1a (v1, no back-ref)
+    static constexpr uint8_t signature_crc32c = 172; // CRC32C (v1, no back-ref)
+    // v2 self-describing blocks: carry their owning {hash,pos} key, enabling
+    // index reconstruction from blocks alone after partial/total index loss.
+    static constexpr uint8_t signature_backref = 173; // FNV-1a (v2, back-ref)
+    static constexpr uint8_t signature_backref_crc32c = 174; // CRC32C (v2, back-ref)
 
     uint8_t is_compressed;           /**< Is this block compressed */
     uint64_t size;                   /**< Size of data array */
     uint64_t original_size;          /**< Original size (size of uncompressed data) */
     std::unique_ptr<uint8_t[]> data; /**< Data block */
     uint32_t checksum;               /**< Checksum (4 bytes) */
-    
+
     compio_checksum_type checksum_type; /**< Algorithm used for checksum */
+
+    /** @brief Owning B-tree key (v2 only). Written into the block, read back on
+     * recovery. has_backref tells whether src_key is present on disk. */
+    tree_key src_key{};
+    bool has_backref = false;
+
+    /** @brief On-disk metadata size implied by a block signature byte */
+    static uint64_t meta_size_for(uint8_t sig);
 
     storage_block();
 
@@ -224,15 +236,25 @@ struct storage_block : public infile_object {
      * @return true if checksum matches, false otherwise
      */
     bool verify_checksum() const;
+
+    /** @brief Compute checksum over (back-ref key if v2) + data */
+    uint32_t compute_checksum() const;
 };
 
 /**
- * @brief Size of storage block metadata (without data)
+ * @brief Size of v1 storage block metadata (without data, no back-ref)
  */
 #define STORAGE_BLOCK_METASIZE                                                                     \
     (sizeof(uint8_t) /* signature */ + sizeof(storage_block::is_compressed) +                      \
      sizeof(storage_block::size) + sizeof(storage_block::original_size) +                          \
      sizeof(uint32_t) /* FNV-1a 32-bit checksum */)
+
+/**
+ * @brief Size of v2 storage block metadata (back-ref {hash,pos} added).
+ * New blocks are always written in v2 layout.
+ */
+#define STORAGE_BLOCK_METASIZE_V2                                                                  \
+    (STORAGE_BLOCK_METASIZE + sizeof(tree_key) /* hash + pos */)
 
 } // namespace compio
 

--- a/include/compio/storage_block_reader.hpp
+++ b/include/compio/storage_block_reader.hpp
@@ -113,6 +113,9 @@ class block {
     bool _is_modified;
     bool _is_removed;
     bool _is_valid;
+    /** @brief On-disk metadata size of the block as read (v1=22, v2=38), so
+     * deallocation frees the exact on-disk footprint. */
+    uint64_t _disk_meta_size = STORAGE_BLOCK_METASIZE_V2;
 
 public:
     /**
@@ -259,6 +262,13 @@ public:
      * @return Size of the block in bytes when compressed (0 if not yet compressed)
      */
     uint64_t c_size() const;
+
+    /**
+     * @brief Get the on-disk metadata size of this block (v1=22, v2=38)
+     *
+     * @return Byte size of the block's on-disk metadata header
+     */
+    uint64_t disk_meta_size() const;
 };
 
 /**

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -1031,9 +1031,16 @@ void block_allocator::perform_defragmentation() {
             continue;
         }
 
-        // Read actual compressed size from on-disk metadata (signature + is_compressed + size).
+        // Read signature + compressed size from on-disk metadata. The signature
+        // determines the metadata footprint (v1=22, v2=38 with {hash,pos} back-ref).
         uint64_t compressed_size = 0;
+        uint8_t sig = 0;
         {
+            if (fseek64(archive_->file, static_cast<int64_t>(src), SEEK_SET) != 0 ||
+                fread(&sig, 1, 1, archive_->file) != 1) {
+                WARNING_PRINT("warning: perform_defragmentation: failed to read signature at %" PRIu64 "\n", src);
+                continue;
+            }
             const int64_t meta_offset = static_cast<int64_t>(src) + 2;
             if (fseek64(archive_->file, meta_offset, SEEK_SET) != 0 ||
                 lendian_fread(&compressed_size, sizeof(compressed_size), 1, archive_->file) != 1 ||
@@ -1042,7 +1049,12 @@ void block_allocator::perform_defragmentation() {
                 continue;
             }
         }
-        const uint64_t block_size = STORAGE_BLOCK_METASIZE + compressed_size;
+        const uint64_t meta_size = storage_block::meta_size_for(sig);
+        if (meta_size == 0) {
+            WARNING_PRINT("warning: perform_defragmentation: bad signature %u at %" PRIu64 "\n", sig, src);
+            continue;
+        }
+        const uint64_t block_size = meta_size + compressed_size;
 
         // Ensure write_pos doesn't overlap with ANY reserved region (Files Table or B-tree nodes)
         while (true) {

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -589,7 +589,8 @@ int compio_remove_file(compio_archive *archive, const char *name) {
                     // Deallocate. Maintenance is suspended globally, so this won't trigger defrag.
                     // Use overloaded deallocate with explicit false for perform_maintenance, although
                     // suspended state also prevents it.
-                    archive->allocator->deallocate(val.addr, STORAGE_BLOCK_METASIZE + sb.size, false);
+                    const uint64_t meta = sb.has_backref ? STORAGE_BLOCK_METASIZE_V2 : STORAGE_BLOCK_METASIZE;
+                    archive->allocator->deallocate(val.addr, meta + sb.size, false);
                 } else {
                     WARNING_PRINT("warning: failed to read block at %" PRIu64 " during removal\n", val.addr);
                     if (saved_pos >= 0) {
@@ -2425,6 +2426,14 @@ int compio_repair(const char *path, const char *output_dir) {
         };
         std::map<uint64_t, std::vector<file_part>> index_files;
 
+        // Addresses referenced by surviving index nodes, and back-refs harvested
+        // directly from v2 self-describing blocks. After the scan, any v2 block
+        // whose address no surviving node references is re-attributed via its
+        // own {hash,pos}, recovering data whose index node was lost.
+        std::set<uint64_t> indexed_addrs;
+        struct block_backref { uint64_t hash, pos, addr, size; };
+        std::vector<block_backref> block_backrefs;
+
         constexpr size_t BUFFER_SIZE = 1024 * 1024;
         std::vector<uint8_t> buffer(BUFFER_SIZE);
         
@@ -2445,31 +2454,50 @@ int compio_repair(const char *path, const char *output_dir) {
                          for (size_t k = 0; k < node.keys.size(); ++k) {
                             if (k < node.values.size()) {
                                 index_files[node.keys[k].hash].push_back({
-                                    node.keys[k].pos, 
-                                    node.values[k].addr, 
+                                    node.keys[k].pos,
+                                    node.values[k].addr,
                                     node.values[k].size
                                 });
+                                indexed_addrs.insert(node.values[k].addr);
                             }
                         }
                     }
                     fseek64(f, saved_pos, SEEK_SET);
                 }
-                
-                if (sig == storage_block::signature || sig == storage_block::signature_crc32c) {
+
+                if (sig == storage_block::signature || sig == storage_block::signature_crc32c ||
+                    sig == storage_block::signature_backref || sig == storage_block::signature_backref_crc32c) {
                     uint64_t saved_pos = ftell64(f);
                     storage_block sb;
                     if (sb.read_from(f, current_addr)) {
                         discovered_blocks[current_addr] = {
-                            current_addr, 
-                            sb.size, 
-                            sb.original_size, 
+                            current_addr,
+                            sb.size,
+                            sb.original_size,
                             (bool)sb.is_compressed
                         };
+                        if (sb.has_backref) {
+                            block_backrefs.push_back({sb.src_key.hash, sb.src_key.pos,
+                                                      current_addr, sb.original_size});
+                        }
                     }
                     fseek64(f, saved_pos, SEEK_SET);
                 }
             }
             offset += bytes_read;
+        }
+
+        // Re-attribute v2 blocks whose owning index node was lost: if no surviving
+        // node references the block's address, trust its self-describing back-ref.
+        int reattributed = 0;
+        for (const auto &br : block_backrefs) {
+            if (indexed_addrs.find(br.addr) == indexed_addrs.end()) {
+                index_files[br.hash].push_back({br.pos, br.addr, br.size});
+                ++reattributed;
+            }
+        }
+        if (reattributed > 0) {
+            WARNING_PRINT("info: re-attributed %d orphan block(s) via self-describing back-refs\n", reattributed);
         }
 
         compio_compressor compressor;

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -2423,6 +2423,7 @@ int compio_repair(const char *path, const char *output_dir) {
             uint64_t pos;
             uint64_t addr;
             uint64_t size;
+            bool from_backref;
         };
         std::map<uint64_t, std::vector<file_part>> index_files;
 
@@ -2456,7 +2457,8 @@ int compio_repair(const char *path, const char *output_dir) {
                                 index_files[node.keys[k].hash].push_back({
                                     node.keys[k].pos,
                                     node.values[k].addr,
-                                    node.values[k].size
+                                    node.values[k].size,
+                                    false
                                 });
                                 indexed_addrs.insert(node.values[k].addr);
                             }
@@ -2492,7 +2494,7 @@ int compio_repair(const char *path, const char *output_dir) {
         int reattributed = 0;
         for (const auto &br : block_backrefs) {
             if (indexed_addrs.find(br.addr) == indexed_addrs.end()) {
-                index_files[br.hash].push_back({br.pos, br.addr, br.size});
+                index_files[br.hash].push_back({br.pos, br.addr, br.size, true});
                 ++reattributed;
             }
         }
@@ -2534,6 +2536,24 @@ int compio_repair(const char *path, const char *output_dir) {
             std::sort(parts.begin(), parts.end(), [](const auto& a, const auto& b) {
                 return a.pos < b.pos;
             });
+
+            // Files rebuilt entirely from self-describing back-refs may carry stale
+            // absolute positions (lazy add_to_range shifts don't rewrite evicted
+            // blocks). The logical stream is densely tiled, so the correct offset of
+            // each block is the running sum of preceding block sizes; sort order is
+            // preserved by every shift, so re-deriving positions this way recovers
+            // the file regardless of drift. Only applied when no surviving index
+            // node anchors any part (a partial index would still hold true offsets).
+            const bool all_from_backref = !parts.empty() &&
+                std::all_of(parts.begin(), parts.end(),
+                            [](const auto& p) { return p.from_backref; });
+            if (all_from_backref) {
+                uint64_t running = 0;
+                for (auto& part : parts) {
+                    part.pos = running;
+                    running += part.size;
+                }
+            }
 
             std::string filename;
             if (hash_to_name.count(hash)) {

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -628,9 +628,12 @@ bool storage_block::read_from(FILE *file, uint64_t addr) {
         return false;
     }
 
-    // Optimization: Read all metadata in one go (22 bytes)
-    uint8_t meta_buffer[STORAGE_BLOCK_METASIZE];
-    if (lendian_fread(meta_buffer, 1, STORAGE_BLOCK_METASIZE, file) != STORAGE_BLOCK_METASIZE) {
+    // Read the common prefix shared by v1 and v2 layouts:
+    // signature(1) + is_compressed(1) + size(8) + original_size(8) = 18 bytes.
+    // The signature then tells us whether a {hash,pos} back-ref follows.
+    constexpr size_t PREFIX_SIZE = sizeof(uint8_t) + sizeof(uint8_t) + sizeof(uint64_t) * 2;
+    uint8_t meta_buffer[STORAGE_BLOCK_METASIZE_V2];
+    if (lendian_fread(meta_buffer, 1, PREFIX_SIZE, file) != PREFIX_SIZE) {
         return false;
     }
 
@@ -650,8 +653,16 @@ bool storage_block::read_from(FILE *file, uint64_t addr) {
     uint8_t signature = read_u8();
     if (signature == storage_block::signature) {
         checksum_type = COMPIO_CHECKSUM_FNV1A;
+        has_backref = false;
     } else if (signature == storage_block::signature_crc32c) {
         checksum_type = COMPIO_CHECKSUM_CRC32C;
+        has_backref = false;
+    } else if (signature == storage_block::signature_backref) {
+        checksum_type = COMPIO_CHECKSUM_FNV1A;
+        has_backref = true;
+    } else if (signature == storage_block::signature_backref_crc32c) {
+        checksum_type = COMPIO_CHECKSUM_CRC32C;
+        has_backref = true;
     } else {
         WARNING_PRINT("warning: storage_block signature does not match (got %d)\n", signature);
         return false;
@@ -672,16 +683,26 @@ bool storage_block::read_from(FILE *file, uint64_t addr) {
     // Cap block size to prevent OOM on corrupted files
     static constexpr uint64_t MAX_BLOCK_SIZE = 256ULL * 1024 * 1024; // 256 MB
     if (size > MAX_BLOCK_SIZE) {
-        WARNING_PRINT("warning: storage_block size %llu exceeds limit at addr=%llu\n", 
+        WARNING_PRINT("warning: storage_block size %llu exceeds limit at addr=%llu\n",
                       (unsigned long long)size, (unsigned long long)addr);
         size = 0;
         return false;
     }
 
     original_size = read_u64();
+
+    // Read the variable tail: [hash, pos] for v2, then the checksum.
+    const size_t tail = (has_backref ? sizeof(uint64_t) * 2 : 0) + sizeof(uint32_t);
+    if (lendian_fread(meta_buffer + PREFIX_SIZE, 1, tail, file) != tail) {
+        return false;
+    }
+    if (has_backref) {
+        src_key.hash = read_u64();
+        src_key.pos = read_u64();
+    }
     checksum = read_u32();
 
-    assert(meta_idx == STORAGE_BLOCK_METASIZE);
+    assert(meta_idx == PREFIX_SIZE + tail);
 
     data = std::unique_ptr<uint8_t[]>(new uint8_t[size]);
     if (lendian_fread(data.get(), 1, size, file) != size) {
@@ -696,45 +717,51 @@ bool storage_block::read_from(FILE *file, uint64_t addr) {
 }
 
 void storage_block::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_manager) const {
-    DEBUG_PRINT("[W][storage_block]addr=%" PRIu64 ";size=%" PRIu64 "\n", addr, STORAGE_BLOCK_METASIZE + size);
+    DEBUG_PRINT("[W][storage_block]addr=%" PRIu64 ";size=%" PRIu64 "\n", addr, STORAGE_BLOCK_METASIZE_V2 + size);
     assert(addr != 0);
     assert(size > 0);
     assert(original_size > 0);
     assert(is_compressed || size == original_size);
 
+    // New blocks are always written in v2 (self-describing) layout.
+    const_cast<storage_block*>(this)->has_backref = true;
+
     // Calculate checksum before writing (non-const, so we cast)
     const_cast<storage_block*>(this)->calculate_checksum();
 
     // Prepare metadata buffer
-    uint8_t meta_buffer[STORAGE_BLOCK_METASIZE];
+    uint8_t meta_buffer[STORAGE_BLOCK_METASIZE_V2];
     size_t meta_idx = 0;
 
     auto push_u8 = [&](uint8_t v) { meta_buffer[meta_idx++] = v; };
-    auto push_u32 = [&](uint32_t v) { 
-        for(int i=0; i<4; ++i) meta_buffer[meta_idx++] = static_cast<uint8_t>(v >> (i*8)); 
+    auto push_u32 = [&](uint32_t v) {
+        for(int i=0; i<4; ++i) meta_buffer[meta_idx++] = static_cast<uint8_t>(v >> (i*8));
     };
-    auto push_u64 = [&](uint64_t v) { 
-        for(int i=0; i<8; ++i) meta_buffer[meta_idx++] = static_cast<uint8_t>(v >> (i*8)); 
+    auto push_u64 = [&](uint64_t v) {
+        for(int i=0; i<8; ++i) meta_buffer[meta_idx++] = static_cast<uint8_t>(v >> (i*8));
     };
 
-    uint8_t sig = (checksum_type == COMPIO_CHECKSUM_CRC32C) ? storage_block::signature_crc32c : storage_block::signature;
+    uint8_t sig = (checksum_type == COMPIO_CHECKSUM_CRC32C) ? storage_block::signature_backref_crc32c
+                                                            : storage_block::signature_backref;
     push_u8(sig);
     push_u8(is_compressed);
     push_u64(size);
     push_u64(original_size);
+    push_u64(src_key.hash);
+    push_u64(src_key.pos);
     push_u32(checksum);
-    
-    assert(meta_idx == STORAGE_BLOCK_METASIZE);
+
+    assert(meta_idx == STORAGE_BLOCK_METASIZE_V2);
 
     if (wal_manager) {
         wal_manager->begin_transaction();
-        
+
         std::vector<compio::WalManager::iovec_buf> buffers;
-        buffers.push_back({meta_buffer, STORAGE_BLOCK_METASIZE});
+        buffers.push_back({meta_buffer, STORAGE_BLOCK_METASIZE_V2});
         if (size > 0 && data) {
             buffers.push_back({data.get(), size});
         }
-        
+
         if (!wal_manager->log_write_vectored(WalRecordType::BLOCK, addr, buffers)) {
             WARNING_PRINT("error: WAL log_write failed for storage_block at addr=%" PRIu64 "\n", addr);
         }
@@ -745,8 +772,8 @@ void storage_block::write_to(FILE *file, uint64_t addr, compio::WalManager* wal_
 
     if (fseek64(file, addr, SEEK_SET))
         DEBUG_PRINT("warning: fseek failed\n");
-        
-    if (fwrite(meta_buffer, 1, STORAGE_BLOCK_METASIZE, file) != STORAGE_BLOCK_METASIZE) {
+
+    if (fwrite(meta_buffer, 1, STORAGE_BLOCK_METASIZE_V2, file) != STORAGE_BLOCK_METASIZE_V2) {
         DEBUG_PRINT("warning: fwrite failed for metadata\n");
     }
     if (size > 0 && data) {
@@ -768,6 +795,19 @@ index_node::index_node(int tree_degree)
     values.clear();
     children.clear();
     key_additions.clear();
+}
+
+uint64_t storage_block::meta_size_for(uint8_t sig) {
+    switch (sig) {
+        case storage_block::signature:
+        case storage_block::signature_crc32c:
+            return STORAGE_BLOCK_METASIZE;
+        case storage_block::signature_backref:
+        case storage_block::signature_backref_crc32c:
+            return STORAGE_BLOCK_METASIZE_V2;
+        default:
+            return 0;
+    }
 }
 
 storage_block::storage_block() : data(nullptr), checksum_type(COMPIO_CHECKSUM_FNV1A) {}
@@ -993,29 +1033,45 @@ int files_table::remove(const char *name) {
     return 0;
 }
 
+// Serialize the back-ref key to a little-endian byte buffer, so the checksum
+// is computed over the same bytes that hit the disk (portable across endianness).
+static void backref_key_bytes(const tree_key &key, uint8_t out[16]) {
+    for (int i = 0; i < 8; ++i) out[i] = static_cast<uint8_t>(key.hash >> (i * 8));
+    for (int i = 0; i < 8; ++i) out[8 + i] = static_cast<uint8_t>(key.pos >> (i * 8));
+}
+
+uint32_t storage_block::compute_checksum() const {
+    // v2 blocks fold {hash,pos} into the checksum so back-ref corruption is caught.
+    if (checksum_type == COMPIO_CHECKSUM_CRC32C) {
+        uint32_t c = 0;
+        if (has_backref) {
+            uint8_t kb[16];
+            backref_key_bytes(src_key, kb);
+            c = crc32c(kb, sizeof(kb));
+        }
+        return crc32c_continue(c, data.get(), size);
+    } else {
+        uint32_t h = 0x811c9dc5;
+        if (has_backref) {
+            uint8_t kb[16];
+            backref_key_bytes(src_key, kb);
+            h = fnv1a_32_continue(h, kb, sizeof(kb));
+        }
+        return fnv1a_32_continue(h, data.get(), size);
+    }
+}
+
 void storage_block::calculate_checksum() {
     if (!data || size == 0) {
         checksum = 0;
         return;
     }
-
-    if (checksum_type == COMPIO_CHECKSUM_CRC32C) {
-        checksum = crc32c(data.get(), size);
-    } else {
-        checksum = fnv1a_32(data.get(), size);
-    }
+    checksum = compute_checksum();
 }
 
 bool storage_block::verify_checksum() const {
     if (!data || size == 0) {
         return checksum == 0;
     }
-
-    uint32_t computed;
-    if (checksum_type == COMPIO_CHECKSUM_CRC32C) {
-        computed = crc32c(data.get(), size);
-    } else {
-        computed = fnv1a_32(data.get(), size);
-    }
-    return checksum == computed;
+    return checksum == compute_checksum();
 }

--- a/src/storage_block_reader.cpp
+++ b/src/storage_block_reader.cpp
@@ -48,6 +48,21 @@ block::block(context_t &context, const tree_key &key, uint64_t addr)
         }
     }
 
+    _disk_meta_size = b.has_backref ? STORAGE_BLOCK_METASIZE_V2 : STORAGE_BLOCK_METASIZE;
+
+    // Verify-on-read: a v2 block carries its owning {hash,pos}. Only the hash
+    // (file identity) is checked: pos legitimately drifts when add_to_range/shift
+    // moves keys without rewriting on-disk blocks, so a pos mismatch is expected.
+    // A hash mismatch means the index points at a block of a different file —
+    // genuine corruption, reject it.
+    if (b.has_backref && b.src_key.hash != key.hash) {
+        WARNING_PRINT("warning: storage block at addr %" PRIu64 " hash mismatch: "
+                      "index {%" PRIu64 ",%" PRIu64 "} != block {%" PRIu64 ",%" PRIu64 "}\n",
+                      addr, key.hash, key.pos, b.src_key.hash, b.src_key.pos);
+        _is_valid = false;
+        return;
+    }
+
     _c_size = b.size;
     _size = b.original_size;
 
@@ -93,6 +108,7 @@ block::~block() {
         storage_block b(context.compressor->get_bufsize(context.compressor, _size));
         b.original_size = _size;
         b.checksum_type = context.checksum_type;
+        b.src_key = _key; // v2 self-describing back-ref
 
         int ret = context.compressor->compress(context.compressor, b.data.get(), &b.size, _data.get(), _size);
         if (ret != 0 || b.size > _size) {
@@ -121,10 +137,10 @@ block::~block() {
             // Disable maintenance during flush: defrag reads the btree index, but the index
             // is only partially updated while clear_cache() destructors are still running.
             // Running defrag mid-flush would see stale block addresses and corrupt the archive.
-            context.allocator->deallocate(_addr, _c_size + STORAGE_BLOCK_METASIZE, false);
+            context.allocator->deallocate(_addr, _c_size + _disk_meta_size, false);
         }
 
-        uint64_t new_addr = context.allocator->allocate(STORAGE_BLOCK_METASIZE + b.size);
+        uint64_t new_addr = context.allocator->allocate(STORAGE_BLOCK_METASIZE_V2 + b.size);
         DEBUG_PRINT(
             "[B][destructor]: writing to file "
             "(new_addr=%" PRIu64 ",addr=%" PRIu64 ",original_size=%" PRIu64 ",size=%" PRIu64 ",is_compressed=%d,key.pos=%" PRIu64 ")\n",
@@ -236,6 +252,8 @@ uint64_t block::size() const { return _size; }
 uint64_t block::addr() const { return _addr; }
 
 uint64_t block::c_size() const { return _c_size; }
+
+uint64_t block::disk_meta_size() const { return _disk_meta_size; }
 
 storage_block_reader::storage_block_reader(FILE *file, block_allocator *allocator, btree *index,
                                            const compio_compressor *compressor, int max_size,
@@ -443,7 +461,7 @@ void storage_block_reader::remove_block(std::shared_ptr<block> b) {
     }
     context.index->remove(key);
     if (b->addr() != 0) {
-        context.allocator->deallocate(b->addr(), b->c_size() + STORAGE_BLOCK_METASIZE);
+        context.allocator->deallocate(b->addr(), b->c_size() + b->disk_meta_size());
     }
 #ifdef COMPIO_BENCHMARK_BLOCKS_COUNTER
     --bm_n_blocks;

--- a/tests/src/test_repair.cpp
+++ b/tests/src/test_repair.cpp
@@ -205,6 +205,73 @@ static int wipe_index_nodes(const std::string &path) {
     return static_cast<int>(node_offsets.size());
 }
 
+// Uniformly shift the on-disk back-ref `pos` of every v2 block by `delta`,
+// rewriting a valid checksum each time. Simulates stale back-refs after lazy
+// add_to_range shifts (order preserved, absolute pos drifted). Returns count.
+static int drift_block_backrefs(const std::string &path, int64_t delta) {
+    FILE *f = fopen(path.c_str(), "rb");
+    if (!f) return -1;
+    compio::fseek64(f, 0, SEEK_END);
+    uint64_t size = compio::ftell64(f);
+    compio::fseek64(f, 0, SEEK_SET);
+    std::vector<uint8_t> bytes(size);
+    if (fread(bytes.data(), 1, size, f) != size) { fclose(f); return -1; }
+    fclose(f);
+
+    FILE *fw = fopen(path.c_str(), "rb+");
+    if (!fw) return -1;
+    int drifted = 0;
+    for (uint64_t off = 1; off < size; ++off) {
+        const uint8_t sig = bytes[off];
+        if (sig != compio::storage_block::signature_backref &&
+            sig != compio::storage_block::signature_backref_crc32c) continue;
+        compio::storage_block b;
+        if (!b.read_from(fw, off)) continue;
+        if (!b.has_backref) continue;
+        b.src_key.pos = static_cast<uint64_t>(static_cast<int64_t>(b.src_key.pos) + delta);
+        b.write_to(fw, off, nullptr);
+        ++drifted;
+    }
+    fclose(fw);
+    return drifted;
+}
+
+// Total index loss AND uniformly drifted back-ref pos: order is preserved but
+// absolute positions are stale. Repair must re-derive positions by contiguous
+// tiling of block sizes, recovering the file byte-for-byte regardless of drift.
+TEST_F(RepairTest, RecoversDriftedOrphanPosViaTiling) {
+    const std::size_t SZ = 128 * 1024;
+    auto payload = pseudo_random(SZ, 4321);
+    {
+        compio_config config;
+        compio_build_default_config(&config);
+        config.block_size = 4096; // force many blocks so tiling order is exercised
+        config.block_size__maximum = 8192;
+        compio_archive* archive = compio_open_archive(archive_path.c_str(), "w", &config);
+        ASSERT_NE(archive, nullptr);
+        compio_file* f = compio_open_file("drift.bin", archive);
+        ASSERT_NE(f, nullptr);
+        ASSERT_EQ(compio_write(payload.data(), SZ, f), (int)SZ);
+        compio_close_file(f);
+        compio_close_archive(archive);
+    }
+
+    int drifted = drift_block_backrefs(archive_path, 777777);
+    ASSERT_GT(drifted, 0) << "test must actually drift back-ref positions";
+    int wiped = wipe_index_nodes(archive_path);
+    ASSERT_GT(wiped, 0) << "test must actually destroy index nodes";
+
+    int count = compio_repair(archive_path.c_str(), recover_dir.c_str());
+    ASSERT_GE(count, 1);
+
+    fs::path recovered = fs::path(recover_dir) / "drift.bin";
+    ASSERT_TRUE(fs::exists(recovered)) << "tiling re-derivation should rebuild the named file";
+    std::ifstream ifs(recovered, std::ios::binary);
+    std::vector<uint8_t> content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    ASSERT_EQ(content.size(), SZ) << "drifted pos must not bloat the file with leading gap";
+    ASSERT_EQ(content, payload) << "recovered content must match original byte-for-byte";
+}
+
 // Total index loss: every index node is wiped, so files can only be rebuilt
 // from the self-describing {hash,pos} back-refs carried by v2 storage blocks.
 TEST_F(RepairTest, RecoversOrphanBlocksViaBackref) {

--- a/tests/src/test_repair.cpp
+++ b/tests/src/test_repair.cpp
@@ -4,13 +4,26 @@
 #include <vector>
 #include <string>
 #include <cinttypes>
+#include <cstring>
+#include <memory>
+#include <algorithm>
 
 #include "compio.h"
 #include "compio/compio_file.hpp"
+#include "compio/file.hpp"
 #include "compio/utils.hpp"
 #include "test_util.hpp"
 
 namespace fs = std::filesystem;
+
+namespace {
+std::vector<uint8_t> pseudo_random(std::size_t n, uint32_t seed) {
+    std::vector<uint8_t> v(n);
+    uint32_t s = seed ? seed : 1;
+    for (auto &b : v) { s = s * 1664525u + 1013904223u; b = static_cast<uint8_t>(s >> 24); }
+    return v;
+}
+} // namespace
 
 class RepairTest : public ::testing::Test {
 protected:
@@ -150,10 +163,173 @@ TEST_F(RepairTest, RecoversWithCorruptedHeader) {
             std::ifstream ifs(entry.path(), std::ios::binary);
             ifs.seekg(0, std::ios::end);
             if (ifs.tellg() == 1000) {
-                any_correct = true; 
+                any_correct = true;
                 break;
             }
          }
          ASSERT_TRUE(any_correct) << "No recovered file has correct size";
     }
+}
+
+// Wipe every readable B-tree index node by zeroing its signature byte,
+// simulating total loss of the index. Returns the number of nodes wiped.
+static int wipe_index_nodes(const std::string &path) {
+    FILE *f = fopen(path.c_str(), "rb");
+    if (!f) return -1;
+    compio::header h;
+    if (!h.load_and_validate(f, 0)) { fclose(f); return -1; }
+    const int degree = h.b_tree_degree;
+
+    compio::fseek64(f, 0, SEEK_END);
+    uint64_t size = compio::ftell64(f);
+    compio::fseek64(f, 0, SEEK_SET);
+    std::vector<uint8_t> bytes(size);
+    if (fread(bytes.data(), 1, size, f) != size) { fclose(f); return -1; }
+
+    std::vector<uint64_t> node_offsets;
+    for (uint64_t off = 0; off < size; ++off) {
+        if (bytes[off] != compio::index_node::signature) continue;
+        compio::index_node node(degree);
+        if (node.read_from(f, off)) node_offsets.push_back(off);
+    }
+    fclose(f);
+
+    FILE *fw = fopen(path.c_str(), "rb+");
+    if (!fw) return -1;
+    const uint8_t zero = 0;
+    for (uint64_t off : node_offsets) {
+        compio::fseek64(fw, off, SEEK_SET);
+        fwrite(&zero, 1, 1, fw);
+    }
+    fclose(fw);
+    return static_cast<int>(node_offsets.size());
+}
+
+// Total index loss: every index node is wiped, so files can only be rebuilt
+// from the self-describing {hash,pos} back-refs carried by v2 storage blocks.
+TEST_F(RepairTest, RecoversOrphanBlocksViaBackref) {
+    const std::size_t SZ = 128 * 1024; // span many blocks across multiple index nodes
+    auto payload = pseudo_random(SZ, 1234);
+    {
+        compio_config config;
+        compio_build_default_config(&config);
+        compio_archive* archive = compio_open_archive(archive_path.c_str(), "w", &config);
+        ASSERT_NE(archive, nullptr);
+        compio_file* f = compio_open_file("big.bin", archive);
+        ASSERT_NE(f, nullptr);
+        ASSERT_EQ(compio_write(payload.data(), SZ, f), (int)SZ);
+        compio_close_file(f);
+        compio_close_archive(archive);
+    }
+
+    int wiped = wipe_index_nodes(archive_path);
+    ASSERT_GT(wiped, 0) << "test must actually destroy index nodes";
+
+    int count = compio_repair(archive_path.c_str(), recover_dir.c_str());
+    ASSERT_GE(count, 1);
+
+    // File recovered under its real name (header survived) purely via back-refs.
+    fs::path recovered = fs::path(recover_dir) / "big.bin";
+    ASSERT_TRUE(fs::exists(recovered)) << "back-ref re-attribution should rebuild the named file";
+    std::ifstream ifs(recovered, std::ios::binary);
+    std::vector<uint8_t> content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    ASSERT_EQ(content.size(), SZ);
+    ASSERT_EQ(content, payload) << "recovered content must match original byte-for-byte";
+}
+
+// v2 storage blocks round-trip their {hash,pos} back-ref, and the checksum
+// covers it so corruption of the back-ref is detected on read.
+TEST_F(RepairTest, StorageBlockBackrefRoundTripAndChecksum) {
+    std::string blk_path = (fs::path(tmp_dir) / "block.bin").string();
+    const uint64_t addr = 64;
+    const uint64_t N = 256;
+    auto data = pseudo_random(N, 99);
+    const compio::tree_key key{0xABCDEF0123456789ull, 0x1122334455667788ull};
+
+    {
+        compio::storage_block b;
+        b.is_compressed = 0;
+        b.size = N;
+        b.original_size = N;
+        b.data = std::make_unique<uint8_t[]>(N);
+        std::copy(data.begin(), data.end(), b.data.get());
+        b.checksum_type = COMPIO_CHECKSUM_FNV1A;
+        b.src_key = key;
+        FILE *f = fopen(blk_path.c_str(), "wb+");
+        ASSERT_NE(f, nullptr);
+        b.write_to(f, addr, nullptr);
+        fclose(f);
+    }
+
+    {
+        compio::storage_block b;
+        FILE *f = fopen(blk_path.c_str(), "rb");
+        ASSERT_NE(f, nullptr);
+        ASSERT_TRUE(b.read_from(f, addr));
+        fclose(f);
+        EXPECT_TRUE(b.has_backref);
+        EXPECT_EQ(b.src_key.hash, key.hash);
+        EXPECT_EQ(b.src_key.pos, key.pos);
+        ASSERT_EQ(b.size, N);
+        EXPECT_EQ(std::memcmp(b.data.get(), data.data(), N), 0);
+    }
+
+    // Corrupt one byte of the on-disk back-ref (hash starts right after the
+    // 18-byte common prefix). Checksum covers it, so read_from must fail.
+    {
+        FILE *f = fopen(blk_path.c_str(), "rb+");
+        ASSERT_NE(f, nullptr);
+        compio::fseek64(f, addr + 18, SEEK_SET);
+        uint8_t v = 0;
+        ASSERT_EQ(fread(&v, 1, 1, f), 1u);
+        v ^= 0xFF;
+        compio::fseek64(f, addr + 18, SEEK_SET);
+        fwrite(&v, 1, 1, f);
+        fclose(f);
+    }
+    {
+        compio::storage_block b;
+        FILE *f = fopen(blk_path.c_str(), "rb");
+        ASSERT_NE(f, nullptr);
+        EXPECT_FALSE(b.read_from(f, addr)) << "corrupted back-ref must fail checksum";
+        fclose(f);
+    }
+}
+
+// Backward compatibility: a hand-written legacy v1 block (no back-ref, 22-byte
+// meta, checksum over data only) must still read correctly.
+TEST_F(RepairTest, ReadsLegacyV1Block) {
+    std::string blk_path = (fs::path(tmp_dir) / "v1block.bin").string();
+    const uint64_t addr = 8; // non-zero (read_from asserts addr != 0)
+    const uint64_t N = 200;
+    auto data = pseudo_random(N, 7);
+    const uint32_t cksum = compio::fnv1a_32(data.data(), N);
+
+    std::vector<uint8_t> buf(addr, 0); // leading padding so block starts at addr
+    auto put_u8 = [&](uint8_t v) { buf.push_back(v); };
+    auto put_u32 = [&](uint32_t v) { for (int i = 0; i < 4; ++i) buf.push_back((uint8_t)(v >> (i * 8))); };
+    auto put_u64 = [&](uint64_t v) { for (int i = 0; i < 8; ++i) buf.push_back((uint8_t)(v >> (i * 8))); };
+
+    put_u8(compio::storage_block::signature); // 171, v1 FNV
+    put_u8(0);                                 // is_compressed
+    put_u64(N);                                // size
+    put_u64(N);                                // original_size
+    put_u32(cksum);                            // checksum (data only)
+    buf.insert(buf.end(), data.begin(), data.end());
+
+    {
+        FILE *f = fopen(blk_path.c_str(), "wb");
+        ASSERT_NE(f, nullptr);
+        ASSERT_EQ(fwrite(buf.data(), 1, buf.size(), f), buf.size());
+        fclose(f);
+    }
+
+    compio::storage_block b;
+    FILE *f = fopen(blk_path.c_str(), "rb");
+    ASSERT_NE(f, nullptr);
+    ASSERT_TRUE(b.read_from(f, addr));
+    fclose(f);
+    EXPECT_FALSE(b.has_backref);
+    ASSERT_EQ(b.size, N);
+    EXPECT_EQ(std::memcmp(b.data.get(), data.data(), N), 0);
 }


### PR DESCRIPTION
## Problem
A `storage_block` carries no key. When a B-tree index node is lost/corrupted, its blocks become orphans — bytes recoverable, but file owner and position unknown. `compio_repair` dumps them as unordered `orphan_*.bin`. Full index reconstruction from blocks alone was impossible.

## Change
Blocks become self-describing: each v2 block stores its owning `{hash,pos}` key (new signatures `173`/`174`), folded into the block checksum.

- **file**: v2 read/write, checksum covers back-ref, `meta_size_for(sig)`
- **allocator / reader / remove_file**: version-aware on-disk footprint so mixed v1/v2 archives deallocate correctly
- **repair**: re-attribute orphan v2 blocks via back-ref instead of `orphan_*.bin`
- **block read**: verify block `hash` matches looked-up key (catches index pointing at the wrong file)
- **v1 blocks (`171`/`172`)** still read unchanged — backward compatible

## Cost
16 bytes per block (~0.1% at 16KB block size). No new syscalls, compression/checksum dominate CPU. No structural change.