### PR TITLE
docs(util): document CLI tools and improve --help/usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ file << data;  // Stream-style I/O
 
 See [`docs/cpp_wrapper.md`](docs/cpp_wrapper.md) for full API reference and [`examples/`](examples/) for code examples.
 
+### Command-line tools
+
+Two standalone executables (built into `build/util/`) extract data from an archive:
+
+- **`compio_unpack`** — extract all files from a healthy archive.
+- **`compio_repair`** — salvage intact data from a corrupted archive.
+
+Both support `-h` / `--help`. See [`util/README.md`](util/README.md) for full documentation.
+
 ## Notes
 
 - Ensure the path `C:/path/to/compio/vcpkg/scripts/buildsystems/vcpkg.cmake` is adjusted to match your actual directory structure on Windows.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,3 +23,8 @@ set_target_properties(cpp_wrapper_example PROPERTIES
 add_executable(repair_example compio_repair.cpp)
 target_link_libraries(repair_example PRIVATE compio)
 target_include_directories(repair_example PRIVATE ${CMAKE_SOURCE_DIR})
+
+# Extraction example
+add_executable(unpack_example compio_unpack.cpp)
+target_link_libraries(unpack_example PRIVATE compio)
+target_include_directories(unpack_example PRIVATE ${CMAKE_SOURCE_DIR})

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,6 +46,24 @@ Demonstrates the C++ wrapper API: RAII archive/file management, stream operators
 ./cpp_wrapper_example
 ```
 
+### `compio_repair.cpp`
+Minimal recovery example: calls `compio_repair()` to salvage files from a corrupted archive into an output directory.
+
+**Usage:**
+```bash
+./repair_example <archive_path> <output_dir>
+```
+
+### `compio_unpack.cpp`
+Minimal extraction example: opens a healthy archive and streams every file into an output directory in fixed-size chunks (memory use independent of file size).
+
+**Usage:**
+```bash
+./unpack_example <archive_path> <output_dir>
+```
+
+> These are stripped-down demos. The full-featured command-line tools — with `--help`, prefix/directory modes, `--force`, and path-traversal guards — live in [`util/`](../util/README.md).
+
 ## Available Compression Algorithms
 
 | Algorithm | Speed | Ratio | Use Case |

--- a/examples/compio_unpack.cpp
+++ b/examples/compio_unpack.cpp
@@ -1,0 +1,63 @@
+// Minimal example: open a healthy archive and extract every file into a
+// directory, streaming in fixed-size chunks. For the full-featured CLI (prefix
+// mode, traversal guards, help) see util/unpack.cpp.
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+
+#include "compio.h"
+#include "compio/compio_file.hpp"
+
+namespace fs = std::filesystem;
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        fprintf(stderr, "Usage: %s <archive_path> <output_dir>\n", argv[0]);
+        return 1;
+    }
+
+    fs::create_directories(argv[2]);
+
+    compio_config config;
+    compio_build_default_config(&config);
+
+    compio_archive *archive = compio_open_archive(argv[1], "r", &config);
+    if (!archive) {
+        fprintf(stderr, "failed to open archive '%s'\n", argv[1]);
+        return 1;
+    }
+
+    const auto *ftable = &archive->header->ftable;
+    constexpr size_t buffer_size = 64 * 1024;
+    auto buffer = std::make_unique<uint8_t[]>(buffer_size);
+
+    for (size_t i = 0; i < ftable->n_files; ++i) {
+        const auto &f = ftable->files[i];
+        compio_file *file = compio_open_file(f.name, archive);
+        if (!file) {
+            fprintf(stderr, "skip '%s': cannot open\n", f.name);
+            continue;
+        }
+
+        fs::path out = fs::path(argv[2]) / f.name;
+        FILE *out_file = fopen(out.string().c_str(), "wb");
+        if (out_file) {
+            uint64_t remaining = f.size;
+            while (remaining > 0) {
+                size_t n = std::min<uint64_t>(buffer_size, remaining);
+                if (compio_read(buffer.get(), n, file) != n) break;
+                fwrite(buffer.get(), 1, n, out_file);
+                remaining -= n;
+            }
+            fclose(out_file);
+            printf("extracted %s (%llu bytes)\n", f.name,
+                   static_cast<unsigned long long>(f.size));
+        }
+        compio_close_file(file);
+    }
+
+    compio_close_archive(archive);
+    return 0;
+}

--- a/util/README.md
+++ b/util/README.md
@@ -1,0 +1,91 @@
+# Command-line tools
+
+Two standalone executables ship with compio for getting data **out** of an
+archive. They are built together with the library (targets `compio_unpack` and
+`compio_repair`) and land in `build/util/`.
+
+| Tool | Use it when | Reads damaged metadata? |
+|------|-------------|--------------------------|
+| `compio_unpack` | The archive is **healthy** and you want every file extracted. | No — needs a valid header/index. |
+| `compio_repair` | The archive is **corrupted** (bad header/index) and you want to salvage whatever is still intact. | Yes — bypasses metadata. |
+
+Both print full help with `-h` / `--help`, validate their arguments, and use
+standard exit codes: `0` on success, `1` on error or bad usage.
+
+---
+
+## `compio_unpack` — extract all files
+
+```
+compio_unpack <archive_path> <output>
+```
+
+Streams every file out of a valid archive in 1 MiB chunks, so memory use does
+not depend on file size.
+
+**Arguments**
+
+- `archive_path` — archive to read.
+- `output` — destination, interpreted by its trailing character:
+  - ends with a path separator (e.g. `out/`) → **directory mode**: files keep
+    their archived names inside that directory;
+  - otherwise (e.g. `out_`) → **prefix mode**: each file is written as
+    `<prefix><name>`.
+
+**Options**
+
+- `-h`, `--help` — show help and exit.
+
+**Safety**: archived names containing `..` or absolute paths are rejected
+(path-traversal guard).
+
+**Examples**
+
+```bash
+# extract into a directory, preserving names
+compio_unpack data.compio extracted/
+
+# extract with a filename prefix into the current directory
+compio_unpack data.compio dump_
+```
+
+---
+
+## `compio_repair` — salvage a corrupted archive
+
+```
+compio_repair <archive_path> <output_dir> [--force]
+```
+
+Scans the archive sequentially by block/index signatures and extracts whatever
+intact data it finds, bypassing damaged metadata. This is **best-effort**
+recovery, not a guarantee.
+
+**Arguments**
+
+- `archive_path` — the corrupted archive.
+- `output_dir` — where recovered files are written; created if missing, and
+  required to be empty unless `--force` is given.
+
+**Options**
+
+- `-f`, `--force` — allow writing into a non-empty output directory.
+- `-h`, `--help` — show help and exit.
+
+**Limitations** (inherited from `compio_repair`):
+
+- small files stored inline in the header may not be recoverable;
+- the original directory structure is not reconstructed;
+- recovery is proportional to archive size (full sequential scan).
+
+**Example**
+
+```bash
+compio_repair broken.compio recovered/
+# -> Success! Recovered N file(s) to 'recovered/'.
+```
+
+---
+
+See [`examples/`](../examples/) for minimal programs that call the underlying
+`compio_repair()` API and the extraction loop directly.

--- a/util/repair.cpp
+++ b/util/repair.cpp
@@ -8,34 +8,46 @@
 struct Args {
     std::string archive_path;
     std::string output_dir;
-    bool help = false;
+    bool help = false;          // explicit -h/--help
+    bool bad_usage = false;      // missing/invalid arguments
     bool force = false;
 };
 
-void print_usage(const char* prog_name) {
-    printf("Usage: %s <archive_path> <output_dir> [--force]\n", prog_name);
-    printf("Recover files from a corrupted compio archive.\n\n");
-    printf("Arguments:\n");
-    printf("  archive_path  Path to the corrupted archive file\n");
-    printf("  output_dir    Directory where recovered files will be saved\n");
-    printf("  --force       Overwrite existing files in output directory if present\n");
+void print_usage(FILE* out, const char* prog_name) {
+    fprintf(out, "Usage: %s <archive_path> <output_dir> [--force]\n", prog_name);
+    fprintf(out, "Recover files from a corrupted compio archive.\n\n");
+    fprintf(out, "Scans the archive sequentially by block/index signatures and extracts\n");
+    fprintf(out, "whatever intact data it finds, bypassing damaged metadata. Best-effort:\n");
+    fprintf(out, "inline-only small files and the directory structure are not recovered.\n\n");
+    fprintf(out, "Arguments:\n");
+    fprintf(out, "  archive_path  Path to the corrupted archive file\n");
+    fprintf(out, "  output_dir    Directory where recovered files are written\n");
+    fprintf(out, "                (created if missing; must be empty unless --force)\n\n");
+    fprintf(out, "Options:\n");
+    fprintf(out, "  -f, --force   Write into a non-empty output directory\n");
+    fprintf(out, "  -h, --help    Show this help and exit\n");
 }
 
 Args parse_args(int argc, char** argv) {
     Args args;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            args.help = true;
+            return args;
+        }
+    }
     if (argc < 3) {
-        args.help = true;
+        args.bad_usage = true;
         return args;
     }
     args.archive_path = argv[1];
     args.output_dir = argv[2];
-    
+
     for (int i = 3; i < argc; ++i) {
         std::string arg = argv[i];
         if (arg == "--force" || arg == "-f") {
             args.force = true;
-        } else if (arg == "--help" || arg == "-h") {
-            args.help = true;
         }
     }
     return args;
@@ -43,9 +55,13 @@ Args parse_args(int argc, char** argv) {
 
 int main(int argc, char** argv) {
     Args args = parse_args(argc, argv);
-    
+
     if (args.help) {
-        print_usage(argv[0]);
+        print_usage(stdout, argv[0]);
+        return 0;
+    }
+    if (args.bad_usage) {
+        print_usage(stderr, argv[0]);
         return 1;
     }
 

--- a/util/unpack.cpp
+++ b/util/unpack.cpp
@@ -37,9 +37,29 @@ fs::path safe_join(const fs::path& base, const std::string& part) {
     return target;
 }
 
-int main(int argc, char **argv) {
+static void print_usage(const char *prog_name) {
+    printf("Usage: %s <archive_path> <output>\n", prog_name);
+    printf("Extract all files from a compio archive (streaming, low memory).\n\n");
+    printf("Arguments:\n");
+    printf("  archive_path  Path to the compio archive to read\n");
+    printf("  output        Destination for extracted files. Interpreted as:\n");
+    printf("                  - a directory, if it ends with a path separator\n");
+    printf("                    (e.g. 'out/'); files keep their archived names;\n");
+    printf("                  - a filename prefix otherwise (e.g. 'out_'); each\n");
+    printf("                    file is written as <prefix><name>.\n\n");
+    printf("Options:\n");
+    printf("  -h, --help    Show this help and exit\n\n");
+    printf("Notes:\n");
+    printf("  Reads in 1 MiB chunks, so memory use is independent of file size.\n");
+    printf("  Paths containing '..' or absolute names are rejected (traversal guard).\n");
+    printf("  For recovering a corrupted archive whose metadata is damaged, use\n");
+    printf("  compio_repair instead.\n");
+}
+
+int unpack(int argc, char **argv) {
     if (argc != 3) {
-        throw std::runtime_error("usage: ./compio_unpack <file> <output_prefix>");
+        print_usage(argv[0]);
+        return 1;
     }
 
     const std::string out_prefix_str = argv[2];
@@ -161,4 +181,21 @@ int main(int argc, char **argv) {
     compio_close_archive(archive);
 
     return 0;
+}
+
+int main(int argc, char **argv) {
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "-h" || arg == "--help") {
+            print_usage(argv[0]);
+            return 0;
+        }
+    }
+
+    try {
+        return unpack(argc, argv);
+    } catch (const std::exception &e) {
+        fprintf(stderr, "error: %s\n", e.what());
+        return 1;
+    }
 }


### PR DESCRIPTION
### Utilities
- **`unpack`**: added `-h`/`--help` with full usage (directory vs prefix mode, chunked streaming, path-traversal note); wrapped `main` in try/catch so failures print `error: …` to stderr and exit `1` instead of an uncaught-exception `terminate`.
- **`repair`**: explicit `--help` now exits `0`; bad/missing args print usage to **stderr** and exit `1`; usage now explains the signature-scan method and recovery limits.
- Consistent exit codes across both: `0` success, `1` error/bad usage.

### Docs
- New `util/README.md` documenting both tools (what/when/how, args, options, examples, limitations).
- `README.md`: new "Command-line tools" section linking the above.
- `examples/README.md`: entries for `repair_example` and `unpack_example`.

### Examples
- New `examples/compio_unpack.cpp` (minimal extraction demo) wired into `examples/CMakeLists.txt` as `unpack_example`.