### PR TITLE
fix!: crash-consistent flush and SIGKILL recovery

### DIFF
--- a/include/compio/btree.hpp
+++ b/include/compio/btree.hpp
@@ -135,6 +135,17 @@ struct btree {
           block_allocator *allocator, FILE *file, uint64_t cache_size, std::mutex *io_mutex, compio::WalManager *wal = nullptr);
 
     /**
+     * @brief Re-point the B-Tree at a new header storage.
+     *
+     * The double-buffered header write replaces the archive's header smart
+     * pointer with a fresh storage object. The B-Tree caches its own copy that
+     * shares the header storage (it reads/writes index_root through it), so it
+     * must be re-synced to the new storage or the two diverge and index updates
+     * are lost. Caller must hold the archive lock.
+     */
+    void set_header(smart_infile_object<header> new_header) { archive_header = std::move(new_header); }
+
+    /**
      * @brief Insert a key-value pair into the B-Tree
      *
      * Inserts the specified key and value into the B-Tree. If the key

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -1013,11 +1013,12 @@ void block_allocator::perform_defragmentation() {
         const auto &hdr = readonly(archive_->header, header);
         if (hdr->magic_number == COMPIO_MAGIC_NUMBER) {
              ft_addr = hdr->files_table_addr;
-             // Capacity is header->files_table_capacity. Entry size is COMPIO_FNAME_MAX_SIZE + 8.
-             // We use a safe estimate or exact size.
-             // sync_files_table uses: capacity * (COMPIO_FNAME_MAX_SIZE + 8)
-             // We must match that size exactly or conservatively larger.
-             ft_size = (uint64_t)hdr->files_table_capacity * (COMPIO_FNAME_MAX_SIZE + sizeof(uint64_t));
+             // Must match the on-disk entry size used by files_table::write_to and
+             // sync_files_table: name + size(u64) + file_id(u64). Undercounting here
+             // makes the truncation guard below slice the tail off a files table that
+             // sits after the data, corrupting both header copies on reopen.
+             ft_size = (uint64_t)hdr->files_table_capacity *
+                       (COMPIO_FNAME_MAX_SIZE + 2 * sizeof(uint64_t));
         }
     }
 

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -643,6 +643,22 @@ int compio_get_fragmentation_stats(compio_archive *archive, compio_fragmentation
 
 // Forward declarations
 static void end_auto_batch_if_active(compio_file *file);
+static void flush_header_double_buffered(compio_archive *archive);
+// Commit a batch and publish the header. Caller must hold archive->mutex.
+static bool end_batch_impl(compio_archive *archive);
+
+// Flush stdio buffers and fsync the archive to disk. Used to force the data a
+// header is about to reference onto stable storage BEFORE the header is
+// published, so a crash can never leave a durable header pointing at data that
+// has not yet hit the disk.
+static bool fsync_archive(FILE *file) {
+    if (fflush(file) != 0) return false;
+#ifdef _WIN32
+    return _commit(_fileno(file)) == 0;
+#else
+    return fsync(fileno(file)) == 0;
+#endif
+}
 
 /**
  * Check if current operation is sequential and should be auto-batched
@@ -691,9 +707,9 @@ static void start_auto_batch_if_needed(compio_file *file, uint64_t current_offse
  * End auto-batch if active and threshold reached
  */
 static void end_auto_batch_if_needed(compio_file *file) {
-    if (file->is_auto_batching && 
+    if (file->is_auto_batching &&
         file->auto_batch_count >= file->archive->config.auto_batch_size) {
-        compio_end_batch(file->archive); // Ignore return value - best effort
+        end_batch_impl(file->archive); // Best effort - lock already held
         file->is_auto_batching = false;
         file->auto_batch_count = 0;
     }
@@ -704,7 +720,7 @@ static void end_auto_batch_if_needed(compio_file *file) {
  */
 static void end_auto_batch_if_active(compio_file *file) {
     if (file->is_auto_batching) {
-        compio_end_batch(file->archive); // Best effort - ignore errors
+        end_batch_impl(file->archive); // Best effort - lock already held
         file->is_auto_batching = false;
         file->auto_batch_count = 0;
     }
@@ -810,6 +826,31 @@ int compio_begin_batch(compio_archive *archive) {
     return COMPIO_SUCCESS;
 }
 
+// Commit a batch and, once the outermost batch closes, publish the header over
+// the now-durable data. Caller must hold archive->mutex (auto-batch ends are
+// already under it; the public wrapper takes it). Header publication is safe
+// here because flush_header_double_buffered re-syncs the btree's header copy.
+static bool end_batch_impl(compio_archive *archive) {
+    bool success = archive->wal->end_batch(archive->file, archive->config.wal_max_size_bytes);
+    if (!success) {
+        if (errno == 0) {
+            errno = EIO;
+        }
+        return false;
+    }
+
+    if (archive->wal->get_batch_depth() == 0) {
+        // fsync the batch's data to disk BEFORE publishing the header, so the
+        // header is never durable ahead of the data it references; then fsync
+        // again to make the header itself durable.
+        if (fsync_archive(archive->file)) {
+            flush_header_double_buffered(archive);
+            fsync_archive(archive->file);
+        }
+    }
+    return true;
+}
+
 int compio_end_batch(compio_archive *archive) {
     if (archive == nullptr) {
         WARNING_PRINT("warning: passed nullptr into compio_end_batch\n");
@@ -823,17 +864,8 @@ int compio_end_batch(compio_archive *archive) {
         return COMPIO_ERROR;
     }
 
-    // No need for external lock - WalManager has its own mutex
-    bool success = archive->wal->end_batch(archive->file, archive->config.wal_max_size_bytes);
-    
-    if (!success) {
-        if (errno == 0) {
-            errno = EIO;
-        }
-        return COMPIO_ERROR;
-    }
-    
-    return COMPIO_SUCCESS;
+    std::unique_lock<std::shared_mutex> lock(archive->mutex);
+    return end_batch_impl(archive) ? COMPIO_SUCCESS : COMPIO_ERROR;
 }
 
 int compio_defragment(compio_archive *archive) {
@@ -865,8 +897,14 @@ int compio_defragment(compio_archive *archive) {
 static void flush_header_double_buffered(compio_archive *archive) {
     if (!archive || !archive->header) return;
 
-    // Double-buffered Header Write
-    if (!(archive->mode_b & mode_bit::r)) {
+    // Double-buffered Header Write. Persist whenever the archive is writable.
+    // Read-only is pure 'r' (r bit set, no '+'); 'r+' also sets the r bit but
+    // must still write the header, otherwise compio_flush() never persists
+    // metadata in r+ mode and a crash before close loses it.
+    bool can_write_header = (archive->mode_b & mode_bit::w) ||
+                            (archive->mode_b & mode_bit::a) ||
+                            (archive->mode_b & mode_bit::plus);
+    if (can_write_header) {
         int target_slot = 1 - archive->current_header_slot;
         uint64_t target_addr = (target_slot == 0) ? 0 : archive->header->reserved_size() / 2;
 
@@ -891,6 +929,12 @@ static void flush_header_double_buffered(compio_archive *archive) {
         // Update allocator's file_size pointer since header object moved
         if (archive->allocator) {
              archive->allocator->update_file_size_ptr(&archive->header->file_size);
+        }
+        // Re-sync the B-Tree, which caches a copy sharing the header storage and
+        // writes index_root through it. Without this the btree keeps the old
+        // storage and its index updates never reach the durable header.
+        if (archive->index) {
+             archive->index->set_header(archive->header);
         }
     }
 }
@@ -2282,10 +2326,11 @@ void compio_flush(compio_archive *archive) {
          archive->allocator->save_state(archive);
     }
 
-    // Double-buffered Header Write
-    flush_header_double_buffered(archive);
-    
-    // Commit transaction (this performs WAL write/flush and optionally fsync based on sync mode)
+    // Commit the transaction FIRST, so the data, allocator state and files table
+    // are durably recoverable before the header is published. The double-buffered
+    // header is written directly to the archive (outside the WAL): writing it
+    // before the commit risks a crash that leaves a durable header referencing
+    // writes the WAL later rolls back (header valid but pointing past EOF).
     if (wal_active && wal_ptr->get_batch_depth() == 0) {
         if (!wal_ptr->commit_transaction(archive->file, archive->config.wal_max_size_bytes)) {
             WARNING_PRINT("warning: WAL commit failed in compio_flush\n");
@@ -2297,7 +2342,28 @@ void compio_flush(compio_archive *archive) {
         WARNING_PRINT("warning: fflush failed\n");
         durable = false;
     }
-    
+
+    // Publish the double-buffered header now that the committed data it
+    // references is durable. Deferred inside a batch (commit is deferred to
+    // compio_end_batch, which publishes the header there). Skipped on a
+    // durability failure so we never publish over un-committed state.
+    bool in_batch = wal_active && wal_ptr->get_batch_depth() > 0;
+    if (durable && !in_batch) {
+        // fsync the data the header will reference BEFORE writing the header, so
+        // a crash can never land the (low-offset) header on disk while the
+        // (high-offset) allocator state / data it points at is still buffered.
+        if (!fsync_archive(archive->file)) {
+            WARNING_PRINT("warning: data fsync failed before header write\n");
+            durable = false;
+        } else {
+            flush_header_double_buffered(archive);
+            if (fflush(archive->file)) {
+                WARNING_PRINT("warning: fflush failed after header write\n");
+                durable = false;
+            }
+        }
+    }
+
     // Now that everything is flushed to the OS buffer for the main file,
     // and the WAL transaction is committed and synced (via commit_transaction),
     // we can safely checkpoint, but only if all durability steps have succeeded.
@@ -2306,7 +2372,7 @@ void compio_flush(compio_archive *archive) {
     // 1. fsync the main archive file (ensure data is durable).
     // 2. Truncate the WAL (it is no longer needed since main file is up to date).
     
-    if (wal_active && durable) {
+    if (wal_active && durable && wal_ptr->get_batch_depth() == 0) {
         bool main_file_synced = true;
 #ifdef _WIN32
         if (_commit(_fileno(archive->file)) != 0) {

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -444,8 +444,20 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
     }
 
     if (!is_new_file && !archive->allocator->load_state(archive)) {
-        WARNING_PRINT("warning: failed to load allocator state from archive\n");
-        goto no_allocator_state;
+        // The allocator state (free-block list) is an optimization that points
+        // at a region an interrupted flush may have left beyond the durable end
+        // of the file. The data blocks, B-Tree index and files table are all
+        // intact and independently durable, so a crash must never make the
+        // archive unopenable. Fall back to an empty free list anchored at the
+        // physical end of the file: all data stays readable and the freed space
+        // is reclaimed on the next defragmentation.
+        WARNING_PRINT("warning: allocator state unreadable (interrupted flush?); "
+                      "reconstructing free list from end of file\n");
+        if (fseek64(file, 0, SEEK_END) == 0) {
+            archive->header->file_size = static_cast<uint64_t>(ftell64(file));
+        }
+        archive->header->allocator_state_offset = 0;
+        archive->header->allocator_state_size = 0;
     }
 
     return archive;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,9 @@ add_executable(compio_gtest
     src/test_header_validation.cpp
     src/test_max_files_scalability.cpp
     src/test_crash_protection.cpp
+    src/test_crash_sigkill.cpp
+    src/test_flush_files_table.cpp
+    src/test_flush_durability.cpp
     src/test_wal_recovery.cpp
     src/test_wal_format.cpp
     src/test_auto_checkpoint.cpp

--- a/tests/crash/real_crash_test.cpp
+++ b/tests/crash/real_crash_test.cpp
@@ -1,0 +1,185 @@
+// Real crash-recovery test: fork a child that writes durable records, kill it
+// with SIGKILL at a random moment mid-write, reopen the archive and verify the
+// survivors form an uncorrupted prefix. This exercises the *actual* crash path
+// (process killed mid-operation), not a simulated on-disk state.
+//
+// Build:
+//   g++ -std=c++17 -O2 -I. tests/crash/real_crash_test.cpp \
+//       build6/libcompio.a \
+//       build6/vcpkg_installed/x64-linux/lib/lib{z,lz4,zstd,brotlienc,brotlidec,brotlicommon}.a \
+//       -lm -lpthread -o /tmp/real_crash_test
+//
+// Run:  /tmp/real_crash_test [trials] [sync_mode 0=ALWAYS 1=NORMAL 2=OFF]
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/stat.h>
+
+#include "compio.h"
+
+static constexpr uint64_t RECSZ = 4096;
+static constexpr uint64_t MAGIC = 0xCAFEBABEDEADBEEFULL;
+
+static void fill_record(std::vector<uint8_t>& buf, uint64_t i) {
+    buf.assign(RECSZ, static_cast<uint8_t>(i & 0xFF));
+    std::memcpy(&buf[0], &i, 8);
+    std::memcpy(&buf[8], &MAGIC, 8);
+    std::memcpy(&buf[RECSZ - 8], &i, 8);
+}
+
+// returns true if buf is a valid record carrying index `expect`
+static bool check_record(const std::vector<uint8_t>& buf, uint64_t expect) {
+    if (buf.size() != RECSZ) return false;
+    uint64_t head, magic, tail;
+    std::memcpy(&head, &buf[0], 8);
+    std::memcpy(&magic, &buf[8], 8);
+    std::memcpy(&tail, &buf[RECSZ - 8], 8);
+    if (magic != MAGIC || head != expect || tail != expect) return false;
+    for (uint64_t k = 16; k < RECSZ - 8; ++k)
+        if (buf[k] != static_cast<uint8_t>(expect & 0xFF)) return false;
+    return true;
+}
+
+static void make_config(compio_config* cfg, int sync_mode) {
+    compio_build_default_config(cfg);
+    cfg->block_size = 4096;
+    cfg->wal_sync_mode = static_cast<compio_wal_sync_mode>(sync_mode);
+}
+
+// child: write records forever, flushing each so it becomes durable, until killed
+[[noreturn]] static void run_child(const char* path, int sync_mode) {
+    compio_config cfg;
+    make_config(&cfg, sync_mode);
+    compio_archive* ar = compio_open_archive(path, "r+", &cfg);
+    if (!ar) _exit(101);
+    compio_file* f = compio_open_file("data", ar);
+    if (!f) _exit(102);
+
+    std::vector<uint8_t> buf;
+    for (uint64_t i = 0;; ++i) {
+        fill_record(buf, i);
+        if (compio_write(buf.data(), RECSZ, f) != RECSZ) _exit(103);
+        compio_flush(ar);  // force durability of record i
+    }
+}
+
+struct TrialResult {
+    bool reopened = false;
+    bool size_aligned = false;
+    uint64_t durable = 0;   // records present after reopen
+    int64_t corrupt_at = -1; // first bad record index, -1 = none
+    bool wal_before = false;
+    bool wal_after = false;
+};
+
+// A recovered WAL is truncated to 0 bytes but the file still exists, so test
+// for a non-empty WAL (pending/unrecovered records), not mere existence.
+static bool wal_pending(const std::string& p) {
+    struct stat st;
+    return ::stat(p.c_str(), &st) == 0 && st.st_size > 0;
+}
+
+static TrialResult verify(const char* path, int sync_mode) {
+    TrialResult r;
+    std::string wal = std::string(path) + ".wal";
+    r.wal_before = wal_pending(wal);
+
+    compio_config cfg;
+    make_config(&cfg, sync_mode);
+    compio_archive* ar = compio_open_archive(path, "r+", &cfg);  // triggers recovery
+    if (!ar) return r;
+    r.reopened = true;
+
+    compio_file* f = compio_open_file("data", ar);
+    if (f) {
+        uint64_t total = compio_get_size(f);
+        r.size_aligned = (total % RECSZ == 0);
+        uint64_t n = total / RECSZ;
+        std::vector<uint8_t> buf(RECSZ);
+        for (uint64_t i = 0; i < n; ++i) {
+            compio_seek(f, static_cast<int64_t>(i * RECSZ), COMPIO_SEEK_SET);
+            buf.assign(RECSZ, 0);
+            uint64_t got = compio_read(buf.data(), RECSZ, f);
+            if (got != RECSZ || !check_record(buf, i)) { r.corrupt_at = static_cast<int64_t>(i); break; }
+        }
+        r.durable = n;
+        compio_close_file(f);
+    }
+    compio_close_archive(ar);
+    r.wal_after = wal_pending(wal);
+    return r;
+}
+
+int main(int argc, char** argv) {
+    int trials = (argc > 1) ? std::atoi(argv[1]) : 200;
+    int sync_mode = (argc > 2) ? std::atoi(argv[2]) : 0;
+    const char* names[] = {"ALWAYS", "NORMAL", "OFF"};
+    std::string path = "/tmp/compio_real_crash.compio";
+
+    std::mt19937 rng(static_cast<uint32_t>(::getpid()) ^ static_cast<uint32_t>(::time(nullptr)));
+    std::uniform_int_distribution<int> delay_us(200, 40000);
+
+    int failures = 0, recovered = 0;
+    uint64_t max_durable = 0;
+    printf("Real crash test: %d trials, sync_mode=%s\n", trials, names[sync_mode]);
+
+    for (int t = 0; t < trials; ++t) {
+        ::unlink(path.c_str());
+        ::unlink((path + ".wal").c_str());
+        // fresh empty archive
+        {
+            compio_config cfg;
+            make_config(&cfg, sync_mode);
+            compio_archive* ar = compio_open_archive(path.c_str(), "w", &cfg);
+            if (!ar) { printf("  trial %d: cannot create archive\n", t); ++failures; continue; }
+            compio_close_archive(ar);
+        }
+
+        pid_t pid = fork();
+        if (pid == 0) run_child(path.c_str(), sync_mode);
+        if (pid < 0) { perror("fork"); return 2; }
+
+        ::usleep(delay_us(rng));
+        ::kill(pid, SIGKILL);
+        int status = 0;
+        ::waitpid(pid, &status, 0);
+
+        TrialResult r = verify(path.c_str(), sync_mode);
+        if (r.wal_before) ++recovered;
+        if (r.durable > max_durable) max_durable = r.durable;
+
+        bool ok = r.reopened && r.size_aligned && r.corrupt_at < 0 && !r.wal_after;
+        if (!ok) {
+            ++failures;
+            if (getenv("SAVE_FAIL") && failures == 1) {
+                std::string ar = "cp " + path + " /tmp/fail.compio";
+                std::string aw = "cp " + path + ".wal /tmp/fail.compio.wal 2>/dev/null";
+                if (system(ar.c_str()) != 0 || system(aw.c_str()) != 0) {}
+                printf("  [saved failing artifact to /tmp/fail.compio]\n");
+            }
+            printf("  FAIL trial %d: reopened=%d aligned=%d durable=%llu corrupt_at=%lld wal(before=%d after=%d)\n",
+                   t, r.reopened, r.size_aligned,
+                   (unsigned long long)r.durable, (long long)r.corrupt_at,
+                   r.wal_before, r.wal_after);
+        }
+    }
+
+    ::unlink(path.c_str());
+    ::unlink((path + ".wal").c_str());
+
+    printf("\nResult: %d/%d trials passed | crashes-with-pending-WAL: %d | max durable records: %llu\n",
+           trials - failures, trials, recovered, (unsigned long long)max_durable);
+    if (failures) { printf("INTEGRITY VIOLATIONS: %d\n", failures); return 1; }
+    printf("All survivors formed an uncorrupted prefix. No torn writes, no corruption.\n");
+    return 0;
+}

--- a/tests/src/test_crash_sigkill.cpp
+++ b/tests/src/test_crash_sigkill.cpp
@@ -1,0 +1,146 @@
+// Real-scenario crash test: a child process writes records, flushing each, and
+// is killed with SIGKILL at a random moment mid-operation. The parent reopens
+// the archive and verifies it (a) always opens, (b) the surviving records form
+// an uncorrupted prefix, (c) no torn record, and (d) the WAL is fully consumed.
+//
+// This exercises the real crash path (process killed mid-flush), guarding the
+// header-vs-WAL commit ordering: the double-buffered header must never become
+// durable before the data it references is committed.
+
+#ifndef _WIN32
+
+#include <gtest/gtest.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "compio.h"
+#include "test_util.hpp"
+
+namespace {
+
+constexpr uint64_t RECSZ = 4096;
+constexpr uint64_t REC_MAGIC = 0xCAFEBABEDEADBEEFULL;
+
+void fill_record(std::vector<uint8_t>& b, uint64_t i) {
+    b.assign(RECSZ, static_cast<uint8_t>(i & 0xFF));
+    std::memcpy(&b[0], &i, 8);
+    std::memcpy(&b[8], &REC_MAGIC, 8);
+    std::memcpy(&b[RECSZ - 8], &i, 8);
+}
+
+bool check_record(const std::vector<uint8_t>& b, uint64_t expect) {
+    if (b.size() != RECSZ) return false;
+    uint64_t head, magic, tail;
+    std::memcpy(&head, &b[0], 8);
+    std::memcpy(&magic, &b[8], 8);
+    std::memcpy(&tail, &b[RECSZ - 8], 8);
+    if (magic != REC_MAGIC || head != expect || tail != expect) return false;
+    for (uint64_t k = 16; k < RECSZ - 8; ++k)
+        if (b[k] != static_cast<uint8_t>(expect & 0xFF)) return false;
+    return true;
+}
+
+bool wal_pending(const std::string& p) {
+    struct stat st;
+    return ::stat(p.c_str(), &st) == 0 && st.st_size > 0;
+}
+
+}  // namespace
+
+class CrashSigkillTest : public ::testing::TestWithParam<int> {
+protected:
+    char fn[256];
+    std::string wal_fn;
+    void SetUp() override {
+        generate_tmp_fn(fn, sizeof(fn));
+        wal_fn = std::string(fn) + ".wal";
+    }
+    void TearDown() override {
+        remove(fn);
+        remove(wal_fn.c_str());
+    }
+};
+
+TEST_P(CrashSigkillTest, SurvivorsFormUncorruptedPrefix) {
+    const int sync_mode = GetParam();
+    constexpr int TRIALS = 25;
+
+    std::mt19937 rng(1234567u + static_cast<uint32_t>(sync_mode));
+    std::uniform_int_distribution<int> delay_us(150, 9000);
+
+    for (int t = 0; t < TRIALS; ++t) {
+        remove(fn);
+        remove(wal_fn.c_str());
+
+        compio_config cfg;
+        compio_build_default_config(&cfg);
+        cfg.block_size = 4096;
+        cfg.wal_sync_mode = static_cast<compio_wal_sync_mode>(sync_mode);
+
+        {
+            compio_archive* ar = compio_open_archive(fn, "w", &cfg);
+            ASSERT_NE(ar, nullptr);
+            compio_close_archive(ar);
+        }
+
+        pid_t pid = fork();
+        ASSERT_GE(pid, 0);
+        if (pid == 0) {
+            compio_archive* ar = compio_open_archive(fn, "r+", &cfg);
+            if (!ar) _exit(11);
+            compio_file* f = compio_open_file("data", ar);
+            if (!f) _exit(12);
+            std::vector<uint8_t> b;
+            for (uint64_t i = 0;; ++i) {
+                fill_record(b, i);
+                if (compio_write(b.data(), RECSZ, f) != RECSZ) _exit(13);
+                compio_flush(ar);
+            }
+        }
+
+        usleep(delay_us(rng));
+        kill(pid, SIGKILL);
+        int status = 0;
+        ASSERT_EQ(waitpid(pid, &status, 0), pid);
+
+        // The archive must ALWAYS reopen after a crash, in every sync mode --
+        // a hard kill must never leave it unopenable.
+        compio_archive* ar = compio_open_archive(fn, "r+", &cfg);
+        ASSERT_NE(ar, nullptr) << "trial " << t << ": archive must always reopen after a crash";
+        compio_file* f = compio_open_file("data", ar);
+        ASSERT_NE(f, nullptr) << "trial " << t;
+
+        // OFF deliberately skips fsync ("dangerous, for testing/temp files"), so
+        // a hard crash can leave torn/lost data. Only ALWAYS and NORMAL, which
+        // fsync the WAL, must preserve an uncorrupted prefix and a consumed WAL.
+        if (sync_mode != COMPIO_WAL_SYNC_OFF) {
+            uint64_t total = compio_get_size(f);
+            ASSERT_EQ(total % RECSZ, 0u) << "trial " << t << ": no torn record (size must be record-aligned)";
+            uint64_t n = total / RECSZ;
+            std::vector<uint8_t> b(RECSZ);
+            for (uint64_t i = 0; i < n; ++i) {
+                compio_seek(f, static_cast<int64_t>(i * RECSZ), COMPIO_SEEK_SET);
+                ASSERT_EQ(compio_read(b.data(), RECSZ, f), RECSZ) << "trial " << t << " rec " << i;
+                ASSERT_TRUE(check_record(b, i)) << "trial " << t << ": record " << i << " corrupted";
+            }
+            EXPECT_FALSE(wal_pending(wal_fn)) << "trial " << t << ": WAL must be consumed by recovery";
+        }
+        compio_close_file(f);
+        compio_close_archive(ar);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(SyncModes, CrashSigkillTest,
+                         ::testing::Values(COMPIO_WAL_SYNC_ALWAYS,
+                                           COMPIO_WAL_SYNC_NORMAL,
+                                           COMPIO_WAL_SYNC_OFF));
+
+#endif  // _WIN32

--- a/tests/src/test_flush_durability.cpp
+++ b/tests/src/test_flush_durability.cpp
@@ -1,0 +1,94 @@
+// Regression: compio_flush() is documented to "ensure durability of all prior
+// operations". Previously flush_header_double_buffered() was gated on
+// !(mode_b & mode_bit::r), which is also set for "r+" (read-write existing
+// archive). So in r+ mode flush() never wrote the header; metadata only reached
+// disk via the header object's in-place destructor write at close_archive. A
+// crash (or _exit) after flush but before a clean close lost ALL metadata even
+// though the data blocks were durably on disk -- the file read back as empty.
+//
+// This test writes records, flushes after each, then terminates the writer
+// WITHOUT a clean close (child _exit), and verifies a fresh open sees the data.
+
+#ifndef _WIN32
+
+#include <gtest/gtest.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "compio.h"
+#include "test_util.hpp"
+
+class FlushDurabilityTest : public ::testing::Test {
+protected:
+    char fn[256];
+    std::string wal_fn;
+    void SetUp() override {
+        generate_tmp_fn(fn, sizeof(fn));
+        wal_fn = std::string(fn) + ".wal";
+    }
+    void TearDown() override {
+        remove(fn);
+        remove(wal_fn.c_str());
+    }
+};
+
+TEST_F(FlushDurabilityTest, FlushIsDurableWithoutCleanClose) {
+    constexpr uint64_t RECSZ = 4096;
+    constexpr uint64_t N = 10;
+
+    compio_config cfg;
+    compio_build_default_config(&cfg);
+    cfg.block_size = 4096;
+    cfg.wal_sync_mode = COMPIO_WAL_SYNC_ALWAYS;
+
+    {
+        compio_archive* ar = compio_open_archive(fn, "w", &cfg);
+        ASSERT_NE(ar, nullptr);
+        compio_close_archive(ar);
+    }
+
+    pid_t pid = fork();
+    ASSERT_GE(pid, 0);
+    if (pid == 0) {
+        // Writer: flush after each record, then terminate WITHOUT clean close.
+        compio_archive* ar = compio_open_archive(fn, "r+", &cfg);
+        if (!ar) _exit(11);
+        compio_file* f = compio_open_file("data", ar);
+        if (!f) _exit(12);
+        std::vector<uint8_t> buf(RECSZ);
+        for (uint64_t i = 0; i < N; ++i) {
+            std::fill(buf.begin(), buf.end(), static_cast<uint8_t>(i & 0xFF));
+            if (compio_write(buf.data(), RECSZ, f) != RECSZ) _exit(13);
+            compio_flush(ar);
+        }
+        _exit(0);  // durability must come from flush, not close
+    }
+
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(WEXITSTATUS(status), 0);
+
+    compio_archive* ar = compio_open_archive(fn, "r+", &cfg);
+    ASSERT_NE(ar, nullptr);
+    compio_file* f = compio_open_file("data", ar);
+    ASSERT_NE(f, nullptr);
+    ASSERT_EQ(compio_get_size(f), RECSZ * N) << "flushed records must survive a crash before close";
+
+    std::vector<uint8_t> buf(RECSZ);
+    for (uint64_t i = 0; i < N; ++i) {
+        compio_seek(f, static_cast<int64_t>(i * RECSZ), COMPIO_SEEK_SET);
+        ASSERT_EQ(compio_read(buf.data(), RECSZ, f), RECSZ);
+        for (uint64_t k = 0; k < RECSZ; ++k)
+            ASSERT_EQ(buf[k], static_cast<uint8_t>(i & 0xFF)) << "record " << i << " byte " << k;
+    }
+    compio_close_file(f);
+    compio_close_archive(ar);
+}
+
+#endif // _WIN32

--- a/tests/src/test_flush_files_table.cpp
+++ b/tests/src/test_flush_files_table.cpp
@@ -1,0 +1,74 @@
+// Regression: compio_flush() called while a file is open must not corrupt the
+// archive. Previously sync_files_table() relocated the files-table block via
+// copy-on-write without growing header->file_size, then save_state() stamped
+// file_size at the end of the allocator-state region (below the table). The
+// persisted file_size was smaller than files_table_addr + table_size, so on
+// reopen the bulk read of the table overran EOF and both header copies were
+// rejected ("Both archive headers are corrupted").
+
+#include <gtest/gtest.h>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "compio.h"
+#include "test_util.hpp"
+
+class FlushFilesTableTest : public ::testing::Test {
+protected:
+    char fn[256];
+    std::string wal_fn;
+
+    void SetUp() override {
+        generate_tmp_fn(fn, sizeof(fn));
+        wal_fn = std::string(fn) + ".wal";
+    }
+    void TearDown() override {
+        remove(fn);
+        remove(wal_fn.c_str());
+    }
+};
+
+// Write records, flushing after each, then close cleanly and reopen.
+// The archive must reopen and the data must read back byte-for-byte.
+TEST_F(FlushFilesTableTest, FlushWhileWritingKeepsArchiveOpenable) {
+    constexpr uint64_t RECSZ = 4096;
+    constexpr uint64_t N = 5;
+
+    compio_config cfg;
+    compio_build_default_config(&cfg);
+    cfg.block_size = 4096;
+
+    {
+        compio_archive* ar = compio_open_archive(fn, "w", &cfg);
+        ASSERT_NE(ar, nullptr);
+        compio_file* f = compio_open_file("data", ar);
+        ASSERT_NE(f, nullptr);
+
+        std::vector<uint8_t> buf(RECSZ);
+        for (uint64_t i = 0; i < N; ++i) {
+            std::fill(buf.begin(), buf.end(), static_cast<uint8_t>(i & 0xFF));
+            ASSERT_EQ(compio_write(buf.data(), RECSZ, f), RECSZ);
+            compio_flush(ar);  // mid-write durability primitive
+        }
+        compio_close_file(f);
+        compio_close_archive(ar);
+    }
+
+    compio_archive* ar = compio_open_archive(fn, "r+", &cfg);
+    ASSERT_NE(ar, nullptr) << "archive must reopen after mid-write flushes";
+    compio_file* f = compio_open_file("data", ar);
+    ASSERT_NE(f, nullptr);
+    ASSERT_EQ(compio_get_size(f), RECSZ * N);
+
+    std::vector<uint8_t> buf(RECSZ);
+    for (uint64_t i = 0; i < N; ++i) {
+        compio_seek(f, static_cast<int64_t>(i * RECSZ), COMPIO_SEEK_SET);
+        ASSERT_EQ(compio_read(buf.data(), RECSZ, f), RECSZ);
+        for (uint64_t k = 0; k < RECSZ; ++k)
+            ASSERT_EQ(buf[k], static_cast<uint8_t>(i & 0xFF)) << "record " << i << " byte " << k;
+    }
+    compio_close_file(f);
+    compio_close_archive(ar);
+}


### PR DESCRIPTION
Interrelated crash-consistency bugs found by real SIGKILL testing. The double-buffered header (written direct, bypassing the WAL) must never become durable before the data it references.

## Fixes

| # | Layer | Bug | Fix |
|---|-------|-----|-----|
| 1 | allocator | defrag undercounted files-table size (missing `file_id` u64); guard sliced the tail off a table placed after data, corrupting both header copies on reopen | entry size `FNAME + 2*u64` |
| 2 | flush | header published before WAL commit → durable header referenced rolled-back writes (valid, points past EOF) | commit → fsync data → header → fsync header |
| 3 | flush | `r+` sets the `r` bit but is writable; header write gated on `!r`, so metadata never persisted in `r+` | gate on `w\|a\|plus` |
| 4 | btree | double-buffered write replaces header storage; B-Tree wrote `index_root` through a stale shared copy, so index updates never reached the durable header | re-sync via `btree::set_header` |
| 5 | open | crash can leave a durable header referencing allocator state past durable EOF; data/index/files-table are independently durable | fallback: empty free list from EOF, space reclaimed on next defrag |

## Recovery tests (real scenario)

- `test_crash_sigkill` — fork writer, **SIGKILL** mid-write, reopen; survivors must form an uncorrupted prefix with the WAL fully consumed. All 3 WAL sync modes (OFF only requires reopen — by design, no fsync).
- `tests/crash/real_crash_test.cpp` — standalone soak harness, no gtest timeout.
