### PR TITLE
feat(wal): add enable_wal config to disable journaling

### DIFF
--- a/benchmarks/src/wal_sync_benchmark.cpp
+++ b/benchmarks/src/wal_sync_benchmark.cpp
@@ -12,8 +12,10 @@ extern compio_config config;
 // Same write workload under each WAL sync mode, exposing the cost of durability:
 //   ALWAYS  fsyncs after every committed op (strict crash safety),
 //   NORMAL  defers fsync to checkpoint/flush/close,
-//   OFF     never fsyncs the WAL on commit.
-// Throughput per mode quantifies the price paid for durability guarantees.
+//   OFF     never fsyncs the WAL on commit (journal still written, just not synced),
+//   NO-WAL  journaling disabled entirely (no double-write) -> cost of journaling itself.
+// Comparing OFF vs NO-WAL isolates the price of maintaining the journal from the
+// price of fsync (ALWAYS vs the rest).
 
 static void BM_WalSyncWrite(benchmark::State& state) {
     const int mode     = static_cast<int>(state.range(0));
@@ -22,7 +24,11 @@ static void BM_WalSyncWrite(benchmark::State& state) {
     const size_t span  = sizeof(html_data) - 1 - block;
 
     compio_config cfg = config;
-    cfg.wal_sync_mode = static_cast<compio_wal_sync_mode>(mode);
+    if (mode == 3) {
+        cfg.enable_wal = false;
+    } else {
+        cfg.wal_sync_mode = static_cast<compio_wal_sync_mode>(mode);
+    }
 
     for (auto _ : state) {
         std::string path = get_temporary_filename();
@@ -46,13 +52,14 @@ static void BM_WalSyncWrite(benchmark::State& state) {
     }
 
     state.SetBytesProcessed(state.iterations() * static_cast<int64_t>(n_ops) * block);
-    state.counters["sync_mode"] = mode; // 0=ALWAYS 1=NORMAL 2=OFF
+    state.counters["sync_mode"] = mode; // 0=ALWAYS 1=NORMAL 2=OFF 3=NO-WAL
 }
 
 BENCHMARK(BM_WalSyncWrite)
     ->Arg(0)
     ->Arg(1)
     ->Arg(2)
+    ->Arg(3)
     ->Unit(benchmark::kMillisecond)
     ->MinTime(0.5)
     ->UseRealTime();

--- a/compio.h
+++ b/compio.h
@@ -258,6 +258,10 @@ typedef struct {
     compio_checksum_type checksum_type; /**< Checksum algorithm for data blocks */
     compio_wal_sync_mode wal_sync_mode; /**< WAL synchronization mode */
     int auto_batch_size; /**< Number of sequential operations to auto-batch (0 = disabled, default: 8) */
+    bool enable_wal; /**< Maintain the write-ahead log (default: true). When false, writes go
+                          straight to the archive with no journaling: maximum write throughput, but
+                          NO crash safety and NO recovery on reopen. Intended for scratch/throwaway
+                          archives or benchmarking the cost of journaling itself. */
 } compio_config;
 
 /**

--- a/src/compio.cpp
+++ b/src/compio.cpp
@@ -49,6 +49,7 @@ void compio_build_default_config(compio_config *result) {
     result->checksum_type = COMPIO_CHECKSUM_CRC32C;
     result->wal_sync_mode = COMPIO_WAL_SYNC_NORMAL;
     result->auto_batch_size = 8; // Conservative default for performance
+    result->enable_wal = true;
 }
 
 int compio_get_compression_type(const char *fp, compio_compression_type *t) {
@@ -249,55 +250,59 @@ compio_archive *compio_open_archive(const char *fp, const char *mode, const comp
         WARNING_PRINT("warning: failed to set stdio buffer size\n");
     }
 
-    // Initialize WAL Manager
-    auto wal = std::make_unique<compio::WalManager>(fp);
-    if (c) {
-        wal->set_sync_mode(c->wal_sync_mode);
-    }
-    
-    // Check for recovery (only if we are not creating a new file from scratch with "w")
-    if (!(mode_b & mode_bit::w)) {
-        if (wal->has_pending_recovery()) {
-            // Recovery needs read-write access to the archive file. 'r' alone is
-            // read-only; everything else (r+, a, a+, w, w+) can write.
-            bool can_write = !((mode_b & mode_bit::r) && !(mode_b & mode_bit::plus));
+    // Initialize WAL Manager. When journaling is disabled the archive carries no
+    // WalManager at all: writers receive a null wal pointer and skip logging.
+    std::unique_ptr<compio::WalManager> wal;
+    if (!c || c->enable_wal) {
+        wal = std::make_unique<compio::WalManager>(fp);
+        if (c) {
+            wal->set_sync_mode(c->wal_sync_mode);
+        }
 
-            if (!can_write) {
-                 WARNING_PRINT("error: WAL file exists but opening in read-only mode. Cannot recover pending transactions.\n");
-                 fclose(file);
-                 errno = EROFS; // Read-only file system (or similar)
-                 return NULL;
-            } else {
-                if (!wal->recover(file)) {
-                    WARNING_PRINT("warning: WAL recovery failed\n");
-                    // Continue anyway? Or fail? 
-                    // Fail seems safer.
-                    fclose(file);
-                    errno = EIO;
-                    return NULL;
+        // Check for recovery (only if we are not creating a new file from scratch with "w")
+        if (!(mode_b & mode_bit::w)) {
+            if (wal->has_pending_recovery()) {
+                // Recovery needs read-write access to the archive file. 'r' alone is
+                // read-only; everything else (r+, a, a+, w, w+) can write.
+                bool can_write = !((mode_b & mode_bit::r) && !(mode_b & mode_bit::plus));
+
+                if (!can_write) {
+                     WARNING_PRINT("error: WAL file exists but opening in read-only mode. Cannot recover pending transactions.\n");
+                     fclose(file);
+                     errno = EROFS; // Read-only file system (or similar)
+                     return NULL;
+                } else {
+                    if (!wal->recover(file)) {
+                        WARNING_PRINT("warning: WAL recovery failed\n");
+                        // Continue anyway? Or fail?
+                        // Fail seems safer.
+                        fclose(file);
+                        errno = EIO;
+                        return NULL;
+                    }
                 }
             }
+        } else {
+            // "w" mode: truncate file. We should also clear any existing WAL.
+            if (!wal->clear()) {
+                WARNING_PRINT("warning: failed to clear existing WAL file in 'w' mode\n");
+                fclose(file);
+                errno = EIO;
+                return NULL;
+            }
         }
-    } else {
-        // "w" mode: truncate file. We should also clear any existing WAL.
-        if (!wal->clear()) {
-            WARNING_PRINT("warning: failed to clear existing WAL file in 'w' mode\n");
-            fclose(file);
-            errno = EIO;
-            return NULL;
-        }
-    }
-    
-    // Open WAL for writing if we are in write mode
-    // We can write if w, a, or + is set.
-    bool can_write_archive = (mode_b & mode_bit::w) || (mode_b & mode_bit::a) || (mode_b & mode_bit::plus);
-    if (can_write_archive) {
-        if (!wal->open()) {
-             WARNING_PRINT("warning: failed to open WAL file\n");
-             // Fail?
-             fclose(file);
-             errno = EIO;
-             return NULL;
+
+        // Open WAL for writing if we are in write mode
+        // We can write if w, a, or + is set.
+        bool can_write_archive = (mode_b & mode_bit::w) || (mode_b & mode_bit::a) || (mode_b & mode_bit::plus);
+        if (can_write_archive) {
+            if (!wal->open()) {
+                 WARNING_PRINT("warning: failed to open WAL file\n");
+                 // Fail?
+                 fclose(file);
+                 errno = EIO;
+                 return NULL;
+            }
         }
     }
 
@@ -835,7 +840,9 @@ int compio_begin_batch(compio_archive *archive) {
     }
 
     // No need for external lock - WalManager has its own mutex
-    archive->wal->begin_batch();
+    if (archive->wal) {
+        archive->wal->begin_batch();
+    }
     return COMPIO_SUCCESS;
 }
 
@@ -844,6 +851,16 @@ int compio_begin_batch(compio_archive *archive) {
 // already under it; the public wrapper takes it). Header publication is safe
 // here because flush_header_double_buffered re-syncs the btree's header copy.
 static bool end_batch_impl(compio_archive *archive) {
+    if (!archive->wal) {
+        // No journal: block data is already written straight to the archive.
+        // Mirror the journaled path's batch boundary by syncing the data and
+        // publishing the header so on-disk metadata stays consistent.
+        if (fsync_archive(archive->file)) {
+            flush_header_double_buffered(archive);
+            fsync_archive(archive->file);
+        }
+        return true;
+    }
     bool success = archive->wal->end_batch(archive->file, archive->config.wal_max_size_bytes);
     if (!success) {
         if (errno == 0) {

--- a/tests/src/test_wal_sync_mode.cpp
+++ b/tests/src/test_wal_sync_mode.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <sys/stat.h>
 #include "compio.h"
 #include "compio/wal.hpp"
 #include "test_util.hpp"
@@ -128,6 +129,42 @@ TEST_F(WalSyncModeTest, ModeOffWorks) {
     compio_read(buffer, strlen(data), file);
     EXPECT_STREQ(buffer, data);
     
+    compio_close_file(file);
+    compio_close_archive(archive);
+}
+
+// enable_wal=false: no journal is maintained, yet a cleanly closed archive must
+// still round-trip its data (writes go straight to the archive, header published
+// on batch end / close). Also verifies no .wal file is left behind.
+TEST_F(WalSyncModeTest, JournalDisabledRoundTrips) {
+    compio_config config;
+    compio_build_default_config(&config);
+    config.enable_wal = false;
+
+    // Enough data to span several blocks and trigger multiple auto-batch ends.
+    std::string data(64 * 1024, '\0');
+    for (size_t i = 0; i < data.size(); ++i)
+        data[i] = static_cast<char>('A' + (i % 26));
+
+    compio_archive* archive = compio_open_archive(test_file.c_str(), "w+", &config);
+    ASSERT_NE(archive, nullptr);
+    compio_file* file = compio_open_file("test", archive);
+    ASSERT_NE(file, nullptr);
+    ASSERT_EQ(compio_write(data.data(), data.size(), file), data.size());
+    compio_close_file(file);
+    compio_close_archive(archive);
+
+    // No journal should exist for a disabled-WAL archive.
+    struct stat st;
+    EXPECT_NE(stat(test_wal.c_str(), &st), 0);
+
+    archive = compio_open_archive(test_file.c_str(), "r", &config);
+    ASSERT_NE(archive, nullptr);
+    file = compio_open_file("test", archive);
+    ASSERT_NE(file, nullptr);
+    std::string buffer(data.size(), '\0');
+    ASSERT_EQ(compio_read(&buffer[0], buffer.size(), file), data.size());
+    EXPECT_EQ(buffer, data);
     compio_close_file(file);
     compio_close_archive(archive);
 }


### PR DESCRIPTION
Add compio_config.enable_wal (default true). When false no WalManager is created: writers get a null wal pointer and skip logging, data goes straight to the archive. Trades all crash-safety and recovery for maximum write throughput, and lets the WAL sync benchmark isolate the cost of journaling itself (NO-WAL) from the cost of fsync. Adds a no-journal round-trip test.